### PR TITLE
Update header navigation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,21 +27,23 @@ module.exports = {
         src: 'images/logo.svg'
       },
       items: [
-        { to: 'posts', label: 'Blog', position: 'right' },
         {
           to: 'downloads',
-          label: 'Downloads',
-          position: 'right'
+          label: 'Downloads'
         },
         {
-          type: 'doc',
-          docId: 'index',
-          label: 'Documentation',
-          position: 'right'
+          to: 'posts',
+          label: 'Blog'
         },
         {
-          type: 'doc',
-          docId: 'developers/index',
+          type: 'docSidebar',
+          sidebarId: 'docs',
+          label: 'Documentation'
+        },
+
+        {
+          type: 'docSidebar',
+          sidebarId: 'developers',
           label: 'Developers',
           position: 'right'
         },


### PR DESCRIPTION
This PR targets the new "developers" branch so we don't update the production site until these changes are more stable.

-----

This change updates the header navigation to left align the primary pages and right align secondary pages. It also changes the "Downloads" page to be the first item, because that's the most important page!

## Before

![image](https://user-images.githubusercontent.com/2305178/218198702-e848929b-c96a-4de4-9a0d-9e7ff71d552b.png)

## After

![image](https://user-images.githubusercontent.com/2305178/218198722-617851b9-aac8-4d9f-8ba8-bc2cb175be7b.png)
