### PR TITLE
Update OS Details

### DIFF
--- a/docs/general/administration/installing.md
+++ b/docs/general/administration/installing.md
@@ -333,7 +333,7 @@ Using the Advanced/Service mode may experience FFmpeg hardware acceleration issu
 2. Search for Jellyfin.
 3. Click Uninstall.
 
-### Manual Installation (x86/x64)
+### Manual Installation (x64)
 
 **Install**
 
@@ -366,7 +366,7 @@ Using the Advanced/Service mode may experience FFmpeg hardware acceleration issu
    jellyfin.bat
    ```
 
-6. Open your browser at `http://<--Server-IP-->:8096` (if auto-start of webapp is disabled)
+6. Open your browser at `http://<--Server-IP-->:8096`.
 
 **Update**
 

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -298,7 +298,7 @@ makepkg -si`}
     name: 'MacOS',
     osTypes: [OsType.MacOS],
     status: DownloadStatus.Official,
-    features: [Feature.CustomFFmpeg],
+    features: [],
     platforms: [Platform.MacOS],
     description: 'Both installers (.dmg) and manual ZIP archives (.tar.gz) are provided.',
     stableButtons: [{ id: 'macos-stable-link', url: 'https://repo.jellyfin.org/releases/server/macos/stable' }],


### PR DESCRIPTION
Some minor changes.

For macOS, though we do bundle FFmpeg, it's not the custom one that we have for our other platforms. It still works well, but it doesn't have some of the minor keyframe fixes, chromaprint, etc.

For Windows, we have not provided an x86 version in a long time, so I just removed the mention from the header.