### PR TITLE
Add Location directive to apache.md to fix issues with WebSocket

### DIFF
--- a/docs/general/networking/apache.md
+++ b/docs/general/networking/apache.md
@@ -42,6 +42,11 @@ title: Apache
     ProxyPass "/" "http://SERVER_IP_ADDRESS:8096/"
     ProxyPassReverse "/" "http://SERVER_IP_ADDRESS:8096/"
 
+    <Location "/socket">
+        ProxyPass "ws://SERVER_IP_ADDRESS:8096/socket"
+        ProxyPassReverse "ws://SERVER_IP_ADDRESS:8096/socket"
+    </Location>
+
     SSLEngine on
     SSLCertificateFile /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem
     SSLCertificateKeyFile /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem


### PR DESCRIPTION
I added a Location directive to the vhost configuration to fix issues with WebSocket and reverse proxy. Without this directive, the browser console would say `GET wss://jellyfin.<domain>.<tld>/socket?api_key=<api key> [HTTP/1.1 404 Not Found 4ms]`.

Before adding this directive, marking a TV series episode as watched on the dashboard or anywhere else, the next episode would not show as the next one. You would have to refresh the page to see what the next episode is.

If someone tests this, be aware that it takes 10 seconds before the next episode shows up. If it takes more than that, you have the same problem I had, and should test the code I added.

System:
Debian 12
Jellyfin 10.8.10
Apache 2.4.57