### PR TITLE
Modernize APT configuration for Debian & Ubuntu

### DIFF
--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -57,20 +57,28 @@ export const Downloads: Array<Download> = [
             <pre>
               <code>
                 {`sudo apt install curl gnupg
-curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin.gpg
-echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release ) $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release ) main" | sudo tee /etc/apt/sources.list.d/jellyfin.list
+sudo mkdir /etc/apt/keyrings
+curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg
+cat <<EOF | sudo tee /etc/apt/sources.list.d/jellyfin.sources
+Types: deb
+URIs: https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )
+Suites: $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )
+Components: main
+Arch: $( dpkg --print-architecture )
+Signed-By: /etc/apt/keyrings/jellyfin.gpg
+EOF
 sudo apt update
 sudo apt install jellyfin`}
               </code>
             </pre>
             <p>
-              <b>Note:</b> The third command should give you output similar to{' '}
-              <code>deb [arch=(architecture)] https://repo.jellyfin.org/(distribution) (release) main</code>. We support{' '}
-              <code>amd64</code>, <code>armhf</code>, and <code>arm64</code> for architectures, <code>debian</code> and{' '}
-              <code>ubuntu</code> for distributions, <code>buster</code> and <code>bullseye</code> for Debian releases
-              and <code>bionic</code>, <code>focal</code>, <code>impish</code> and <code>jammy</code> for Ubuntu
-              releases. If you see something different in your output, you might need to manually modify it. Use the
-              closest equivalent Debian or Ubuntu version instead.
+              <b>Note:</b> The third command will output the Jellyfin APT repository configuration for your system. We
+              support <code>amd64</code>, <code>armhf</code>, and <code>arm64</code> for architectures (
+              <code>Arch:</code>), <code>debian</code> and <code>ubuntu</code> for distributions (the text after the
+              final slash in <code>URIs:</code>), <code>buster</code> and <code>bullseye</code> for Debian releases and{' '}
+              <code>bionic</code>, <code>focal</code>, <code>impish</code> and <code>jammy</code> for Ubuntu releases (
+              <code>Suites:</code>). If you see something different in your output, you might need to manually modify
+              it. Use the closest equivalent Debian or Ubuntu version, instead.
             </p>
             <p className='margin-bottom--none'>
               Once installed, Jellyfin will be running as a service. Manage it with{' '}
@@ -90,24 +98,32 @@ sudo apt install jellyfin`}
             <pre>
               <code>
                 {`sudo apt install curl gnupg
-curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin.gpg
-echo "deb [arch=$( dpkg --print-architecture )] https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release ) $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release ) main unstable" | sudo tee /etc/apt/sources.list.d/jellyfin.list
+sudo mkdir /etc/apt/keyrings
+curl -fsSL https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg
+cat <<EOF | sudo tee /etc/apt/sources.list.d/jellyfin.sources
+Types: deb
+URIs: https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )
+Suites: $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )
+Components: main unstable
+Arch: $( dpkg --print-architecture )
+Signed-By: /etc/apt/keyrings/jellyfin.gpg
+EOF
 sudo apt update
 sudo apt install jellyfin`}
               </code>
             </pre>
             <p>
-              <b>Note:</b> The third command should give you output similar to{' '}
-              <code>deb [arch=(architecture)] https://repo.jellyfin.org/(distribution) (release) main</code>. We support{' '}
-              <code>amd64</code>, <code>armhf</code>, and <code>arm64</code> for architectures, <code>debian</code> and{' '}
-              <code>ubuntu</code> for distributions, <code>buster</code> and <code>bullseye</code> for Debian releases
-              and <code>bionic</code>, <code>focal</code>, <code>impish</code> and <code>jammy</code> for Ubuntu
-              releases. If you see something different in your output, you might need to manually modify it. Use the
-              closest equivalent Debian or Ubuntu version instead.
+              <b>Note:</b> The third command will output the Jellyfin APT repository configuration for your system. We
+              support <code>amd64</code>, <code>armhf</code>, and <code>arm64</code> for architectures (
+              <code>Arch:</code>), <code>debian</code> and <code>ubuntu</code> for distributions (the text after the
+              final slash in <code>URIs:</code>), <code>buster</code> and <code>bullseye</code> for Debian releases and{' '}
+              <code>bionic</code>, <code>focal</code>, <code>impish</code> and <code>jammy</code> for Ubuntu releases (
+              <code>Suites:</code>). If you see something different in your output, you might need to manually modify
+              it. Use the closest equivalent Debian or Ubuntu version, instead.
             </p>
             <p>
-              <b>Note:</b> Both the <code>main</code> and <code>unstable</code> are needed as the{' '}
-              <code>jellyfin-ffmpeg</code> package is only in the <code>main</code> component.
+              <b>Note:</b> Both the <code>main</code> and <code>unstable</code> are needed in <code>Components:</code>{' '}
+              as the <code>jellyfin-ffmpeg</code> package is only in the <code>main</code> component.
             </p>
             <p className='margin-bottom--none'>
               Once installed, Jellyfin will be running as a service. Manage it with{' '}


### PR DESCRIPTION
Recently, Debian-based distributions have switched to using the deb822
configuration format for APT sources by default.

This feature was first released in APT 1.1.

So, deb822-formatted sources have been supported since...
* Debian 9
* Ubuntu 16.04

Additionally, it is no longer recommended to globally add repository GPG
keys to APT's configuration. Instead, keys should be stored in
/etc/apt/keyrings and referenced only by the sources signed by them.

See: https://wiki.debian.org/DebianRepository/UseThirdParty
See: https://salsa.debian.org/apt-team/apt/-/commit/81460e32961bb0b9922bf8a1a27d87705d8c3e51