### PR TITLE
Fix vscode not using prettier for formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"esbenp.prettier-vscode"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "typescript.tsdk": "node_modules/typescript/lib",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
 }


### PR DESCRIPTION
Fixes the issue mentioned in #80 by adding prettier as a recommended vscode plugin and using it for the default formatter.