### PR TITLE
Update Quadlet RemapUsers option to UserNS

### DIFF
--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -211,7 +211,7 @@ As always it is recommended to run the container rootless. Therefore we want to 
    Image=docker.io/jellyfin/jellyfin:latest
    Label=io.containers.autoupdate=registry
    PublishPort=8096:8096/tcp
-   RemapUsers=keep-id
+   UserNS=keep-id
    Volume=jellyfin-config:/config:Z
    Volume=jellyfin-cache:/cache:Z
    Volume=jellyfin-media:/media:Z


### PR DESCRIPTION
RemapUsers is not present in the latest Quadlet documentation and UserNS appears to be equivalent