### PR TITLE
Fix style guide spelling and declaration export

### DIFF
--- a/docs/general/style-guides/javascript.md
+++ b/docs/general/style-guides/javascript.md
@@ -31,11 +31,11 @@ import 'otherDependency';
  * @returns {Int|null} The resulting object from the function.
  */
 function privateFunction (argument) {
-    // Code ommitted
+    // Code omitted
 }
 
-export publicFunction (argument) {
-    // Code ommitted
+export function publicFunction (argument) {
+    // Code omitted
 }
 
 export default { publicFunction }


### PR DESCRIPTION
Fixed spelling of "ommitted" twice and included the type declaration on export.