### PR TITLE
Combine download filters

### DIFF
--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -103,17 +103,21 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
             </Admonition>
           )}
 
-          {Downloads.filter((download) => download.osTypes.includes(osType))
-            .filter((download) => isStableLinks || download.unstableButtons.length > 0)
-            .map((download) => (
-              <DownloadDetails
-                key={download.id}
-                download={download}
-                isStableLinks={isStableLinks}
-                activeButton={activeButton}
-                setActiveButton={setActiveButton}
-              />
-            ))}
+          {Downloads.filter(
+            (download) =>
+              // OS Type matches filter
+              download.osTypes.includes(osType) &&
+              // Ensure there are unstable links if unstable is selected
+              (isStableLinks || download.unstableButtons.length > 0)
+          ).map((download) => (
+            <DownloadDetails
+              key={download.id}
+              download={download}
+              isStableLinks={isStableLinks}
+              activeButton={activeButton}
+              setActiveButton={setActiveButton}
+            />
+          ))}
         </section>
       </main>
     </Layout>


### PR DESCRIPTION
Just a minor cleanup to avoid multiple `.filter()` calls.