### PR TITLE
Use swiper pagination for screenshots

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,7 +110,11 @@ Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/
           showReadingTime: true
         },
         theme: {
-          customCss: [require.resolve('@fontsource/noto-sans/index.css'), require.resolve('./src/css/custom.css')]
+          customCss: [
+            require.resolve('@fontsource/noto-sans/index.css'),
+            require.resolve('./src/css/custom.css'),
+            require.resolve('./src/css/swiper.css')
+          ]
         }
       }
     ]

--- a/src/components/home/InActionSection.tsx
+++ b/src/components/home/InActionSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigation } from 'swiper';
+import { Pagination } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 import HomeImageUrl from '../../../static/images/screenshots/home/10.8-home.png';
@@ -8,7 +8,7 @@ import DetailsImageUrl from '../../../static/images/screenshots/home/10.8-detail
 import PlaybackImageUrl from '../../../static/images/screenshots/home/10.8-playback.png';
 
 import 'swiper/css';
-import 'swiper/css/navigation';
+import 'swiper/css/pagination';
 import landingSectionStyles from './LandingSection.module.css';
 import clsx from 'clsx';
 
@@ -53,10 +53,10 @@ export default function InActionSection() {
         </div>
         <div className='row row--center'>
           <div className='col col--10 padding--none'>
-            <Swiper navigation modules={[Navigation]}>
+            <Swiper pagination modules={[Pagination]} className='swiper-pagination--below'>
               {screenshots.map(({ id, caption, url, alt }) => (
                 <SwiperSlide key={`slide-${id}`}>
-                  <figure>
+                  <figure className='margin--none'>
                     <img src={url} alt={alt} />
                     <figcaption className='text--center'>{caption}</figcaption>
                   </figure>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -43,9 +43,6 @@ html {
   --ifm-navbar-search-input-background-color: #172138;
   --ifm-navbar-search-input-icon: url('data:image/svg+xml;utf8,<svg fill="%23ffffff" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" height="16px" width="16px"><path d="M6.02945,10.20327a4.17382,4.17382,0,1,1,4.17382-4.17382A4.15609,4.15609,0,0,1,6.02945,10.20327Zm9.69195,4.2199L10.8989,9.59979A5.88021,5.88021,0,0,0,12.058,6.02856,6.00467,6.00467,0,1,0,9.59979,10.8989l4.82338,4.82338a.89729.89729,0,0,0,1.29912,0,.89749.89749,0,0,0-.00087-1.29909Z" /></svg>');
 
-  /* custom swiper colors */
-  --swiper-theme-color: #ffffff !important;
-
   /* custom Jellyfin colors */
   --jf-gradient-color-primary-dark: #003c50;
   --jf-gradient-color-secondary-dark: #3e2247;

--- a/src/css/swiper.css
+++ b/src/css/swiper.css
@@ -1,0 +1,17 @@
+/* stylelint-disable docusaurus/copyright-header */
+/**
+ * Custom styles for swiper.js
+ */
+
+:root {
+  /* custom swiper colors */
+  --swiper-theme-color: #00afeb !important;
+  --swiper-navigation-color: #eeeeee;
+  --swiper-pagination-color: #eeeeee;
+  --swiper-pagination-bullet-inactive-color: #eeeeee;
+}
+
+/* custom class to place pagination below slides */
+.swiper-pagination--below > .swiper-pagination {
+  position: initial;
+}


### PR DESCRIPTION
* Moves swiper customization to a separate css file
* Use pagination instead of navigation for screenshot slides
* Fixes margin issue due to browser styles of `<figure>`
* Changes active swiper to use `#eee` instead of `#fff` because I thought it looked a little better, but I am not a designer so :man_shrugging: 

![Screenshot 2022-09-08 at 16-48-55 The Free Software Media System Jellyfin](https://user-images.githubusercontent.com/3450688/189224304-cb8470be-b9aa-43fe-9789-9daf9d555f40.png)
