### PR TITLE
Warning against using Raspberry Pis or other SBCs for hosting JF

### DIFF
--- a/docs/general/administration/hardware-acceleration/index.md
+++ b/docs/general/administration/hardware-acceleration/index.md
@@ -27,7 +27,7 @@ The supported and validated video [hardware acceleration (HWA)](https://trac.ffm
 
 :::caution
 
-While hardware acceleration is supported on Raspberry Pi hardware, it is recommended that Jellyfin NOT be hosted on Raspberry Pis or other SBCs. Many hardware acceleration features are not supported and will fallback to software. In addation, they are generally too slow to provide a good experience when transcoding is needed. Please consider getting a more powerful system to host Jellyfin.
+While hardware acceleration is supported on Raspberry Pi hardware, it is recommended that Jellyfin NOT be hosted on Raspberry Pis or other SBCs. Many hardware acceleration features are not supported and will fallback to software. In addition, they are generally too slow to provide a good experience when transcoding is needed. Please consider getting a more powerful system to host Jellyfin.
 
 :::
 

--- a/docs/general/administration/hardware-acceleration/index.md
+++ b/docs/general/administration/hardware-acceleration/index.md
@@ -28,6 +28,7 @@ The supported and validated video [hardware acceleration (HWA)](https://trac.ffm
 :::caution
 
 While hardware acceleration is supported on Raspberry Pi hardware, it is recommended that Jellyfin NOT be hosted on Raspberry Pis or other SBCs. Many hardware acceleration features are not supported and will fallback to software. In addition, they are generally too slow to provide a good experience when transcoding is needed. Please consider getting a more powerful system to host Jellyfin.
+We recommend getting a system with an Intel 7th gen or above Core series CPU.
 
 :::
 

--- a/docs/general/administration/hardware-acceleration/index.md
+++ b/docs/general/administration/hardware-acceleration/index.md
@@ -25,6 +25,12 @@ The supported and validated video [hardware acceleration (HWA)](https://trac.ffm
 
 - **Raspberry Pi** Video4Linux2 (V4L2, Linux only)
 
+:::caution
+
+While Hardware Acceleration is supported on Raspberry Pi Hardware, it is recommended that Jellyfin NOT be used on Raspberry Pi or other SBCs. They are too slow to provide a good experience when transcoding is needed. Please consider getting a more powerful system.
+
+:::
+
 ## Full & Partial Acceleration
 
 The transcoding pipeline usually has multiple stages, which can be simplified to:

--- a/docs/general/administration/hardware-acceleration/index.md
+++ b/docs/general/administration/hardware-acceleration/index.md
@@ -27,7 +27,7 @@ The supported and validated video [hardware acceleration (HWA)](https://trac.ffm
 
 :::caution
 
-While Hardware Acceleration is supported on Raspberry Pi Hardware, it is recommended that Jellyfin NOT be used on Raspberry Pi or other SBCs. They are too slow to provide a good experience when transcoding is needed. Please consider getting a more powerful system.
+While hardware acceleration is supported on Raspberry Pi hardware, it is recommended that Jellyfin NOT be hosted on Raspberry Pis or other SBCs. Many hardware acceleration features are not supported and will fallback to software. In addation, they are generally too slow to provide a good experience when transcoding is needed. Please consider getting a more powerful system to host Jellyfin.
 
 :::
 


### PR DESCRIPTION
While many people like to use these SBCs to host Jellyfin, they are underpowered and don't provide a good experience whenever transcoding is needed as a result.

This PR intends to add a warning message against using these devices for hosting Jellyfin and recommend users to use more powerful hardware.