### PR TITLE
Fix HTTP -> HTTPS redirect for Let's Encrypt to work

### DIFF
--- a/docs/general/networking/apache.md
+++ b/docs/general/networking/apache.md
@@ -12,7 +12,7 @@ title: Apache
     ServerName DOMAIN_NAME
 
     # Comment to prevent HTTP to HTTPS redirect
-    Redirect permanent / https://DOMAIN_NAME
+    Redirect permanent / https://DOMAIN_NAME/
 
     ErrorLog /var/log/apache2/DOMAIN_NAME-error.log
     CustomLog /var/log/apache2/DOMAIN_NAME-access.log combined


### PR DESCRIPTION
Hello,

while using my deployment with the configuration provided in the official documentation I noticed that certificate renewals (I am using acme.sh) were broken because the HTTP to HTTPS upgrade causes the URL to be malformed. Assuming my domain is example.com, the validation process of Let's Encrypt would get redirected to https://example.com.well.known/... which resulted in the following error message:

[Sat 04 Mar 2023 01:32:41 AM CET] _example.com_:Verify error:_<IP>_: Fetching https://_example.com_.well-known/acme-challenge/_<challenge-path>_: Invalid host in redirect target

Adding the trailing slash fixed this misbehavior.

