### PR TITLE
Caddy Subpath Redirect

### DIFF
--- a/docs/general/networking/caddy.md
+++ b/docs/general/networking/caddy.md
@@ -68,6 +68,7 @@ Then simply give the `reverse_proxy` directive a path matcher.
 ```txt
 example.com
 
+redir /jellyfin /jellyfin/
 reverse_proxy /jellyfin/* 127.0.0.1:8096
 ```
 


### PR DESCRIPTION
set Caddy to redirect example.com/jellyfin to example.com/jellyfin/