### PR TITLE
Update link on Swiftfin

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -346,7 +346,7 @@ export const Clients: Array<Client> = [
     platforms: [Platform.IOS, Platform.TVOS],
     primaryLinks: [
       {
-         id: 'apple-store',
+        id: 'apple-store',
         name: 'App Store',
         url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
       }

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -346,9 +346,9 @@ export const Clients: Array<Client> = [
     platforms: [Platform.IOS, Platform.TVOS],
     primaryLinks: [
       {
-        id: 'test-flight',
-        name: 'TestFlight',
-        url: 'https://testflight.apple.com/join/oZd0QzWv'
+         id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
       }
     ],
     secondaryLinks: [


### PR DESCRIPTION
Replaces the TestFlight link with the App Store link. I wonder if we can/should move it up to be recommended though.