### PR TITLE
Add dedicated page for all clients listing

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -67,6 +67,13 @@ mark {
   color: var(--ifm-color-black);
 }
 
+a.pills__item {
+  text-decoration: none;
+}
+a.pills__item:not(.pills__item--active) {
+  color: var(--ifm-font-color-base);
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgb(72, 77, 91);
   display: block;

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -446,7 +446,7 @@ export const Clients: Array<Client> = [
   {
     id: 'jellyfin-androidtv',
     name: 'Jellyfin for Android TV',
-    description: 'The official Jellyfin app for Android TV devices.',
+    description: 'The official Jellyfin app for Android TV and Fire TV devices.',
     clientType: ClientType.Official,
     deviceTypes: [DeviceType.TV],
     licenseType: LicenseType.OpenSource,

--- a/src/pages/clients/all.tsx
+++ b/src/pages/clients/all.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import ClientsPage from './index';
+
+export default function AllClients() {
+  return <ClientsPage recommended={false} />;
+}

--- a/src/pages/clients/index.tsx
+++ b/src/pages/clients/index.tsx
@@ -1,10 +1,11 @@
+import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
+import clsx from 'clsx';
 import React, { useState } from 'react';
 
-import ClientDetails from '../components/clients/ClientDetails';
-import Pill from '../components/common/Pill';
-import { Clients, DeviceType } from '../data/clients';
-import Platform from '../data/platform';
+import ClientDetails from '../../components/clients/ClientDetails';
+import { Clients, DeviceType } from '../../data/clients';
+import Platform from '../../data/platform';
 
 type ClientFilter = {
   recommended: boolean;
@@ -12,9 +13,9 @@ type ClientFilter = {
   platform?: Platform;
 };
 
-export default function Plugins() {
-  const [filter, setFilter] = useState<ClientFilter>({
-    recommended: true
+export default function ClientsPage({ recommended = true }: { recommended?: boolean }) {
+  const [filter] = useState<ClientFilter>({
+    recommended
   });
 
   return (
@@ -23,24 +24,14 @@ export default function Plugins() {
 
       <main className='margin-vert--lg'>
         <section className='container'>
-          <ul className='pills'>
-            <Pill
-              active={filter.recommended}
-              onClick={() => {
-                setFilter({ ...filter, recommended: true });
-              }}
-            >
+          <div className='pills margin-bottom--md'>
+            <Link to='/clients' className={clsx('pills__item', { 'pills__item--active': filter.recommended })}>
               Recommended Clients
-            </Pill>
-            <Pill
-              active={!filter.recommended}
-              onClick={() => {
-                setFilter({ ...filter, recommended: false });
-              }}
-            >
+            </Link>
+            <Link to='/clients/all' className={clsx('pills__item', { 'pills__item--active': !filter.recommended })}>
               All Clients
-            </Pill>
-          </ul>
+            </Link>
+          </div>
 
           {Clients.filter((client) => {
             let result = true;


### PR DESCRIPTION
Adds a dedicated page for listing all clients `/clients/all` this helps with searchability and linking.
Also includes a minor update to the Android TV description to mention Fire TV.