### PR TITLE
Update Debug Logging Documentation

### DIFF
--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -54,9 +54,8 @@ Once the need for verbose logging has passed, debug logging can be disabled by c
 {
   "Serilog": {
     "MinimumLevel": "Information"
-    }
+  }
 }
-```
 
 ## Real Time Monitoring
 

--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -56,6 +56,7 @@ Once the need for verbose logging has passed, debug logging can be disabled by c
     "MinimumLevel": "Information"
   }
 }
+```
 
 ## Real Time Monitoring
 

--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -36,7 +36,7 @@ To make this change, go to the [Jellyfin configuration directory](/docs/general/
 {
   "Serilog": {
     "MinimumLevel": "Debug"
-    }
+  }
 }
 ```
 

--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -56,7 +56,7 @@ The structure for the `logging.json` file is slightly different, and should be m
 Jellyfin will automatically reload the new configuration without needing to restart.
 The debug messages show up in the log with the `DBG` tag.
 
-Once the need for verbose logging has passed, debug logging can be disabled again by reversing the above changes back the default value of `"Information"`.
+Once the need for verbose logging has passed, debug logging can be disabled again by reversing the above changes back to the default value of `"Information"`.
 
 ## Real Time Monitoring
 

--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -28,8 +28,10 @@ This would indicate either an incorrect address or an issue somewhere else on th
 
 ## Debug Logging
 
-To enable debug (much more verbose) logging, it is currently required to manually edit config files since no options exist yet on the frontend.
-Go to the Jellyfin configuration directory, find the `logging.default.json` file, and change the minimum level to debug as seen below.
+To enable much more verbose debug logging, it is currently required to manually edit configuration files since no option yet exists to enable debug functionality within the frontend UI.
+Go to the [Jellyfin configuration directory](/docs/general/administration/configuration#configuration-directory) and find the `logging.json` file if it exists, or the `logging.default.json` file if it does not. Debug logging is then enabled by changing the minimum logging level to debug as in the examples below.
+
+The `logging.default.json` file should be modified as below.
 
 ```json
 {
@@ -41,8 +43,20 @@ Go to the Jellyfin configuration directory, find the `logging.default.json` file
 }
 ```
 
+The structure for the `logging.json` file is slightly different, and should be modified as below.
+
+```json
+{
+  "Serilog": {
+    "MinimumLevel": "Debug"
+    }
+}
+```
+
 Jellyfin will automatically reload the new configuration without needing to restart.
 The debug messages show up in the log with the `DBG` tag.
+
+Once the need for verbose logging has passed, debug logging can be again disabled by reversing the above changes back the default value of `"Information"`.
 
 ## Real Time Monitoring
 

--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -56,7 +56,7 @@ The structure for the `logging.json` file is slightly different, and should be m
 Jellyfin will automatically reload the new configuration without needing to restart.
 The debug messages show up in the log with the `DBG` tag.
 
-Once the need for verbose logging has passed, debug logging can be again disabled by reversing the above changes back the default value of `"Information"`.
+Once the need for verbose logging has passed, debug logging can be disabled again by reversing the above changes back the default value of `"Information"`.
 
 ## Real Time Monitoring
 

--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -28,22 +28,9 @@ This would indicate either an incorrect address or an issue somewhere else on th
 
 ## Debug Logging
 
-To enable much more verbose debug logging, it is currently required to manually edit configuration files since no option yet exists to enable debug functionality within the frontend UI.
-Go to the [Jellyfin configuration directory](/docs/general/administration/configuration#configuration-directory) and find the `logging.json` file if it exists, or the `logging.default.json` file if it does not. Debug logging is then enabled by changing the minimum logging level to debug as in the examples below.
+To enable much more verbose debug logging, it is currently required to manually edit a configuration file, since Jellyfin does not yet have an option to enable debug functionality within the frontend UI.
 
-The `logging.default.json` file should be modified as below.
-
-```json
-{
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Debug"
-    }
-  }
-}
-```
-
-The structure for the `logging.json` file is slightly different, and should be modified as below.
+To make this change, go to the [Jellyfin configuration directory](/docs/general/administration/configuration#configuration-directory) and find the `logging.json` file if it exists, or create the file if it does not. Debug logging is then enabled by changing the minimum logging level to debug as in the example below. If `logging.json` already exists and contains existing keys, the `"MinimumLevel"` key should be added to the `"Serilog"` object as seen in the example. If `logging.json` does not already exist, or if it is empty, a configuration containing only the following example structure will enable debug logging.
 
 ```json
 {
@@ -53,10 +40,23 @@ The structure for the `logging.json` file is slightly different, and should be m
 }
 ```
 
-Jellyfin will automatically reload the new configuration without needing to restart.
-The debug messages show up in the log with the `DBG` tag.
+Debug messages appear in the log with the `DBG` tag prefixed to each line.
 
-Once the need for verbose logging has passed, debug logging can be disabled again by reversing the above changes back to the default value of `"Information"`.
+:::note
+
+If the `logging.json` file existed before the last server start, Jellyfin will automatically reload the new configuration, once the change is made, without needing to restart. If the `logging.json` file was created after the last server start, a server restart will be required before the changes enabling debug logging will take effect.
+
+:::
+
+Once the need for verbose logging has passed, debug logging can be disabled by changing the `"MinimumLevel"` key in `logging.json` to `"Information"`, as in the example below, in order to restore the default logging level. It is not necessary to delete the `logging.json` configuration after debugging is complete.
+
+```json
+{
+  "Serilog": {
+    "MinimumLevel": "Information"
+    }
+}
+```
 
 ## Real Time Monitoring
 


### PR DESCRIPTION
Expanded and revised the documentation on debug logging to include the case where an installation has the optional 'logging.json' file present. Also generally revised and clarified language, added a link to the configuration directory documentation, and added instructions for disabling debug logging.