### PR TITLE
Add headers to modules needed

### DIFF
--- a/docs/general/networking/apache.md
+++ b/docs/general/networking/apache.md
@@ -60,10 +60,10 @@ title: Apache
 </IfModule>
 ```
 
-If you encouter errors, you may have to enable `mod_proxy`, `mod_ssl`, `proxy_wstunnel`, `http2` and `remoteip` support manually.
+If you encouter errors, you may have to enable `mod_proxy`, `mod_ssl`, `proxy_wstunnel`, `http2`, `headers` and `remoteip` support manually.
 
 ```bash
-sudo a2enmod proxy proxy_http ssl proxy_wstunnel remoteip http2
+sudo a2enmod proxy proxy_http ssl proxy_wstunnel remoteip http2 headers
 ```
 
 ## Apache with Subpath (example.org/jellyfin)


### PR DESCRIPTION
The apache module 'headers' is also required to use the configuration provided, so I added it to the list of modules the user may have to enable manually.