### PR TITLE
Update HWA instructions for Intel and NVIDIA

### DIFF
--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -276,7 +276,7 @@ Root permission is required.
    :::
 
    ```shell
-   $ /usr/lib/jellyfin-ffmpeg/vainfo --display drm --device /dev/dri/renderD128
+   sudo /usr/lib/jellyfin-ffmpeg/vainfo --display drm --device /dev/dri/renderD128
 
    libva info: VA-API version 1.17.0
    libva info: Trying to open /usr/lib/jellyfin-ffmpeg/lib/dri/radeonsi_drv_video.so
@@ -292,7 +292,7 @@ Root permission is required.
 7. Check the OpenCL runtime status:
 
    ```shell
-   $ /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device opencl=ocl:.0,device_vendor="Advanced Micro Devices"
+   sudo /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device opencl=ocl:.0,device_vendor="Advanced Micro Devices"
 
    [AVHWDeviceContext @ 0x55d3ea4bfd00] 1 OpenCL platforms found.
    [AVHWDeviceContext @ 0x55d3ea4bfd00] 1 OpenCL devices found on platform "AMD Accelerated Parallel Processing".
@@ -303,7 +303,7 @@ Root permission is required.
 8. Check the Vulkan runtime status:
 
    ```shell
-   $ /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device drm=dr:/dev/dri/renderD128 -init_hw_device vulkan@dr
+   sudo /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device drm=dr:/dev/dri/renderD128 -init_hw_device vulkan@dr
 
    [AVHWDeviceContext @ 0x557f13a57bc0] GPU listing:
    [AVHWDeviceContext @ 0x557f13a57bc0]     0: AMD Radeon RX Vega (RADV VEGA10) (discrete) (0x687f)
@@ -369,19 +369,19 @@ Root permission is required.
 
    ```shell
    sudo pacman -Sy libva-utils
-   vainfo --display drm --device /dev/dri/renderD128
+   sudo vainfo --display drm --device /dev/dri/renderD128
    ```
 
 4. Check the OpenCL runtime status:
 
    ```shell
-   /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device opencl=ocl:.0,device_vendor="Advanced Micro Devices"
+   sudo /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device opencl=ocl:.0,device_vendor="Advanced Micro Devices"
    ```
 
 5. Check the Vulkan runtime status:
 
    ```shell
-   /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device drm=dr:/dev/dri/renderD128 -init_hw_device vulkan@dr
+   sudo /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device drm=dr:/dev/dri/renderD128 -init_hw_device vulkan@dr
    ```
 
 6. Check to the remaining parts of [Debian And Ubuntu Linux](/docs/general/administration/hardware-acceleration/amd#debian-and-ubuntu-linux).

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -379,7 +379,7 @@ Root permission is required.
    :::
 
    ```shell
-   $ /usr/lib/jellyfin-ffmpeg/vainfo --display drm --device /dev/dri/renderD128
+   sudo /usr/lib/jellyfin-ffmpeg/vainfo --display drm --device /dev/dri/renderD128
 
    libva info: VA-API version 1.17.0
    libva info: Trying to open /usr/lib/jellyfin-ffmpeg/lib/dri/iHD_drv_video.so
@@ -395,7 +395,7 @@ Root permission is required.
 8. Check the OpenCL runtime status:
 
    ```shell
-   $ /usr/lib/jellyfin-ffmpeg/ffmpeg -v verbose -init_hw_device vaapi=va:/dev/dri/renderD128 -init_hw_device opencl@va
+   sudo /usr/lib/jellyfin-ffmpeg/ffmpeg -v verbose -init_hw_device vaapi=va:/dev/dri/renderD128 -init_hw_device opencl@va
 
    [AVHWDeviceContext @ 0x55cc8ac21a80] 0.0: Intel(R) OpenCL HD Graphics / Intel(R) Iris(R) Xe Graphics [0x9a49]
    [AVHWDeviceContext @ 0x55cc8ac21a80] Intel QSV to OpenCL mapping function found (clCreateFromVA_APIMediaSurfaceINTEL).
@@ -449,8 +449,8 @@ Root permission is required.
 
    ```shell
    sudo pacman -Sy libva-utils
-   vainfo --display drm --device /dev/dri/renderD128
-   /usr/lib/jellyfin-ffmpeg/ffmpeg -v verbose -init_hw_device vaapi=va:/dev/dri/renderD128 -init_hw_device opencl@va
+   sudo vainfo --display drm --device /dev/dri/renderD128
+   sudo /usr/lib/jellyfin-ffmpeg/ffmpeg -v verbose -init_hw_device vaapi=va:/dev/dri/renderD128 -init_hw_device opencl@va
    ```
 
 4. Check to the remaining parts of [Debian And Ubuntu Linux](/docs/general/administration/hardware-acceleration/intel#debian-and-ubuntu-linux).

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -121,6 +121,12 @@ Intel added support for AV1 acceleration in their latest GPUs:
 
 - **Encoding AV1 8/10-bit** - Gen 12.5 DG2 / ARC A-series, Gen 12.7 Meteor Lake (14th?? Gen Core) and newer
 
+:::note
+
+Note that Jasper Lake and Elkhart Lake processors are 10th Gen Pentium/Celeron/Atom, which don't have AV1 acceleration.
+
+:::
+
 ### Transcode Other Codecs
 
 Please refer to these links:
@@ -433,7 +439,7 @@ Root permission is required.
 
    - [intel-media-sdk](https://archlinux.org/packages/community/x86_64/intel-media-sdk/)
 
-   - [onevpl-intel-gpu](https://aur.archlinux.org/packages/onevpl-intel-gpu)
+   - [onevpl-intel-gpu](https://archlinux.org/packages/community/x86_64/onevpl-intel-gpu/)
 
    - [intel-compute-runtime](https://archlinux.org/packages/community/x86_64/intel-compute-runtime/)
 

--- a/docs/general/administration/hardware-acceleration/nvidia.md
+++ b/docs/general/administration/hardware-acceleration/nvidia.md
@@ -355,7 +355,7 @@ Root permission is required.
 
    :::note
 
-   If you encounter an upsteam issue - `CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected`. Pass these extra devices to the Docker:
+   If you encounter the upsteam issue `CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected`, pass these extra devices to the Docker:
 
    ```shell
    /dev/nvidia-caps:/dev/nvidia-caps

--- a/docs/general/administration/hardware-acceleration/nvidia.md
+++ b/docs/general/administration/hardware-acceleration/nvidia.md
@@ -353,6 +353,21 @@ Root permission is required.
                  - capabilities: [gpu]
      ```
 
+   :::note
+
+   If you encounter an upsteam issue - `CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected`. Pass these extra devices to the Docker:
+
+   ```shell
+   /dev/nvidia-caps:/dev/nvidia-caps
+   /dev/nvidia0:/dev/nvidia0
+   /dev/nvidiactl:/dev/nvidiactl
+   /dev/nvidia-modeset:/dev/nvidia-modeset
+   /dev/nvidia-uvm:/dev/nvidia-uvm
+   /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
+   ```
+
+   :::
+
 4. Add your username to the video group:
 
    ```shell


### PR DESCRIPTION
- JSL and EHL are 10th Gen, no AV1 decoding.
- Update the link of `onevpl-intel-gpu` on Arch Linux.
- Add a workaround for the upstream issue `CUDA_ERROR_NO_DEVICE` in Docker.
- Add more 'sudo' for verifying drm render node.