### PR TITLE
Remove caution warning `.ignore`

### DIFF
--- a/docs/general/server/media/excluding-directory.md
+++ b/docs/general/server/media/excluding-directory.md
@@ -29,9 +29,3 @@ Shows
         ├── .ignore
         └── ...
 ```
-
-:::caution
-
-Currently, placing a `.ignore` file inside an [`Extras`](/docs/general/server/media/shows#extras-folders) directory [does not work](https://github.com/jellyfin/jellyfin/issues/9571).
-
-:::


### PR DESCRIPTION
Blocked by https://github.com/jellyfin/jellyfin/pull/9706
Remove the caution block which describes that using `.ignore` files inside `extras` folders does not work.