### PR TITLE
Fix subtitles link redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -133,7 +133,7 @@ Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/
           },
           // Jellyfin 10.8 and below linked to this subtitle docs page
           {
-            from: '/docs/general/server/media/subtitles',
+            from: ['/docs/general/server/media/subtitles', '/docs/general/server/media/subtitles.html'],
             to: '/docs/general/server/media/external-files'
           },
           // Storage docs moved from the server guide to administrative docs

--- a/scripts/data/jellyfin-web-urls.json
+++ b/scripts/data/jellyfin-web-urls.json
@@ -13,6 +13,7 @@
   "/docs/general/server/media/movies.html",
   "/docs/general/server/media/music.html",
   "/docs/general/server/media/shows.html",
+  "/docs/general/server/media/subtitles.html",
   "/docs/general/server/notifications.html",
   "/docs/general/server/plugins/index.html",
   "/docs/general/server/settings.html",


### PR DESCRIPTION
Fixes an issue where the `subtitles.html` link in web in versions 10.8 and below is not redirected correctly.

Fixes https://github.com/jellyfin/jellyfin-web/issues/4410