### PR TITLE
Remove andtv-privacy page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -163,7 +163,6 @@ Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/
         indexPages: true,
         blogRouteBasePath: '/posts',
         ignoreFiles: [
-          'andtv-privacy',
           // NOTE: We need to explicitly ignore the blog routes because it seems to fall through to the page indexing
           'posts',
           /^posts\//

--- a/src/pages/andtv-privacy.md
+++ b/src/pages/andtv-privacy.md
@@ -1,9 +1,0 @@
----
-title: Jellyin for Android TV - Privacy Policy
----
-
-# Jellyin for Android TV - Privacy Policy
-
-Jellyfin does not purposefully gather any information about your usage of the app or media playback.
-
-On devices with supported hardware, you may be prompted to enable microphone access, to allow voice search. This is strictly optional, and is not required to use the app. Any audio processing happens at the device provider level, and is never sent to Jellyfin.


### PR DESCRIPTION
We've updated the privacy policy links on Google Play some time ago and this page is no longer needed