### PR TITLE
Update fail2ban.md

### DIFF
--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -37,7 +37,7 @@ filter = jellyfin
 maxretry = 3
 bantime = 86400
 findtime = 43200
-logpath = /path_to_logs/*.log
+logpath = /path_to_logs/jellyfin*.log
 ```
 
 Save and exit nano.


### PR DESCRIPTION
by adding jellyfin before the asterix, log files not connected to auth fails are ignored (like ffmpeg). Possible performance gain?