### PR TITLE
Replace @docusaurus/preset-classic with manual plugin configurations

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,7 @@ module.exports = {
   favicon: 'images/favicon.ico',
   organizationName: 'jellyfin',
   projectName: 'jellyfin.org',
+  /** @type {import('@docusaurus/types').ThemeConfig} */
   themeConfig: {
     image: 'images/social.png',
     metadata: [
@@ -86,80 +87,77 @@ module.exports = {
 Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/'>CC-BY-ND-4.0</a>`
     }
   },
-  presets: [
-    [
-      '@docusaurus/preset-classic',
-      {
-        docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
-          editUrl: 'https://github.com/jellyfin/jellyfin.org/edit/master/'
-        },
-        blog: {
-          routeBasePath: 'posts',
-          showReadingTime: true
-        },
-        theme: {
-          customCss: [
-            require.resolve('@fontsource/noto-sans/index.css'),
-            require.resolve('./src/css/custom.scss'),
-            require.resolve('./src/css/swiper.scss')
-          ]
-        }
-      }
-    ]
-  ],
   plugins: [
-    'docusaurus-plugin-sass',
+    [
+      '@docusaurus/plugin-content-docs',
+      /** @type {import('@docusaurus/plugin-content-docs').Options} */
+      {
+        sidebarPath: require.resolve('./sidebars.js'),
+        // Please change this to your repo.
+        editUrl: 'https://github.com/jellyfin/jellyfin.org/edit/master/'
+      }
+    ],
+    [
+      '@docusaurus/plugin-content-blog',
+      /** @type {import('@docusaurus/plugin-content-blog').Options} */
+      {
+        id: 'blog-main',
+        routeBasePath: 'posts',
+        showReadingTime: true,
+        path: 'blog'
+      }
+    ],
+    // Uncomment to enable developer blog
+    // [
+    //   '@docusaurus/plugin-content-blog',
+    //   /** @type {import('@docusaurus/plugin-content-blog').Options} */
+    //   {
+    //     id: 'blog-developers',
+    //     routeBasePath: 'developers/posts',
+    //     showReadingTime: true,
+    //     path: 'blog-dev',
+    //     authorsMapPath: '../blog/authors.yml'
+    //   }
+    // ],
+    [
+      '@docusaurus/plugin-content-pages',
+      /** @type {import('@docusaurus/plugin-content-pages').Options} */
+      {}
+    ],
+    [
+      '@docusaurus/plugin-sitemap',
+      /** @type {import('@docusaurus/plugin-sitemap').Options} */
+      {}
+    ],
+    [
+      'docusaurus-plugin-sass',
+      /** @type {import('docusaurus-plugin-sass').Options} */
+      {}
+    ],
     [
       '@docusaurus/plugin-client-redirects',
+      /** @type {import('@docusaurus/plugin-client-redirects').Options} */
       {
         fromExtensions: ['html'],
-        redirects: [
-          // These pages existed on the jellyfin-blog site, but were not fully configured
-          {
-            from: ['/categories', '/tags'],
-            to: '/posts'
-          },
-          // Jellyfin 10.8 and below linked to this subtitle docs page
-          {
-            from: '/docs/general/server/media/subtitles',
-            to: '/docs/general/server/media/external-files'
-          },
-          // Storage docs moved from the server guide to administrative docs
-          {
-            from: '/docs/general/server/storage',
-            to: '/docs/general/administration/storage'
-          },
-          // Unified client + server download pages
-          {
-            from: '/clients',
-            to: '/downloads/clients/'
-          },
-          {
-            from: '/clients/all',
-            to: '/downloads/clients/all'
-          },
-          // New installation documentation
-          {
-            from: '/docs/general/administration/installing',
-            to: '/docs/general/installation/'
-          },
-          {
-            from: '/docs/general/administration/install/synology',
-            to: '/docs/general/installation/synology'
-          },
-          {
-            from: '/docs/general/administration/building',
-            to: '/docs/general/installation/source'
-          }
-        ]
+        redirects: require('./redirects.js')
       }
     ]
   ],
   themes: [
     [
+      require.resolve('@docusaurus/theme-classic'),
+      /** @type {import('@docusaurus/theme-classic').Options} */
+      {
+        customCss: [
+          require.resolve('@fontsource/noto-sans/index.css'),
+          require.resolve('./src/css/custom.scss'),
+          require.resolve('./src/css/swiper.scss')
+        ]
+      }
+    ],
+    [
       require.resolve('@easyops-cn/docusaurus-search-local'),
+      /** @type {import('@easyops-cn/docusaurus-search-local').Options} */
       {
         hashed: true,
         indexBlog: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,11 @@
       "dependencies": {
         "@docusaurus/core": "2.3.1",
         "@docusaurus/plugin-client-redirects": "2.3.1",
-        "@docusaurus/preset-classic": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/plugin-sitemap": "2.3.1",
+        "@docusaurus/theme-classic": "2.3.1",
         "@easyops-cn/docusaurus-search-local": "0.33.6",
         "@fontsource/noto-sans": "4.5.11",
         "@icons-pack/react-simple-icons": "5.11.0",
@@ -61,151 +65,6 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
       "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
       "dev": true
-    },
-    "node_modules/@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
-      }
-    },
-    "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
-      },
-      "peerDependencies": {
-        "@algolia/client-search": "^4.9.1",
-        "algoliasearch": "^4.9.1"
-      }
-    },
-    "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
-    },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
-      "dependencies": {
-        "@algolia/cache-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
-      "dependencies": {
-        "@algolia/cache-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
-      "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
-      "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
-      "dependencies": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
-      "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
-      "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/events": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
-      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
-    },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
-      "dependencies": {
-        "@algolia/logger-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
-      "dependencies": {
-        "@algolia/requester-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
-      "dependencies": {
-        "@algolia/requester-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
-      "dependencies": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
-      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -2013,38 +1872,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
-    },
-    "node_modules/@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
-      "dependencies": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
-        "algoliasearch": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 19.0.0",
-        "react": ">= 16.8.0 < 19.0.0",
-        "react-dom": ">= 16.8.0 < 19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@docusaurus/core": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
@@ -2314,80 +2141,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz",
-      "integrity": "sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "fs-extra": "^10.1.0",
-        "react-json-view": "^1.21.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
-      "integrity": "sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz",
-      "integrity": "sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
-      "integrity": "sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-sitemap": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz",
@@ -2402,33 +2155,6 @@
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
-      "integrity": "sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/plugin-debug": "2.3.1",
-        "@docusaurus/plugin-google-analytics": "2.3.1",
-        "@docusaurus/plugin-google-gtag": "2.3.1",
-        "@docusaurus/plugin-google-tag-manager": "2.3.1",
-        "@docusaurus/plugin-sitemap": "2.3.1",
-        "@docusaurus/theme-classic": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-search-algolia": "2.3.1",
-        "@docusaurus/types": "2.3.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -2508,36 +2234,6 @@
         "prism-react-renderer": "^1.3.5",
         "tslib": "^2.4.0",
         "use-sync-external-store": "^1.2.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz",
-      "integrity": "sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==",
-      "dependencies": {
-        "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "algoliasearch": "^4.13.1",
-        "algoliasearch-helper": "^3.10.0",
-        "clsx": "^1.2.1",
-        "eta": "^2.0.0",
-        "fs-extra": "^10.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
       },
       "engines": {
@@ -4320,38 +4016,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
-      "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/algoliasearch-helper": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
-      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
-      "dependencies": {
-        "@algolia/events": "^4.0.1"
-      },
-      "peerDependencies": {
-        "algoliasearch": ">= 3.1 < 6"
-      }
-    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -4522,11 +4186,6 @@
         "es-shim-unscopables": "^1.0.0",
         "get-intrinsic": "^1.1.3"
       }
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
@@ -4733,11 +4392,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/base16": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -5633,33 +5287,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/cross-spawn": {
@@ -7538,33 +7165,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/fbemitter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
-      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
-      "dependencies": {
-        "fbjs": "^3.0.0"
-      }
-    },
-    "node_modules/fbjs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
-      "integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
-      "dependencies": {
-        "cross-fetch": "^3.1.5",
-        "fbjs-css-vars": "^1.0.0",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
-      }
-    },
-    "node_modules/fbjs-css-vars": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
-    },
     "node_modules/feed": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
@@ -7745,18 +7345,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "devOptional": true
-    },
-    "node_modules/flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
-      "dependencies": {
-        "fbemitter": "^3.0.0",
-        "fbjs": "^3.0.1"
-      },
-      "peerDependencies": {
-        "react": "^15.0.2 || ^16.0.0 || ^17.0.0"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
@@ -9801,20 +9389,10 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
     },
-    "node_modules/lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.flow": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -11984,14 +11562,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -12077,11 +11647,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/pure-color": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-      "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
     },
     "node_modules/qs": {
       "version": "6.10.3",
@@ -12207,17 +11772,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-base16-styling": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
-      "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
-      "dependencies": {
-        "base16": "^1.0.0",
-        "lodash.curry": "^4.0.1",
-        "lodash.flow": "^3.3.0",
-        "pure-color": "^1.2.0"
-      }
-    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -12304,26 +11858,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-json-view": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.21.3.tgz",
-      "integrity": "sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==",
-      "dependencies": {
-        "flux": "^4.0.1",
-        "react-base16-styling": "^0.6.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-textarea-autosize": "^8.3.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^16.3.0 || ^15.5.4",
-        "react-dom": "^17.0.0 || ^16.3.0 || ^15.5.4"
-      }
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "node_modules/react-loadable": {
       "name": "@docusaurus/react-loadable",
       "version": "5.5.2",
@@ -12399,22 +11933,6 @@
       },
       "peerDependencies": {
         "react": ">=15"
-      }
-    },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -13378,11 +12896,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -14152,11 +13665,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -14341,24 +13849,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {
@@ -14797,43 +14287,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/use-composed-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-latest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
-      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -14981,11 +14434,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
       "version": "5.74.0",
@@ -15376,15 +14824,6 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
   "dependencies": {
     "@docusaurus/core": "2.3.1",
     "@docusaurus/plugin-client-redirects": "2.3.1",
-    "@docusaurus/preset-classic": "2.3.1",
+    "@docusaurus/plugin-content-blog": "2.3.1",
+    "@docusaurus/plugin-content-docs": "2.3.1",
+    "@docusaurus/plugin-content-pages": "2.3.1",
+    "@docusaurus/plugin-sitemap": "2.3.1",
+    "@docusaurus/theme-classic": "2.3.1",
     "@easyops-cn/docusaurus-search-local": "0.33.6",
     "@fontsource/noto-sans": "4.5.11",
     "@icons-pack/react-simple-icons": "5.11.0",

--- a/redirects.js
+++ b/redirects.js
@@ -1,0 +1,40 @@
+/** @type {import('@docusaurus/plugin-client-redirects').Options['redirects']} */
+module.exports = [
+  // These pages existed on the jellyfin-blog site, but were not fully configured
+  {
+    from: ['/categories', '/tags'],
+    to: '/posts'
+  },
+  // Jellyfin 10.8 and below linked to this subtitle docs page
+  {
+    from: '/docs/general/server/media/subtitles',
+    to: '/docs/general/server/media/external-files'
+  },
+  // Storage docs moved from the server guide to administrative docs
+  {
+    from: '/docs/general/server/storage',
+    to: '/docs/general/administration/storage'
+  },
+  // Unified client + server download pages
+  {
+    from: '/clients',
+    to: '/downloads/clients/'
+  },
+  {
+    from: '/clients/all',
+    to: '/downloads/clients/all'
+  },
+  // New installation documentation
+  {
+    from: '/docs/general/administration/installing',
+    to: '/docs/general/installation/'
+  },
+  {
+    from: '/docs/general/administration/install/synology',
+    to: '/docs/general/installation/synology'
+  },
+  {
+    from: '/docs/general/administration/building',
+    to: '/docs/general/installation/source'
+  }
+];


### PR DESCRIPTION
This PR targets the developers branch.

----

With this PR the classic preset is removed in favor of manual plugin/theme configurations in preparation for a second blog.

This isn't strictly necessary for multi-blog etc. but it makes the config easier to read when we do, it also shaves of _some_ of the other plugins we don't use from the dependency graph which should help a bit with the node_modules folder size.

Other changes include:

- Move the redirects for the redirect plugin to their own file (easier to maintain that way)
- Add `@type` comments for IDE assistance to plugins/themes
- Add second developer blog (commented out) to confirm multi blog works (and it does, even creates a separate RSS feed)