### PR TITLE
comment in docker command should be removed

### DIFF
--- a/docs/general/administration/hardware-acceleration.md
+++ b/docs/general/administration/hardware-acceleration.md
@@ -223,7 +223,7 @@ docker run -d \
  --volume /path/to/cache:/cache \
  --volume /path/to/media:/media \
  --user 1000:1000 \
- --group-add="122" \ # Change this to match your system
+ --group-add="122" \ # Change this to match your system and remove this comment
  --net=host \
  --restart=unless-stopped \
  --device /dev/dri/renderD128:/dev/dri/renderD128 \


### PR DESCRIPTION
Command fails with comment.

```
❯ docker run -d \
 --volume /path/to/config:/config \
 --volume /path/to/cache:/cache \
 --volume /path/to/media:/media \
 --user 1000:1000 \
 --group-add="122" \ # Change this to match your system
 --net=host \
 --restart=unless-stopped \
 --device /dev/dri/renderD128:/dev/dri/renderD128 \
 --device /dev/dri/card0:/dev/dri/card0 \
 jellyfin/jellyfin
docker: invalid reference format.
See 'docker run --help'.
zsh: command not found: --net=host
```