### PR TITLE
Add DavidAnson.vscode-markdownlint as recommended workspace extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,3 @@
 {
-	"recommendations": [
-		"esbenp.prettier-vscode"
-	]
+  "recommendations": ["esbenp.prettier-vscode", "DavidAnson.vscode-markdownlint"]
 }


### PR DESCRIPTION
This should help users that are not 100% familiar with markdown or the linter rules by showing error lines in VSCode.

Also reformatted the file because settings.json enables formatOnSave and prettier is set as default formatter and wants everything on one line...