### PR TITLE
Add markdownlint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,3 +27,14 @@ jobs:
 
       - name: Run eslint
         run: npm run lint
+
+  lint:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+      - name: Set up problem matcher
+        uses: xt0rted/markdownlint-problem-matcher@b643b0751c371f357690337d4549221347c0e1bc # tag=v1.1.0
+      - name: Run markdownlint
+        run: npx --package markdownlint-cli markdownlint '**/*.md' --ignore node_modules

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,19 @@
+# MD013/line-length
+MD013: false
+
+# MD033/no-inline-html
+
+MD033: false
+
+# MD025/single-title
+MD025:
+  # Ignore front matter 'title' property, it is not used in generated markup
+  front_matter_title: ''
+
+# MD026/no-trailing-punctuation
+MD026:
+  # Allow headings to end with '?'
+  punctuation: '.,;:!'
+
+# MD028/no-blanks-blockquote
+MD028: false

--- a/blog/2021/04-12-mirrorbits-cdn.md
+++ b/blog/2021/04-12-mirrorbits-cdn.md
@@ -5,7 +5,7 @@ authors: joshuaboniface
 date: 2021-04-12
 slug: mirrorbits-cdn
 ---
-
+<!-- markdownlint-disable -->
 For many projects, distributing binary assets is easy: put the files on GitHub and you're done. It's not something many think about. But at Jellyfin, we needed something more robust, something able to handle our needs more elegantly than GitHub or a basic web server could. And both for those interested, and for those supporting other similar projects, I'd like to share how we do it.
 
 <!--truncate-->

--- a/docs/general/community-standards.md
+++ b/docs/general/community-standards.md
@@ -53,5 +53,5 @@ Questions or comments regarding these standards should be forwarded to the [Proj
 
 This document represents official Jellyfin project policy. Any changes to this document require a changelog entry here and approval by a Project Leader.
 
-* 2020-09-14, Joshua Boniface: Initial version of the community standards document. Based *very* loosely on several CoCs including the Contributor Covenant, and various Forum rules I've read and written over the years.
-* 2022-09-03, Joshua Boniface: Update header and footer sections; reduce redundant wording; make rules clearer.
+- 2020-09-14, Joshua Boniface: Initial version of the community standards document. Based *very* loosely on several CoCs including the Contributor Covenant, and various Forum rules I've read and written over the years.
+- 2022-09-03, Joshua Boniface: Update header and footer sections; reduce redundant wording; make rules clearer.


### PR DESCRIPTION
The config is copied from the current jellyfin-docs repository because most content is from there. Two files contained some problems, one of them was a blog post in which I just disabled the linting.

Right now mdx files are not linted, I'm not sure if we want to add those.