### PR TITLE
dotnet-sdk-6.0 -> 7.0 at contributing/development

### DIFF
--- a/docs/general/contributing/development.md
+++ b/docs/general/contributing/development.md
@@ -190,7 +190,7 @@ docker exec -ti jftest bash
 apt-get update && apt-get install git gnupg wget apt-transport-https curl autoconf g++ make libpng-dev gifsicle automake libtool make gcc musl-dev nasm
 wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
 wget -q https://packages.microsoft.com/config/debian/10/prod.list && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
-apt-get update && apt-get install dotnet-sdk-6.0 npm
+apt-get update && apt-get install dotnet-sdk-7.0 npm
 cd /opt && git clone https://github.com/jellyfin/jellyfin.git && git clone https://github.com/jellyfin/jellyfin-web.git
 cd jellyfin/ && DOTNET_CLI_TELEMETRY_OPTOUT=1 && DOTNET_CLI_HOME="/tmp/" dotnet publish --disable-parallel Jellyfin.Server --configuration Debug --output="/jellyfin" --self-contained --runtime linux-x64
 cd /opt/jellyfin-web && npm install && cp -r /opt/jellyfin-web/dist /jellyfin/jellyfin-web


### PR DESCRIPTION
There is a typo, at the https://jellyfin.org/docs/general/contributing/development#master-branch section. The command states that dotnet-sdk-6.0 should be installed, but the project requires dotnet-sdk-7.0.