### PR TITLE
Add release badge

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,11 @@ module.exports = {
           to: '/contact'
         }
       ],
-      copyright: `Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/'>CC-BY-ND-4.0</a>`
+      copyright: `<a href="https://github.com/jellyfin/jellyfin/releases/latest">
+<img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin.svg"/>
+</a>
+<br/>
+Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/'>CC-BY-ND-4.0</a>`
     }
   },
   presets: [

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -15,9 +15,14 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
 
   return (
     <Layout title='Downloads'>
-      <h1 className='text--center'>Downloads</h1>
+      <h1 className='text--center margin-bottom--sm'>Downloads</h1>
+      <div className='text--center'>
+        <a href='https://github.com/jellyfin/jellyfin/releases/latest'>
+          <img alt='Current Release' src='https://img.shields.io/github/release/jellyfin/jellyfin.svg' />
+        </a>
+      </div>
 
-      <main className='margin-vert--lg'>
+      <main className='margin-top--md margin-bottom--lg'>
         <section className='container'>
           <div className='row margin-bottom--md'>
             <div className='col'>


### PR DESCRIPTION
Adds the release badge to the top of the downloads page and the footer (on all pages).

![Screenshot 2022-08-29 at 23-19-48 Downloads Jellyfin](https://user-images.githubusercontent.com/3450688/187454728-ecd5f7f9-8d31-426e-ad31-ad0d65bab5c3.png)

![Screenshot 2022-08-30 at 09-49-37 Downloads Jellyfin](https://user-images.githubusercontent.com/3450688/187454754-42100d25-ecd3-49d8-a98c-5cea1a7f6745.png)

Fixes #92