### PR TITLE
Add warning for metadata providers in mainland china

### DIFF
--- a/docs/general/server/metadata/index.md
+++ b/docs/general/server/metadata/index.md
@@ -17,7 +17,7 @@ There are more official providers available in our [Plugin Catalog](/docs/genera
 
 :::caution Notice for Users in Mainland China 中国大陆地区用户请注意
 
-Because of external factors, certain metadata providers may not be accessible in mainland China. <br />
+Because of external factors, certain metadata providers may not be accessable in mainland China. <br />
 由于外部因素，部分元数据提供者在中国大陆地区可能无法访问。
 
 Below is a list of known inaccessable providers: <br />

--- a/docs/general/server/metadata/index.md
+++ b/docs/general/server/metadata/index.md
@@ -24,6 +24,7 @@ Below is a list of known inaccessable providers: <br />
 下方为已知无法访问的提供者：
 
 - The Movie Database (TMDb)
-- TheTVDB 
+- TheTVDB
 
 :::
+

--- a/docs/general/server/metadata/index.md
+++ b/docs/general/server/metadata/index.md
@@ -27,4 +27,3 @@ Below is a list of known inaccessable providers: <br />
 - TheTVDB
 
 :::
-

--- a/docs/general/server/metadata/index.md
+++ b/docs/general/server/metadata/index.md
@@ -14,3 +14,16 @@ Jellyfin can get metadata for your media through multiple sources. By default, J
 [^1]: OMDb only provides English metadata.
 
 There are more official providers available in our [Plugin Catalog](/docs/general/server/plugins#official-plugins), like TheTVDB, fanart.tv or AniDB. If you still can't find the provider you are looking for, you could even develop your own with our Plugin API.
+
+:::caution Notice for Users in Mainland China 中国大陆地区用户请注意
+
+Because of external factors, certain metadata providers may not be accessible in mainland China. <br />
+由于外部因素，部分元数据提供者在中国大陆地区可能无法访问。
+
+Below is a list of known inaccessable providers: <br />
+下方为已知无法访问的提供者：
+
+- The Movie Database (TMDb)
+- TheTVDB 
+
+:::


### PR DESCRIPTION
There have been a few issues opened on Jellyfin about being unable to use certain media providers. Some of these issues are caused by TMDb and TVDb being blocked in mainland China.

This PR aims to properly document this.

The warning is also in Chinese for good measure

Sampie issue: [jellyfin/#4352](https://github.com/jellyfin/jellyfin/issues/4352)