### PR TITLE
Disable search indexing of blog posts

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -138,9 +138,16 @@ Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/
       require.resolve('@easyops-cn/docusaurus-search-local'),
       {
         hashed: true,
+        indexBlog: false,
         indexPages: true,
         blogRouteBasePath: '/posts',
-        ignoreFiles: ['andtv-privacy']
+        ignoreFiles: [
+          'andtv-privacy',
+          // NOTE: We need to explicitly ignore the blog routes because it seems to fall through to the page indexing
+          'posts',
+          /^posts\//
+        ],
+        explicitSearchResultPath: true
       }
     ]
   ]


### PR DESCRIPTION
Blog search results seem to be taking priority over others and I suspect they won't be what most people are looking for on the site, so I think it is best to disable them until we can possibly provide some ranking/weighting to the search results.