### PR TITLE
Make client icons on homepage clickable

### DIFF
--- a/src/components/home/ClientSection.module.scss
+++ b/src/components/home/ClientSection.module.scss
@@ -1,8 +1,11 @@
 .client-icon {
+  display: block;
   max-width: 7rem;
+  color: white;
 }
 
 .client-icon > svg {
   display: block;
   margin: 0 auto;
+  color: white;
 }

--- a/src/components/home/ClientSection.tsx
+++ b/src/components/home/ClientSection.tsx
@@ -27,34 +27,52 @@ export default function ClientSection() {
             <Icon path={mdiWeb} size='48px' className='fill-white' />
             <div className='margin-top--sm'>Web</div>
           </div>
-          <div className={clsx('col', styles['client-icon'], 'margin-top--md')}>
+          <Link
+            to='/downloads/clients?platform=Desktop'
+            className={clsx('col', styles['client-icon'], 'margin-top--md')}
+          >
             <Icon path={mdiMonitor} size='48px' className='fill-white' />
             <div className='margin-top--sm'>Desktop</div>
-          </div>
-          <div className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}>
+          </Link>
+          <Link
+            to='/downloads/clients?platform=Android,Android TV'
+            className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
+          >
             <Android color='#ffffff' size={48} />
             <div className='margin-top--sm'>Android</div>
-          </div>
-          <div className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}>
+          </Link>
+          <Link
+            to='/downloads/clients?platform=iOS,tvOS'
+            className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
+          >
             <Apple color='#ffffff' size={48} />
             <div className='margin-top--sm'>Apple</div>
-          </div>
-          <div className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}>
+          </Link>
+          <Link
+            to='/downloads/clients?platform=Fire TV'
+            className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
+          >
             <Amazon color='#ffffff' size={48} />
             <div className='margin-top--sm'>Amazon</div>
-          </div>
-          <div className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}>
+          </Link>
+          <Link
+            to='/downloads/clients?platform=Roku'
+            className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
+          >
             <Roku color='#ffffff' size={48} />
             <div className='margin-top--sm'>Roku</div>
-          </div>
-          <div className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}>
+          </Link>
+          <Link
+            to='/downloads/clients?platform=Kodi'
+            className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
+          >
             <Kodi color='#ffffff' size={48} />
             <div className='margin-top--sm'>Kodi</div>
-          </div>
-          <div className={clsx('col', styles['client-icon'], 'margin-top--md')}>
+          </Link>
+          <Link to='/downloads/clients' className={clsx('col', styles['client-icon'], 'margin-top--md')}>
             <Icon path={mdiPlusThick} size='48px' className='fill-white' />
             <div className='margin-top--sm'>And more</div>
-          </div>
+          </Link>
         </div>
 
         <div className='row'>

--- a/src/pages/downloads/clients/index.tsx
+++ b/src/pages/downloads/clients/index.tsx
@@ -46,16 +46,16 @@ export default function ClientsPage({ recommended = true }: { recommended?: bool
   const [isFiltersVisible, setIsFiltersVisible] = useState(false);
 
   const setFilter = (filter: ClientFilter) => {
-    let search: string[] = [];
+    const search = new URLSearchParams();
 
     if (filter.deviceTypes.length > 0) {
-      search.push(`type=${filter.deviceTypes.join(',')}`);
+      search.set('type', filter.deviceTypes.join(','));
     }
     if (filter.platforms.length > 0) {
-      search.push(`platform=${filter.platforms.join(',')}`);
+      search.set('platform', filter.platforms.join(','));
     }
     history.push({
-      search: '?' + search.join('&')
+      search: search.toString()
     });
 
     setFilterValue(filter);
@@ -105,13 +105,13 @@ export default function ClientsPage({ recommended = true }: { recommended?: bool
             <div className={clsx('col', 'margin-bottom--md', styles['header-pills-middle'])}>
               <div className='pills'>
                 <Link
-                  to='/downloads/clients'
+                  to={`/downloads/clients${location.search}`}
                   className={clsx('pills__item', { 'pills__item--active': filter.recommended })}
                 >
                   Recommended
                 </Link>
                 <Link
-                  to='/downloads/clients/all'
+                  to={`/downloads/clients/all${location.search}`}
                   className={clsx('pills__item', { 'pills__item--active': !filter.recommended })}
                 >
                   All

--- a/src/pages/downloads/clients/index.tsx
+++ b/src/pages/downloads/clients/index.tsx
@@ -1,4 +1,5 @@
 import Link from '@docusaurus/Link';
+import { useHistory, useLocation } from '@docusaurus/router';
 import { mdiFilter } from '@mdi/js';
 import Icon from '@mdi/react';
 import Layout from '@theme/Layout';
@@ -31,13 +32,34 @@ function toggleValue<Type>(array: Type[], value: Type): Type[] {
 }
 
 export default function ClientsPage({ recommended = true }: { recommended?: boolean }) {
+  const history = useHistory();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+
   const [filteredClients, setFilteredClients] = useState<Client[]>([...Clients]);
-  const [filter, setFilter] = useState<ClientFilter>({
+  const [filter, setFilterValue] = useState<ClientFilter>({
     recommended,
-    deviceTypes: [],
-    platforms: []
+    deviceTypes: (searchParams.get('type')?.split(',') ?? []) as DeviceType[],
+    platforms: (searchParams.get('platform')?.split(',') ?? []) as Platform[]
   });
+
   const [isFiltersVisible, setIsFiltersVisible] = useState(false);
+
+  const setFilter = (filter: ClientFilter) => {
+    let search: string[] = [];
+
+    if (filter.deviceTypes.length > 0) {
+      search.push(`type=${filter.deviceTypes.join(',')}`);
+    }
+    if (filter.platforms.length > 0) {
+      search.push(`platform=${filter.platforms.join(',')}`);
+    }
+    history.push({
+      search: '?' + search.join('&')
+    });
+
+    setFilterValue(filter);
+  };
 
   useEffect(() => {
     setFilteredClients(


### PR DESCRIPTION
This PR:
 - Allows you to click on all of the client icons on the homepage except web.
 - Persists the filters on the client page into the URL search param.

I excluded web from the clickable links because it would either show an empty page, or, if showing all options would mislead users into thinking jellyfin-vue was the main web client.