### PR TITLE
Switch arch pacman args from -Sy to -Syu to prevent system breakage

### DIFF
--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -361,14 +361,14 @@ Root permission is required.
    - [rocm-opencl-runtime](https://archlinux.org/packages/community/x86_64/rocm-opencl-runtime/)
 
    ```shell
-   sudo pacman -Sy libva-mesa-driver vulkan-radeon rocm-opencl-runtime
+   sudo pacman -Syu libva-mesa-driver vulkan-radeon rocm-opencl-runtime
    sudo sh -c "echo ROC_ENABLE_PRE_VEGA=1 >> /etc/profile"
    ```
 
 3. Check the VA-API codecs:
 
    ```shell
-   sudo pacman -Sy libva-utils
+   sudo pacman -Syu libva-utils
    sudo vainfo --display drm --device /dev/dri/renderD128
    ```
 
@@ -590,7 +590,7 @@ Root permission is required.
    - On Arch Linux:
 
      ```shell
-     sudo pacman -Sy radeontop
+     sudo pacman -Syu radeontop
      ```
 
 2. Play a video in the Jellyfin web client and trigger a video transcoding by setting a lower resolution or bitrate.

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -466,7 +466,7 @@ Root permission is required.
 3. Check the QSV / VA-API codecs and the OpenCL runtime status:
 
    ```shell
-   sudo pacman -Sy libva-utils
+   sudo pacman -Syu libva-utils
    sudo vainfo --display drm --device /dev/dri/renderD128
    sudo /usr/lib/jellyfin-ffmpeg/ffmpeg -v verbose -init_hw_device vaapi=va:/dev/dri/renderD128 -init_hw_device opencl@va
    ```
@@ -747,7 +747,7 @@ Root permission is required.
    - On Arch Linux:
 
      ```shell
-     sudo pacman -Sy intel-gpu-tools
+     sudo pacman -Syu intel-gpu-tools
      ```
 
 2. Play a video in Jellyfin web client and trigger a video transcoding by setting a lower resolution or bitrate.
@@ -863,7 +863,7 @@ Root permission is required.
    - On Arch Linux:
 
      ```shell
-     sudo pacman -Sy linux-firmware
+     sudo pacman -Syu linux-firmware
      ```
 
    - Pull firmwares from Linux repository directly:

--- a/docs/general/administration/hardware-acceleration/nvidia.md
+++ b/docs/general/administration/hardware-acceleration/nvidia.md
@@ -248,7 +248,7 @@ Root permission is required.
    - <https://wiki.archlinux.org/title/NVIDIA#Installation>
 
    ```shell
-   sudo pacman -Sy nvidia-utils
+   sudo pacman -Syu nvidia-utils
    ```
 
 3. Check the NVIDIA GPU status by using `nvidia-smi`:


### PR DESCRIPTION
As pointed out by https://forum.jellyfin.org/t-official-jellyfin-documentation-prompts-the-usage-of-unsafe-flags-under-arch the arguments should be changed.