### PR TITLE
Update docker-compose.yml example

### DIFF
--- a/docs/general/administration/installing.md
+++ b/docs/general/administration/installing.md
@@ -115,6 +115,9 @@ services:
     # Optional - alternative address used for autodiscovery
     environment:
       - JELLYFIN_PublishedServerUrl=http://example.com
+    # Optional - may be necessary for docker healthcheck to pass if running in host network mode
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 ```
 
 Then while in the same folder as the `docker-compose.yml` run:


### PR DESCRIPTION
Add optional `extra_hosts:` argument to docker-compose example, which is necessary to pass docker healthcheck when running in host network mode.  Otherwise results in false-positive "unhealthy" warning in `docker container ls` output, as localhost is unresolved without setting host.docker.internal:host-gateway.  At least, this is the case for me on linux, running:

~/self-hosted/jellyfin
⟩ pacman -Q | grep docker
docker 1:20.10.21-1
docker-compose 2.12.2-1

~/self-hosted/jellyfin
⟩ pacman -Q | grep container
containerd 1.6.10-1
containers-common 1:0.50.1-2