### PR TITLE
Modernize APT configuration for Debian & Ubuntu

### DIFF
--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -57,8 +57,16 @@ export const Downloads: Array<Download> = [
             <pre>
               <code>
                 {`sudo apt install curl gnupg
-curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin.gpg
-echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release ) $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release ) main" | sudo tee /etc/apt/sources.list.d/jellyfin.list
+sudo mkdir /etc/apt/keyrings
+curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg
+cat <<EOF | sudo tee /etc/apt/sources.list.d/jellyfin.sources
+Types: deb
+URIs: https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )
+Suites: $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )
+Components: main
+Arch: $( dpkg --print-architecture )
+Signed-By: /etc/apt/keyrings/jellyfin.gpg
+EOF
 sudo apt update
 sudo apt install jellyfin`}
               </code>
@@ -90,8 +98,16 @@ sudo apt install jellyfin`}
             <pre>
               <code>
                 {`sudo apt install curl gnupg
-curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin.gpg
-echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release ) $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release ) main unstable" | sudo tee /etc/apt/sources.list.d/jellyfin.list
+sudo mkdir /etc/apt/keyrings
+curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg
+cat <<EOF | sudo tee /etc/apt/sources.list.d/jellyfin.sources
+Types: deb
+URIs: https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )
+Suites: $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )
+Components: main unstable
+Arch: $( dpkg --print-architecture )
+Signed-By: /etc/apt/keyrings/jellyfin.gpg
+EOF
 sudo apt update
 sudo apt install jellyfin`}
               </code>


### PR DESCRIPTION
Recently, Debian-based distributions have switched to using the deb822
configuration format for APT sources by default.

This feature was first released in APT 1.1.

So, deb822-formatted sources have been supported since...
* Debian 9
* Ubuntu 16.04

Additionally, it is no longer recommended to globally add repository GPG
keys to APT's configuration. Instead, keys should be stored in
/etc/apt/keyrings and referenced only by the sources signed by them.

See: https://wiki.debian.org/DebianRepository/UseThirdParty
See: https://salsa.debian.org/apt-team/apt/-/commit/81460e32961bb0b9922bf8a1a27d87705d8c3e51