### PR TITLE
Add note about naming flags not being supported yet

### DIFF
--- a/docs/general/server/media/external-files.md
+++ b/docs/general/server/media/external-files.md
@@ -39,6 +39,12 @@ If multiple languages are defined within the filename the last one will be used 
 
 ### Naming Flags
 
+:::note
+
+Support for naming flags is coming with the next feature release for Jellyfin. Until then it is recommended you avoid adding additional flags. This is especially true for `hi` flags (see note below).
+
+:::
+
 Additional flags can be appended to the filename (separated by the `.` delimiter) to add metadata. Supported metadata and flags are:
 
 - Default: `default`


### PR DESCRIPTION
The feature has been merged into master, but has not been released yet. The docs are ahead of time. This adds a note to avoid confusion for users.

See discussion [here](https://matrix.to/#/!YOoxJKhsHoXZiIHyBG:matrix.org/$oAMehUYdavAeJ8l5gACGcazXGTVV1idX8RNwm8EtQZA?via=bonifacelabs.ca&via=t2bot.io&via=matrix.org) for extra context. In short: The docs were released a little early, so this notes is there to avoid confusing users.