### PR TITLE
Update the getting help documentation to reference the contact page

### DIFF
--- a/docs/general/getting-help.md
+++ b/docs/general/getting-help.md
@@ -6,47 +6,6 @@ sidebar_position: 1
 
 # Getting Help
 
-If you are having trouble using or configuring Jellyfin, there are several ways to get help. Please ensure you read our [Community Standards](/docs/general/community-standards) before interacting in any of the following locations.
-
-- The Jellyfin [Matrix channels](https://matrix.to/#/#jellyfinorg:matrix.org): For chat and real-time discussions.
-
-  - All channels are bridged to IRC and Discord.
-
-- The Jellyfin [subreddit](https://www.reddit.com/r/jellyfin): For general discussions.
-
-We are also active on social media.
-
-- [Facebook](https://www.facebook.com/jellyfin.media)
-
-- [Twitter](https://twitter.com/jellyfin)
-
-## Matrix Channels
-
-- <a href="https://matrix.to/#/#jellyfin:matrix.org"><img alt="jellyfin" src="https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix&label=jellyfin" /></a>: General chat related to the project
-- <a href="https://matrix.to/#/#jellyfin-announce:matrix.org"><img alt="jellyfin-announce" src="https://img.shields.io/matrix/jellyfin-announce:matrix.org.svg?logo=matrix&label=jellyfin-announce" /></a>: Announcements for releases and other important information
-- <a href="https://matrix.to/#/#jellyfin-troubleshooting:matrix.org"><img alt="jellyfin-troubleshooting" src="https://img.shields.io/matrix/jellyfin-troubleshooting:matrix.org.svg?logo=matrix&label=jellyfin-troubleshooting" /></a>: User troubleshooting
-- <a href="https://matrix.to/#/#jellyfin-dev:matrix.org"><img alt="jellyfin-dev" src="https://img.shields.io/matrix/jellyfin-dev:matrix.org.svg?logo=matrix&label=jellyfin-dev" /></a>: Main room for development communication
-- <a href="https://matrix.to/#/#jellyfin-dev-client:matrix.org"><img alt="jellyfin-dev-client" src="https://img.shields.io/matrix/jellyfin-dev-client:matrix.org.svg?logo=matrix&label=jellyfin-dev-client" /></a>: Client and Web development
-- <a href="https://matrix.to/#/#jellyfin-dev-android:matrix.org"><img alt="jellyfin-dev-android" src="https://img.shields.io/matrix/jellyfin-dev-android:matrix.org.svg?logo=matrix&label=jellyfin-dev-android" /></a>: Android, Android TV and Fire TV development
-- <a href="https://matrix.to/#/#jellyfin-dev-ios:matrix.org"><img alt="jellyfin-dev-ios" src="https://img.shields.io/matrix/jellyfin-dev-ios:matrix.org.svg?logo=matrix&label=jellyfin-dev-ios" /></a>: iOS, iPadOS, macOS, and tvOS development
-- <a href="https://matrix.to/#/#jellyfin-dev-python:matrix.org"><img alt="jellyfin-dev-python" src="https://img.shields.io/matrix/jellyfin-dev-python:matrix.org.svg?logo=matrix&label=jellyfin-dev-python" /></a>: Python development
-- <a href="https://matrix.to/#/#jellyfin-dev-roku:matrix.org"><img alt="jellyfin-dev-roku" src="https://img.shields.io/matrix/jellyfin-dev-roku:matrix.org.svg?logo=matrix&label=jellyfin-dev-roku" /></a>: Roku development
-- <a href="https://matrix.to/#/#jellyfin-offtopic:matrix.org"><img alt="jellyfin-offtopic" src="https://img.shields.io/matrix/jellyfin-offtopic:matrix.org.svg?logo=matrix&label=jellyfin-offtopic" /></a>: Chat about anything
-
-## IRC Channels
-
-All channels are bridged from Matrix to [Libera.chat](https://libera.chat) for convenience.
-
-- [#jellyfin](ircs://irc.libera.chat:6697/#jellyfin)
-- [#jellyfin-announce](ircs://irc.libera.chat:6697/#jellyfin-announce)
-- [#jellyfin-troubleshooting](ircs://irc.libera.chat:6697/#jellyfin-troubleshooting)
-- [#jellyfin-dev](ircs://irc.libera.chat:6697/#jellyfin-dev)
-- [#jellyfin-dev-client](ircs://irc.libera.chat:6697/#jellyfin-dev-client)
-- [#jellyfin-dev-android](ircs://irc.libera.chat:6697/#jellyfin-dev-android)
-- [#jellyfin-offtopic](ircs://irc.libera.chat:6697/#jellyfin-offtopic)
-
-## Discord
-
-For convenience, we have a Discord server that is bridged to the chats above. Note that **Matrix** is still the preferred chat platform, and Discord messages may be missed due to bridge instability.
-
-[Join our Discord](https://discord.gg/zHBxVSXdBV)
+If you are having trouble using or configuring Jellyfin, there are several ways to get help.
+Please ensure you read our [Community Standards](/docs/general/community-standards) before interacting with the Jellyfin community.
+See the [Contact page](/contact) for a comprehensive list of places to find community discussion and support.


### PR DESCRIPTION
Updates the getting help page in the documentation to just reference the main contact page instead of duplicating information.

Fixes #170