### PR TITLE
Update GH pages deploy action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,34 +7,34 @@ on:
     branches: [master]
 
 jobs:
-  test-build:
-    if: github.event_name != 'push'
-    name: Test Build
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
       - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # tag=v3.4.1
         with:
           node-version: 16
+      - uses: actions/configure-pages@v1
       - name: Run build
         run: |
           npm ci
           npm run build
-
-  gh-release:
-    if: github.event_name != 'pull_request'
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # tag=v3.4.1
-        with:
-          node-version: 16
-      - name: Run build
-        run: |
-          npm ci
-          npm run build
-      - name: Deploy to GitHub Pages
-        uses: actions/upload-pages-artifact@v1.0.3
+      - name: Upload artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v1
         with:
           path: ./build
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
It looks like we need a few different steps for the GH pages action to work. This is mostly based on the starter workflows: https://github.com/actions/starter-workflows/blob/main/pages/nextjs.yml