### PR TITLE
Move status link from header to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,11 +54,6 @@ module.exports = {
           href: 'https://forum.jellyfin.org',
           label: 'Forum',
           position: 'right'
-        },
-        {
-          href: 'https://status.jellyfin.org',
-          label: 'Status',
-          position: 'right'
         }
       ]
     },
@@ -81,6 +76,10 @@ module.exports = {
         {
           label: 'Contribute',
           to: '/contribute'
+        },
+        {
+          label: 'Status',
+          to: 'https://status.jellyfin.org'
         },
         {
           label: 'Contact',


### PR DESCRIPTION
It's nice we have it now but it's not relevant for most of the people visiting our website. It may also confuse users thinking we are a streaming service or provide hosted instances. Moving the status link to the footer which is in my opinion the best place for a status page link.