### PR TITLE
Use official deploy pages action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
           npm ci
           npm run build
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # tag=v3.8.0
+        uses: actions/upload-pages-artifact@v1.0.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          path: ./build


### PR DESCRIPTION
Untested but should work fine. Additional changes need to be made after merge (and if the build works):

1. Change the repository settings to use GH actions for page deployment
2. Delete the gh-pages branch
3. Additionally, Renovate will make a PR to pin the version


See also https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site