### PR TITLE
arch linux package now in extra

### DIFF
--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -16,9 +16,10 @@ To enable the web UI after installing `jellyfin-web`, make sure to remove the `-
 
 ## Arch Linux
 
-The `Extra` repository contains builds for both [`jellyfin-server`](https://archlinux.org/packages/?name=jellyfin-server) and [`jellyfin-web`](https://archlinux.org/packages/?name=jellyfin-web).
+The `Extra` repository contains builds for both [`jellyfin-server`](https://archlinux.org/packages/?name=jellyfin-server) and [`jellyfin-web`](https://archlinux.org/packages/?name=jellyfin-web). `jellyfin-server` includes a hard dependency on [`jellyfin-ffmpeg`](https://archlinux.org/packages/?name=jellyfin-ffmpeg).
 
-The Jellyfin binary can be installed from the AUR as [`jellyfin-bin`](https://aur.archlinux.org/packages/jellyfin-bin/) and can be built at the tip of the master branch with [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/).
+Both packages, server and web, can also be built from source at the tip of the master branch using [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/).
+Debian builds of the Jellyfin server and web binaries can be installed from the AUR at [`jellyfin-bin`](https://aur.archlinux.org/packages/jellyfin-bin/).
 
 ## Fedora
 

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -16,9 +16,9 @@ To enable the web UI after installing `jellyfin-web`, make sure to remove the `-
 
 ## Arch Linux
 
-Jellyfin can be found in the AUR as [`jellyfin`](https://aur.archlinux.org/packages/jellyfin/), [`jellyfin-bin`](https://aur.archlinux.org/packages/jellyfin-bin/) and [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/).
+The `Extra` repository contains builds for both [`jellyfin-server`](https://archlinux.org/packages/?name=jellyfin-server) and [`jellyfin-web`](https://archlinux.org/packages/?name=jellyfin-web).
 
-The `Extra` repository also contains builds for both [`jellyfin-server`](https://archlinux.org/packages/?name=jellyfin-server) and [`jellyfin-web`](https://archlinux.org/packages/?name=jellyfin-web).
+The Jellyfin binary can be installed from the AUR as [`jellyfin-bin`](https://aur.archlinux.org/packages/jellyfin-bin/) and can be built at the tip of the master branch with [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/).
 
 ## Fedora
 

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -18,6 +18,8 @@ To enable the web UI after installing `jellyfin-web`, make sure to remove the `-
 
 Jellyfin can be found in the AUR as [`jellyfin`](https://aur.archlinux.org/packages/jellyfin/), [`jellyfin-bin`](https://aur.archlinux.org/packages/jellyfin-bin/) and [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/).
 
+The `Extra` repository also contains builds for both [`jellyfin-server`](https://archlinux.org/packages/?name=jellyfin-server) and [`jellyfin-web`](https://archlinux.org/packages/?name=jellyfin-web).
+
 ## Fedora
 
 Fedora builds in RPM package format are available [here](/downloads/linux#fedora-centos) for now but an official Fedora repository is coming soon.

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -18,8 +18,7 @@ To enable the web UI after installing `jellyfin-web`, make sure to remove the `-
 
 The `Extra` repository contains builds for both [`jellyfin-server`](https://archlinux.org/packages/?name=jellyfin-server) and [`jellyfin-web`](https://archlinux.org/packages/?name=jellyfin-web). `jellyfin-server` includes a hard dependency on [`jellyfin-ffmpeg`](https://archlinux.org/packages/?name=jellyfin-ffmpeg).
 
-Both packages, server and web, can also be built from source at the tip of the master branch using [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/).
-Debian builds of the Jellyfin server and web binaries can be installed from the AUR at [`jellyfin-bin`](https://aur.archlinux.org/packages/jellyfin-bin/).
+Both packages, server and web, can also be built from source at the tip of the master branch using [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/). The AUR also offers each separately at [`jellyfin-server-git`](https://aur.archlinux.org/packages/jellyfin-server-git/) and [`jellyfin-web-git`](https://aur.archlinux.org/packages/jellyfin-web-git/).
 
 ## Fedora
 

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -16,9 +16,11 @@ To enable the web UI after installing `jellyfin-web`, make sure to remove the `-
 
 ## Arch Linux
 
-The `Extra` repository contains builds for both [`jellyfin-server`](https://archlinux.org/packages/?name=jellyfin-server) and [`jellyfin-web`](https://archlinux.org/packages/?name=jellyfin-web). `jellyfin-server` includes a hard dependency on [`jellyfin-ffmpeg`](https://archlinux.org/packages/?name=jellyfin-ffmpeg).
+The `Extra` repository contains builds for both [`jellyfin-server`](https://archlinux.org/packages/?name=jellyfin-server) and [`jellyfin-web`](https://archlinux.org/packages/?name=jellyfin-web).
+`jellyfin-server` includes a hard dependency on [`jellyfin-ffmpeg`](https://archlinux.org/packages/?name=jellyfin-ffmpeg).
 
-Both packages, server and web, can also be built from source at the tip of the master branch using [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/). The AUR also offers each separately at [`jellyfin-server-git`](https://aur.archlinux.org/packages/jellyfin-server-git/) and [`jellyfin-web-git`](https://aur.archlinux.org/packages/jellyfin-web-git/).
+Both packages, server and web, can also be built from source at the tip of the master branch using [`jellyfin-git`](https://aur.archlinux.org/packages/jellyfin-git/).
+The AUR also offers each separately at [`jellyfin-server-git`](https://aur.archlinux.org/packages/jellyfin-server-git/) and [`jellyfin-web-git`](https://aur.archlinux.org/packages/jellyfin-web-git/).
 
 ## Fedora
 

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -191,23 +191,15 @@ sudo apt install jellyfin`}
     id: 'arch',
     name: 'Arch Linux',
     osTypes: [OsType.Linux],
-    status: DownloadStatus.Community,
+    status: DownloadStatus.Official,
     features: [Feature.CustomFFmpeg],
     platforms: [Platform.Arch],
-    description: 'Install Jellyfin via the Arch User Repository.',
+    description: 'Install Jellyfin via Arch-Extra Repository.',
     stableButtons: [
       {
-        id: 'arch-stable-button',
-        name: 'Install Instructions',
-        details: (
-          <pre className='margin-bottom--none'>
-            <code>
-              {`git clone https://aur.archlinux.org/jellyfin.git
-cd jellyfin
-makepkg -si`}
-            </code>
-          </pre>
-        )
+        id: 'arch-stable-link',
+        name: 'Arch Downloads',
+        url: 'https://archlinux.org/packages/?q=jellyfin'
       }
     ],
     unstableButtons: [


### PR DESCRIPTION
The Arch Linux "Extra" repo now has `jellyfin-server` and `jellyfin-web`.
The [Jellyfin wiki page](https://wiki.archlinux.org/title/Jellyfin) has been updated.