### PR TITLE
Update jellyfin version listed in tutorial

### DIFF
--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -19,19 +19,19 @@ cd /opt/jellyfin
 ```
 
 Download the latest generic Linux build for your architecture.
-The rest of these instructions assume version 10.7.7 is being installed (i.e. `jellyfin_10.7.7_amd64.tar.gz`).
+The rest of these instructions assume version 10.8.8 is being installed (i.e. `jellyfin_10.8.8_amd64.tar.gz`).
 Download the generic build, then extract the archive:
 
 ```sh
-sudo wget https://repo.jellyfin.org/releases/server/linux/stable/combined/jellyfin_10.7.7_amd64.tar.gz
-sudo tar xvzf jellyfin_10.7.7_amd64.tar.gz
+sudo wget https://repo.jellyfin.org/releases/server/linux/stable/combined/jellyfin_10.8.8_amd64.tar.gz
+sudo tar xvzf jellyfin_10.8.8_amd64.tar.gz
 ```
 
-Create a symbolic link to the Jellyfin 10.7.7 directory.
+Create a symbolic link to the Jellyfin 10.8.8 directory.
 This allows an upgrade by repeating the above steps and enabling it by simply re-creating the symbolic link to the new version.
 
 ```sh
-sudo ln -s jellyfin_10.7.7 jellyfin
+sudo ln -s jellyfin_10.8.8 jellyfin
 ```
 
 Create four sub-directories for Jellyfin data.


### PR DESCRIPTION
Jellyfin version listed in the tutorial is out of date, which causes an error 404 when attempting to access the archives.