### PR TITLE
Add mdx extension to recommendation list and add tags to all Android TV related blog posts

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "DavidAnson.vscode-markdownlint"]
+  "recommendations": ["esbenp.prettier-vscode", "davidanson.vscode-markdownlint", "unifiedjs.vscode-mdx"]
 }

--- a/blog/2020/02-04-android-tv-11.mdx
+++ b/blog/2020/02-04-android-tv-11.mdx
@@ -1,9 +1,10 @@
 ---
-title: "New Android TV Release - v0.11.0"
-description: "Improved Video Playback That Goes up to 11"
+title: 'New Android TV Release - v0.11.0'
+description: 'Improved Video Playback That Goes up to 11'
 authors: nielsvanvelzen
 date: 2020-02-04
 slug: android-tv-11
+tags: [release, android-tv]
 ---
 
 Thank you for using Jellyfin! This is a major update for the Android TV client.
@@ -19,10 +20,10 @@ We have added crash reporting. Read the notes below for more information.
 ## Highlights
 
 - Upgraded ExoPlayer to version 2
-   This means video playback should be a lot smoother now!
+  This means video playback should be a lot smoother now!
 - New home screen
-   The newly made home screen now looks more or less the same as the webclient. It will display the sections you have chosen under your "Home" preferences.  
-   *Note: changing sections is only available in the web version for now*
+  The newly made home screen now looks more or less the same as the webclient. It will display the sections you have chosen under your "Home" preferences.  
+   _Note: changing sections is only available in the web version for now_
 - Integration with "Next Up" section on Android TV devices
 
 ## Crash Reporting
@@ -41,8 +42,15 @@ Full release notes available on [GitHub](https://github.com/jellyfin/jellyfin-an
 
 ## Download Now
 
-<a className="margin-right--md" href='https://play.google.com/store/apps/details?id=org.jellyfin.androidtv&utm_source=blog&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img width="153" alt='Get it on Google Play' src='/images/store-icons/google-play.png'/></a>
+<a
+  className='margin-right--md'
+  href='https://play.google.com/store/apps/details?id=org.jellyfin.androidtv&utm_source=blog&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'
+>
+  <img width='153' alt='Get it on Google Play' src='/images/store-icons/google-play.png' />
+</a>
 
-<a href='https://www.amazon.com/gp/product/B07TX7Z725/ref=jellyfin_for_fire_tv'><img width="153" alt='Available at Amazon App Store' src='/images/store-icons/amazon.png'/></a>
+<a href='https://www.amazon.com/gp/product/B07TX7Z725/ref=jellyfin_for_fire_tv'>
+  <img width='153' alt='Available at Amazon App Store' src='/images/store-icons/amazon.png' />
+</a>
 
 Direct downloads are always available from [our repository](https://repo.jellyfin.org/releases/client/androidtv/).

--- a/blog/2021/07-24-android-betas.mdx
+++ b/blog/2021/07-24-android-betas.mdx
@@ -4,7 +4,9 @@ description: 'A small FAQ about our beta programs'
 authors: nielsvanvelzen
 date: 2021-07-24
 slug: android-betas
+tags: [android-tv]
 ---
+
 <!-- markdownlint-disable MD033 -->
 
 With the release of the first Android TV 0.12 release beta, this is a good time to explain how our Android beta programs work and how to start using them. The mobile app has used a public beta channel for around a year now and with the Android TV app coming close to a new release we're adding a similar program for that as well.
@@ -36,16 +38,16 @@ The Amazon Appstore has no options for beta apps. Therefore, we unfortunately ca
 
 ### Android TV
 
-<a href="https://play.google.com/apps/testing/org.jellyfin.androidtv">
-  <img width="153" alt="Jellyfin for Android TV on Google Play" src="/images/store-icons/google-play.png" />
+<a href='https://play.google.com/apps/testing/org.jellyfin.androidtv'>
+  <img width='153' alt='Jellyfin for Android TV on Google Play' src='/images/store-icons/google-play.png' />
 </a>
 
 Direct downloads available in [our repository](https://repo.jellyfin.org/releases/client/androidtv/).
 
 ### Android (mobile)
 
-<a href="https://play.google.com/apps/testing/org.jellyfin.mobile">
-  <img width="153" alt="Jellyfin on Google Play" src="/images/store-icons/google-play.png" />
+<a href='https://play.google.com/apps/testing/org.jellyfin.mobile'>
+  <img width='153' alt='Jellyfin on Google Play' src='/images/store-icons/google-play.png' />
 </a>
 
 Direct downloads available in [our repository](https://repo.jellyfin.org/releases/client/android/).

--- a/blog/2021/09-30-android-tv-12/index.mdx
+++ b/blog/2021/09-30-android-tv-12/index.mdx
@@ -4,6 +4,7 @@ description: Our biggest app update to date.
 authors: nielsvanvelzen
 date: 2021-09-30
 slug: android-tv-12
+tags: [release, android-tv]
 ---
 
 import { ImgComparisonSlider } from '@img-comparison-slider/react';
@@ -23,9 +24,9 @@ Over 400[^1] pull requests containing 2400+ commits, 750+ changed files with 540
 
 We got a lot of complaints about our authentication flow. It wasn't obvious how to enable the auto-login option and managing multiple servers or users was not an easy task. We also didn't like this part of the app, and decided to completely revamp it! The rewritten sign-in screen looks more modern and is much easier to use. There is a new help section that links to our documentation to help new users get started with Jellyfin. The auto-discovery feature of the app now shows all servers instead of the first one, you can select one of those or manually enter your server address to connect. You can then proceed to add a user and start using the app. Users are automatically saved now with auto-login enabled by default.
 
-<ImgComparisonSlider className="margin-bottom--md">
-    <img slot="before" src={require("./11-user-select.png").default} />
-    <img slot="after" src={require("./12-user-select.png").default} />
+<ImgComparisonSlider className='margin-bottom--md'>
+  <img slot='before' src={require('./11-user-select.png').default} />
+  <img slot='after' src={require('./12-user-select.png').default} />
 </ImgComparisonSlider>
 
 ## Updated user interface design
@@ -33,32 +34,28 @@ We got a lot of complaints about our authentication flow. It wasn't obvious how 
 After logging in you will be presented with a modern look and feel in our refreshed user interface. A new toolbar is added to the top-right corner of the screen to open the search page, settings or to switch to a different user. No need to scroll down to the bottom of the home screen anymore.
 Beneath this new toolbar is your media, like it always was, but the cards got a new look with the debatable colored backgrounds removed.
 
-
-<ImgComparisonSlider className="margin-bottom--md">
-    <img slot="before" src={require("./11-home.png").default} />
-    <img slot="after" src={require("./12-home.png").default} />
+<ImgComparisonSlider className='margin-bottom--md'>
+  <img slot='before' src={require('./11-home.png').default} />
+  <img slot='after' src={require('./12-home.png').default} />
 </ImgComparisonSlider>
 
 The settings screen got a refresh too. It allows you to more easily change settings. Some new settings got added to customize the app to your own taste.
 
-
-<ImgComparisonSlider className="margin-bottom--md">
-    <img slot="before" src={require("./11-settings.png").default} />
-    <img slot="after" src={require("./12-settings.png").default} />
+<ImgComparisonSlider className='margin-bottom--md'>
+  <img slot='before' src={require('./11-settings.png').default} />
+  <img slot='after' src={require('./12-settings.png').default} />
 </ImgComparisonSlider>
 
 The user interface when browsing inside libraries got some slight changes too. We're hoping to completely revamp this part of the app at some point, but that didn't stop us from making it slightly better now.
 
-
-<ImgComparisonSlider className="margin-bottom--md">
-    <img slot="before" src={require("./11-browse.png").default} />
-    <img slot="after" src={require("./12-browse.png").default} />
+<ImgComparisonSlider className='margin-bottom--md'>
+  <img slot='before' src={require('./11-browse.png').default} />
+  <img slot='after' src={require('./12-browse.png').default} />
 </ImgComparisonSlider>
 
-
-<ImgComparisonSlider className="margin-bottom--md">
-    <img slot="before" src={require("./11-details.png").default} />
-    <img slot="after" src={require("./12-details.png").default} />
+<ImgComparisonSlider className='margin-bottom--md'>
+  <img slot='before' src={require('./11-details.png').default} />
+  <img slot='after' src={require('./12-details.png').default} />
 </ImgComparisonSlider>
 
 ### Themes
@@ -69,10 +66,9 @@ The web client supported theming since forever but the Android TV app did not. T
 
 The video player was completely redesigned to remove a lot of clutter and make it easier to use. The new design is bigger so you can more easily see the information on a television.
 
-
-<ImgComparisonSlider className="margin-bottom--md">
-    <img slot="before" src={require("./11-player.png").default} />
-    <img slot="after" src={require("./12-player.png").default} />
+<ImgComparisonSlider className='margin-bottom--md'>
+  <img slot='before' src={require('./11-player.png').default} />
+  <img slot='after' src={require('./12-player.png').default} />
 </ImgComparisonSlider>
 
 The new video player design is just the beginning. A project to rewrite the playback code behind it is already in the works. This rewrite should help with the crashes and unnecessary transcoding that happens sometimes. It will also give us the opportunity to add new features like SyncPlay. But this doesn't mean the current code isn't being worked on anymore! We did fix some issues with the current video player code. Notable are changes for Fire TV to direct play more often and a lot of crashes got fixed.
@@ -136,12 +132,12 @@ Full changelog with all pull requests available on [GitHub](https://github.com/j
 
 ## Download Now
 
-<a className="margin-right--md" href="https://play.google.com/store/apps/details?id=org.jellyfin.androidtv">
-  <img width="153" alt='Jellyfin for Android TV on Google Play' src="/images/store-icons/google-play.png" />
+<a className='margin-right--md' href='https://play.google.com/store/apps/details?id=org.jellyfin.androidtv'>
+  <img width='153' alt='Jellyfin for Android TV on Google Play' src='/images/store-icons/google-play.png' />
 </a>
 
-<a href="https://www.amazon.com/gp/product/B07TX7Z725">
-  <img width="153" alt="Jellyfin for Fire TV at Amazon App Store" src="/images/store-icons/amazon.png" />
+<a href='https://www.amazon.com/gp/product/B07TX7Z725'>
+  <img width='153' alt='Jellyfin for Fire TV at Amazon App Store' src='/images/store-icons/amazon.png' />
 </a>
 
 Direct downloads are always available from [our repository](https://repo.jellyfin.org/releases/client/androidtv/).

--- a/blog/2022/03-17-android-tv-13/index.mdx
+++ b/blog/2022/03-17-android-tv-13/index.mdx
@@ -4,6 +4,7 @@ description: That was quick
 authors: nielsvanvelzen
 date: 2022-03-17
 slug: android-tv-13
+tags: [release, android-tv]
 ---
 
 <!-- markdownlint-disable MD033 MD036 -->
@@ -52,7 +53,11 @@ The app has quite a lot of preferences. To make it easier to find the correct pr
 
 Some new preferences were added too. We've added subtitle preferences (see above), the ability to (finally) change the home sections from within the app. And the licenses of third party libraries are now shown in the about section.
 
-<img src={require("./newprefs.png").default} alt="Screenshot of the new preference categories" style={{ maxHeight: "500px" }} />
+<img
+  src={require('./newprefs.png').default}
+  alt='Screenshot of the new preference categories'
+  style={{ maxHeight: '500px' }}
+/>
 
 ## Contributors
 
@@ -79,12 +84,12 @@ Full changelog with all pull requests available on [GitHub](https://github.com/j
 
 ## Download Now
 
-<a className="margin-right--md" href="https://play.google.com/store/apps/details?id=org.jellyfin.androidtv">
-  <img width="153" alt='Jellyfin for Android TV on Google Play' src="/images/store-icons/google-play.png" />
+<a className='margin-right--md' href='https://play.google.com/store/apps/details?id=org.jellyfin.androidtv'>
+  <img width='153' alt='Jellyfin for Android TV on Google Play' src='/images/store-icons/google-play.png' />
 </a>
 
-<a href="https://www.amazon.com/gp/product/B07TX7Z725">
-  <img width="153" alt="Jellyfin for Fire TV at Amazon App Store" src="/images/store-icons/amazon.png" />
+<a href='https://www.amazon.com/gp/product/B07TX7Z725'>
+  <img width='153' alt='Jellyfin for Fire TV at Amazon App Store' src='/images/store-icons/amazon.png' />
 </a>
 
 Direct downloads are always available from [our repository](https://repo.jellyfin.org/releases/client/androidtv/).

--- a/blog/2022/08-02-android-tv-14/index.mdx
+++ b/blog/2022/08-02-android-tv-14/index.mdx
@@ -4,6 +4,7 @@ description: Quick, connect!
 authors: nielsvanvelzen
 date: 2022-08-02
 slug: android-tv-14
+tags: [release, android-tv]
 ---
 
 <!-- markdownlint-disable MD033 MD036 -->


### PR DESCRIPTION
Working on the ATV 0.15 post and I did some work on other files, made sense to create a separate PR for them. I added two new tags:

- release
  Meant for all posts for releases (all of server, client and plugin). Only tagged ATV posts for now.
- android-tv
  Meant for all posts related to the Android TV client/platform. This includes the releases and the post explaining the beta program.

I encourage everyone to tag their future posts just like these are.

Someone enabled `editor.formatOnSave` so all blog posts I touched have been formatted too.