### PR TITLE
Add Warning message on DNS Tokens

### DIFF
--- a/docs/general/networking/caddy.md
+++ b/docs/general/networking/caddy.md
@@ -30,7 +30,7 @@ example.com {
 Please proceed with caution when using this option:
 
 - This will **NOT** automatically update your DNS records if you have a dynamic IP.
-- This is **NOT** required for automatic SSL to work in most cases.
+- This is **NOT** required for automatic HTTPS to work in most cases.
 - Misconfiguration can lead to **compromised domains and/or accounts**.
 - API keys should only be granted the least permissions required for the application to function.
 


### PR DESCRIPTION
This PR does the following:
1. Add warning to warn against giving Caddy DNS Tokens 
2. Fix some other minor issues with the Caddy page
3. Remove references to other community links

Reasoning for each of the actions:
1. Supplying Caddy with DNS Tokens can be dangerous since this grants Caddy the privileges to edit more DNS records than it needs to in most cases. (Eg. Being able to edit DNS records of the entire domain or Account) This can be dangerous in the event of an attack as compromising this token means attackers can compromise your entire domain or even other domains under the same account
2. Clarify the subpath so it is less confusing
3. The Youtube Video contains steps that can be dangerous (as pointed out in the first point). The Reddit links are outdated (As stated in #412 )