### PR TITLE
Fix GitHub page deployment after multiple merges in a small timeframe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     name: Deploy to GitHub Pages
+    concurrency: build-deploy-pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The deployment task would sometimes fail when an existing deployment is in progress. Adding the concurrency option to the workflow should resolve this as only one instance of the job can run at any time.