### PR TITLE
Update transcoding.md

### DIFF
--- a/docs/general/server/transcoding.md
+++ b/docs/general/server/transcoding.md
@@ -20,9 +20,9 @@ This option will manually set the number of threads to use when transcoding. If 
 
 ## Types of Transcoding
 
-There are three types of transcoding. The type being used will be listed in the dashboard when playing a file. They are ordered below from lowest to highest load on the server:
+There are four types of playback; three of which involve transcoding.  The type being used will be listed in the dashboard when playing a file. They are ordered below from lowest to highest load on the server:
 
-- Direct Play: Delivers the file with no modifications. Almost no additional load on the server.
+- Direct Play: Delivers the file without transcoding.  There is no modification to the file and almost no additional load on the server.
 - Remux: Changes the container but leaves both audio and video streams untouched.
 - Direct Stream: Transcodes audio but leaves original video untouched.
 - Transcode: Transcodes the video stream.

--- a/docs/general/server/transcoding.md
+++ b/docs/general/server/transcoding.md
@@ -20,7 +20,7 @@ This option will manually set the number of threads to use when transcoding. If 
 
 ## Types of Transcoding
 
-There are four types of playback; three of which involve transcoding.  The type being used will be listed in the dashboard when playing a file. They are ordered below from lowest to highest load on the server:
+There are four types of playback; three of which involve transcoding. The type being used will be listed in the dashboard when playing a file. They are ordered below from lowest to highest load on the server:
 
 - Direct Play: Delivers the file without transcoding.  There is no modification to the file and almost no additional load on the server.
 - Remux: Changes the container but leaves both audio and video streams untouched.

--- a/docs/general/server/transcoding.md
+++ b/docs/general/server/transcoding.md
@@ -22,7 +22,7 @@ This option will manually set the number of threads to use when transcoding. If 
 
 There are four types of playback; three of which involve transcoding. The type being used will be listed in the dashboard when playing a file. They are ordered below from lowest to highest load on the server:
 
-- Direct Play: Delivers the file without transcoding.  There is no modification to the file and almost no additional load on the server.
+- Direct Play: Delivers the file without transcoding. There is no modification to the file and almost no additional load on the server.
 - Remux: Changes the container but leaves both audio and video streams untouched.
 - Direct Stream: Transcodes audio but leaves original video untouched.
 - Transcode: Transcodes the video stream.


### PR DESCRIPTION
Previously it stated there are three types of transcoding, but there were four items in the list.  The first item was for direct play, so I updated to clarify that there are four types of playback, yet only three of which perform transcoding.