### PR TITLE
Add index page for developers site

### DIFF
--- a/content/developers/docs/index.md
+++ b/content/developers/docs/index.md
@@ -1,7 +1,0 @@
----
-uid: developers-index
-title: Developers
-sidebar_position: 1
----
-
-# Jellyfin developer documentation

--- a/content/developers/pages/index.scss
+++ b/content/developers/pages/index.scss
@@ -1,0 +1,16 @@
+.card--dev-index {
+  h2 {
+    margin: 10px 20px 0 20px;
+  }
+
+  ul {
+    padding: 0;
+    list-style: none;
+    margin: 10px 10px 0 10px;
+
+    li a {
+      display: block;
+      padding: 10px;
+    }
+  }
+}

--- a/content/developers/pages/index.tsx
+++ b/content/developers/pages/index.tsx
@@ -1,0 +1,86 @@
+import React, { ReactNode } from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import Hero from '../../../src/components/common/Hero';
+import blogPosts from '../../../.docusaurus/docusaurus-plugin-content-blog/developers-blog/blog-post-list-prop-developers-blog.json';
+
+import './index.scss';
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className='col col--4 margin-top--md margin-bottom--md'>
+      <div className='card card--dev-index'>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function DocsHighlights() {
+  return (
+    <Section title='Documentation'>
+      <ul>
+        <li>
+          <Link to='/developers/docs/api/authorization'>Using the REST API</Link>
+        </li>
+        <li>
+          <Link to='/developers/docs/api/authorization'>Creating a server plugin</Link>
+        </li>
+      </ul>
+    </Section>
+  );
+}
+
+function OtherPages() {
+  return (
+    <Section title='More resources'>
+      <ul>
+        <li>
+          <Link to='/developers/docs/contributing/'>Contributing</Link>
+        </li>
+        <li>
+          <Link to='/developers/docs/branding'>Jellyfin branding</Link>
+        </li>
+      </ul>
+    </Section>
+  );
+}
+
+function RecentBlogPosts() {
+  return (
+    <Section title={blogPosts.title}>
+      <ul>
+        {blogPosts.items.slice(0, 5).map((item, index) => (
+          <li key={index}>
+            <a href={`${item.permalink}`}>{item.title}</a>{' '}
+          </li>
+        ))}
+      </ul>
+    </Section>
+  );
+}
+
+function Index() {
+  return (
+    <Layout title={`Jellyfin developers`}>
+      <Hero title='Jellyfin for Developers'>
+        <p className='hero__text margin-vert--lg'>Get started developing with or for Jellyfin today.</p>
+        <div className='hero__buttons'>
+          <Link to='/docs/'>Not a developer? Go to the user documentation</Link>
+        </div>
+      </Hero>
+      <main>
+        <section className='container'>
+          <div className='row'>
+            <DocsHighlights />
+            <RecentBlogPosts />
+            <OtherPages />
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}
+
+export default Index;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ module.exports = {
         },
 
         {
-          to: 'developers/docs/',
+          to: 'developers',
           label: 'Developers',
           position: 'right'
         },


### PR DESCRIPTION
(merged to developers branch)

Definitely not my best work but good enough for now. The developer index redirects to the docs and blog. Blog posts are loaded from the blog plugin (that awful import, and yes this is the recommended way). The docs/more resources sections will be updated over time when we have more content.

![image](https://user-images.githubusercontent.com/2305178/226706543-91464f5b-bef2-41c1-9940-604ba0d25506.png)
