### PR TITLE
Fix background color for inline code elements

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -26,6 +26,7 @@
   --ifm-color-primary-lighter: #009ed4;
   --ifm-color-primary-lightest: #00afeb;
   --ifm-code-font-size: 95%;
+  --ifm-code-background: #292d3e; /* match code blocks */
   --ifm-navbar-background-color: #000b25;
   --ifm-background-color: #000b25 !important;
   --ifm-footer-background-color: #333c44;


### PR DESCRIPTION
Currently these are white text on a white background... which is not great. A good example of this is [this post](http://next.jellyfin.org/posts/jellyfin-apt-key). This change reuses the same background color from the code blocks for the inline code.