### PR TITLE
Major cleanup of Linux install instructions

### DIFF
--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -175,7 +175,7 @@ If you would prefer to install everything manually, the full steps are as follow
    :::note
 
    The supported values for the above variables are:
-   
+
    * `${VERSION_OS}`: One of `debian` or `ubuntu`; if it is not, use the closest one for your distribution.
    * `${VERSION_CODENAME}: One of our supported [Debian](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L7) or [Ubuntu](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L8) release codenames. These can change as new releases come out and old releases are dropped, so check the script to be sure yours is supported.
    * `${DPKG_ARCHITECTURE}`: One of our [supported architectures](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L6). Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is **not** supported on the `i386` architecture.
@@ -251,7 +251,6 @@ The repository is the preferred way to obtain Jellyfin on Debian and Ubuntu syst
    This step may throw errors; continue to the next step to resolve them.
 
    :::
-
 
 4. Use `apt` to install any missing dependencies:
 

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -24,9 +24,9 @@ The AUR also offers each separately at [`jellyfin-server-git`](https://aur.archl
 
 ## Fedora
 
-Fedora builds in RPM package format are available [here](/downloads/linux#fedora-centos) for now but an official Fedora repository is coming soon.
+Fedora builds in RPM package format are available [in the main download repository](https://repo.jellyfin.org/releases/server/). We do not yet have an official Fedora repository, but one is planned for the future.
 
-1. You will need to enable rpmfusion as ffmpeg is a dependency of the jellyfin server package
+1. You will need to enable `rpmfusion`, as `ffmpeg` is a dependency of the `jellyfin` server package
 
    ```sh
    sudo dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
@@ -34,33 +34,29 @@ Fedora builds in RPM package format are available [here](/downloads/linux#fedora
 
    :::note
 
-   You do not need to manually install ffmpeg, it will be installed by the jellyfin server package as a dependency
+   You do not need to manually install `ffmpeg`; it will be installed by the Jellyfin server package as a dependency.
 
    :::
 
-2. Install the jellyfin server
+2. Install the Jellyfin server
 
    ```sh
-   sudo dnf install (link to version jellyfin server you want to install)
+   sudo dnf install <link to server `.rpm` file URL>
    ```
 
-3. Install the jellyfin web interface
+3. Install the Jellyfin web interface
 
    ```sh
-   sudo dnf install (link to web RPM you want to install)
+   sudo dnf install <link to web `.rpm` file URL>
    ```
 
-4. Enable jellyfin service with systemd
+4. Enable and start the Jellyfin service:
 
    ```sh
-   sudo systemctl start jellyfin
+   sudo systemctl enable --now jellyfin
    ```
 
-   ```sh
-   sudo systemctl enable jellyfin
-   ```
-
-5. Open jellyfin service with firewalld
+5. Allow Jellyfin through the firewall:
 
    ```sh
    sudo firewall-cmd --permanent --add-service=jellyfin
@@ -68,25 +64,20 @@ Fedora builds in RPM package format are available [here](/downloads/linux#fedora
 
    :::note
 
-   This will open the following ports
-   8096 TCP used by default for HTTP traffic, you can change this in the dashboard
-   8920 TCP used by default for HTTPS traffic, you can change this in the dashboard
-   1900 UDP used for service auto-discovery, this is not configurable
-   7359 UDP used for auto-discovery, this is not configurable
+   This will open the following ports:
+
+   * `8096 TCP`, used by default for HTTP traffic; you can change this in the dashboard
+   * `8920 TCP`, used by default for HTTPS traffic; you can change this in the dashboard
+   * `1900 UDP`, used for service auto-discovery; this is not configurable
+   * `7359 UDP`, used for auto-discovery; this is not configurable
 
    :::
 
-6. Reboot your machine
-
-   ```sh
-   sudo systemctl reboot
-   ```
-
-7. Go to `localhost:8096` or `ip-address-of-jellyfin-server:8096` to finish setup in the web UI
+6. Go to `localhost:8096` or `ip-address-of-jellyfin-server:8096` to finish setup in the web UI
 
 ## CentOS
 
-CentOS/RHEL 7 builds in RPM package format are available [here](/downloads/linux#fedora-centos) and an official CentOS/RHEL repository is planned for the future.
+CentOS/RHEL 7 builds in RPM package format are available [in the main download repository](https://repo.jellyfin.org/releases/server/). We do not yet have an official CentOS/RHEL repository, but one is planned for the future.
 
 The default CentOS/RHEL repositories don't provide FFmpeg, which the RPM requires.
 You will need to add a third-party repository which provide FFmpeg, such as [RPM Fusion's Free repository](https://rpmfusion.org/Configuration).
@@ -95,33 +86,47 @@ You can also build [Jellyfin's version](https://github.com/jellyfin/jellyfin-ffm
 This includes gathering the dependencies and compiling and installing them.
 Instructions can be found at [the FFmpeg wiki](https://trac.ffmpeg.org/wiki/CompilationGuide/Centos).
 
-## Debian
+The general process should follow the above Fedora instructions.
 
-### Repository
+## Debuntu (Debian, Ubuntu, and derivatives using `apt`)
 
-The Jellyfin team provides a Debian repository for installation on Debian Buster, Bullseye and Bookworm.
-Supported architectures are `amd64`, `arm64`, and `armhf`.
+The Jellyfin team provides 3rd-party Debian and Ubuntu repositories, to help ensure your Jellyfin install is always kept up-to-date.
 
-:::note
+### Repository (Automatic)
 
-Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is **not** supported on the `i386` architecture.
-
-:::
-
-We provide an installer script to easily configure the Jellyfin APT repository.
-All you need to do is run this command on your system:
+To simplify deployment and help automate this for as many users as possible, we provide a BASH script to handle repo installation as well as installing Jellyfin.
+All you need to do is run this command on your system (requires `curl`, or subsitute `curl` with `wget -O-`):
 
 ```sh
 curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash
 ```
 
-If you do not have `curl` installed, you can try `wget` instead:
+:::note
+
+You can verify the script download integrity with (requires `sha256sum`) with:
 
 ```sh
-wget -O- https://repo.jellyfin.org/install-debuntu.sh | sudo bash
+diff <( curl -s https://repo.jellyfin.org/install-debuntu.sh -o install-debuntu.sh; sha256sum install-debuntu.sh ) <( curl -s https://repo.jellyfin.org/install-debuntu.sh.sha256sum )
 ```
 
-If you don't trust the script or want to do everything manually, the full steps are as follows:
+An empty output means everything is correct. Then you can inspect the script to see what it does (optional but recommended) and execute it with:
+
+```sh
+less install-debuntu.sh
+sudo bash install-debuntu.sh
+```
+
+:::
+
+:::note
+
+The script tries to handle as many common derivatives as possible, including, at least, Linux Mint (Ubuntu and Debian editions), Raspbian/Raspberry Pi OS, and KDE Neon. We welcome PRs [to the script](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L52) for any other common derivatives, or you can use the steps below instead.
+
+:::
+
+### Repository (Manual)
+
+If you would prefer to install everything manually, the full steps are as follows:
 
 1. Install `curl` and `gnupg` if you haven't already:
 
@@ -129,129 +134,7 @@ If you don't trust the script or want to do everything manually, the full steps 
    sudo apt install curl gnupg
    ```
 
-2. Download the GPG signing key (signed by the Jellyfin Team):
-
-   ```sh
-   sudo mkdir -p /etc/apt/keyrings
-   curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg
-   ```
-
-3. Add a repository configuration at `/etc/apt/sources.list.d/jellyfin.sources`:
-
-   ```sh
-   cat <<EOF | sudo tee /etc/apt/sources.list.d/jellyfin.sources
-   Types: deb
-   URIs: https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )
-   Suites: $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )
-   Components: main
-   Architectures: $( dpkg --print-architecture )
-   Signed-By: /etc/apt/keyrings/jellyfin.gpg
-   EOF
-   ```
-
-   :::note
-
-   Supported releases are `buster`, `bullseye` and `bookworm`.
-
-   :::
-
-4. Update APT repositories:
-
-   ```sh
-   sudo apt update
-   ```
-
-5. Install Jellyfin:
-
-   ```sh
-   sudo apt install jellyfin
-   ```
-
-6. Manage the Jellyfin system service:
-
-   ```sh
-   sudo systemctl {action} jellyfin
-   ```
-
-### Packages
-
-Raw Debian packages, including old versions, are available [here](/downloads/linux#debubuntu).
-
-:::note
-
-The repository is the preferred way to obtain Jellyfin on Debian, as it contains several dependencies as well.
-
-:::
-
-1. Download the desired `jellyfin` and `jellyfin-ffmpeg` `.deb` packages from the repository.
-
-2. Install the downloaded `.deb` packages:
-
-   ```sh
-   sudo dpkg -i jellyfin_*.deb jellyfin-ffmpeg_*.deb
-   ```
-
-3. Use `apt` to install any missing dependencies:
-
-   ```sh
-   sudo apt -f install
-   ```
-
-4. Manage the Jellyfin system service:
-
-   ```sh
-   sudo systemctl {action} jellyfin
-   ```
-
-## Ubuntu
-
-### Migrating to the new repository
-
-Previous versions of Jellyfin included Ubuntu under the Debian repository.
-This has now been split out into its own repository to better handle the separate binary packages.
-If you encounter errors about the `ubuntu` release not being found and you previously configured an `ubuntu` `jellyfin.list` file, please follow these steps.
-
-1. Remove the old `/etc/apt/sources.list.d/jellyfin.list` file:
-
-   ```sh
-   sudo rm /etc/apt/sources.list.d/jellyfin.list
-   ```
-
-2. Proceed with the following section as written.
-
-### Ubuntu Repository
-
-The Jellyfin team provides an Ubuntu repository for installation on Ubuntu Bionic, Focal, Impish, and Jammy.
-Supported architectures are `amd64`, `arm64`, and `armhf`.
-
-:::note
-
-Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is **not** supported on the `i386` architecture.
-
-:::
-
-We provide an installer script to easily configure the Jellyfin APT repository.
-All you need to do is run this command on your system:
-
-```sh
-curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash
-```
-
-If you do not have `curl` installed, you can try `wget` instead:
-
-```sh
-wget -O- https://repo.jellyfin.org/install-debuntu.sh | sudo bash
-```
-
-If you don't trust the script or want to do everything manually, the full steps are as follows:
-
-1. Install `curl` and `gnupg` if you haven't already:
-
-   ```sh
-   sudo apt install curl gnupg
-   ```
-
-2. Enable the Universe repository to obtain all the FFMpeg dependencies:
+2. On Ubuntu (and derivatives) only, enable the Universe repository to obtain all the FFMpeg dependencies:
 
    ```sh
    sudo add-apt-repository universe
@@ -264,7 +147,9 @@ If you don't trust the script or want to do everything manually, the full steps 
 
    :::
 
-3. Download the GPG signing key (signed by the Jellyfin Team):
+   On Debian, you can also enable the `non-free` components of your base repositories for additional FFMpeg dependencies, but this is optional.
+
+3. Download the GPG signing key (signed by the Jellyfin Team) and install it:
 
    ```sh
    sudo mkdir -p /etc/apt/keyrings
@@ -274,86 +159,116 @@ If you don't trust the script or want to do everything manually, the full steps 
 4. Add a repository configuration at `/etc/apt/sources.list.d/jellyfin.sources`:
 
    ```sh
+   export VERSION_OS="$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )"
+   export VERSION_CODENAME="$( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )"
+   export DPKG_ARCHITECTURE="$( dpkg --print-architecture )"
    cat <<EOF | sudo tee /etc/apt/sources.list.d/jellyfin.sources
    Types: deb
-   URIs: https://repo.jellyfin.org/$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )
-   Suites: $( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )
+   URIs: https://repo.jellyfin.org/${VERSION_OS}
+   Suites: ${VERSION_CODENAME}
    Components: main
-   Architectures: $( dpkg --print-architecture )
+   Architectures: ${DPKG_ARCHITECTURE}
    Signed-By: /etc/apt/keyrings/jellyfin.gpg
    EOF
    ```
 
    :::note
 
-   Supported releases are `bionic`, `focal`, `impish`, and `jammy`.
+   The supported values for the above variables are:
+   
+   * `${VERSION_OS}`: One of `debian` or `ubuntu`; if it is not, use the closest one for your distribution.
+   * `${VERSION_CODENAME}: One of our supported [Debian](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L7) or [Ubuntu](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L8) release codenames. These can change as new releases come out and old releases are dropped, so check the script to be sure yours is supported.
+   * `${DPKG_ARCHITECTURE}`: One of our [supported architectures](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L6). Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is **not** supported on the `i386` architecture.
 
    :::
 
-5. Update APT repositories:
+5. Update your APT repositories:
 
    ```sh
    sudo apt update
    ```
 
-6. Install Jellyfin:
+6. Install the Jellyfin metapackage, which will automatically fetch the various sub-packages:
 
    ```sh
    sudo apt install jellyfin
    ```
 
+   :::note
+
+   If you want to be explicit, instead of the metapackage, you can install the sub-packages individually:
+
+   ```sh
+   sudo apt install jellyfin-server jellyfin-web
+   ```
+
+   The `jellyfin-server` package will automatically select the right `jellyfin-ffmpeg` package for you as well.
+
+   :::
+
 7. Manage the Jellyfin system service:
 
    ```sh
    sudo systemctl {action} jellyfin
+   sudo service jellyfin {action}
    ```
 
-### Ubuntu Packages
+### `.deb` Packages (Very Manual)
 
-Raw Ubuntu packages, including old versions, are available [here](/downloads/linux#debubuntu).
+Raw `.deb` packages, including old versions, source packages, and `dpkg` meta files, are available [in the main download repository](https://repo.jellyfin.org/releases/server/).
 
 :::note
 
-The repository is the preferred way to install Jellyfin on Ubuntu, as it contains several dependencies as well.
+The repository is the preferred way to obtain Jellyfin on Debian and Ubuntu systems, as this ensures you get automatic updates and that all dependencies are properly resolved. Use these steps only if you really know what you're doing.
 
 :::
 
-1. Enable the Universe repository to obtain all the FFMpeg dependencies, and update repositories:
+1. On Ubuntu (and derivatives) only, enable the Universe repository to obtain all the FFMpeg dependencies:
 
    ```sh
    sudo add-apt-repository universe
-   sudo apt update
    ```
 
-2. Download the desired `jellyfin` and `jellyfin-ffmpeg` `.deb` packages from the repository.
+   :::note
 
-3. Install the required dependencies:
+   If the above command fails you will need to install the following package `software-properties-common`.
+   This can be achieved with the following command `sudo apt-get install software-properties-common`
 
-   ```sh
-   sudo apt install at libsqlite3-0 libfontconfig1 libfreetype6 libssl1.0.0
-   ```
+   :::
 
-4. Install the downloaded `.deb` packages:
+   On Debian, you can also enable the `non-free` components of your base repositories for additional FFMpeg dependencies, but this is optional.
+
+2. Download the desired `jellyfin-server`, `jellyfin-web`, and `jellyfin-ffmpeg` `.deb` packages from the repository; `jellyfin` is a metapackage and is not required.
+
+3. Install the downloaded `.deb` packages:
 
    ```sh
    sudo dpkg -i jellyfin_*.deb jellyfin-ffmpeg_*.deb
    ```
 
-5. Use `apt` to install any missing dependencies:
+   :::note
+
+   This step may throw errors; continue to the next step to resolve them.
+
+   :::
+
+
+4. Use `apt` to install any missing dependencies:
 
    ```sh
    sudo apt -f install
    ```
 
-6. Manage the Jellyfin system service:
+5. Manage the Jellyfin system service:
 
    ```sh
    sudo systemctl {action} jellyfin
+   sudo service jellyfin {action}
    ```
 
 ## Gentoo
 
-The Gentoo ebuild repositoy includes the Jellyfin package which can be installed like other software:
+The Gentoo ebuild repository includes the Jellyfin package which can be installed like other software:
 
    ```sh
    emerge www-apps/jellyfin
@@ -361,7 +276,7 @@ The Gentoo ebuild repositoy includes the Jellyfin package which can be installed
 
 ## Linux (generic amd64)
 
-Generic `amd64`, `arm64`, and `armhf` Linux builds in TAR archive format are available [here](/downloads/linux).
+Generic `amd64`, `arm64`, and `armhf` Linux builds in TAR archive format are available [in the main download repository](https://repo.jellyfin.org/releases/server/).
 
 ### Base Installation Process
 

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -103,7 +103,7 @@ curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash
 
 :::note
 
-You can verify the script download integrity with (requires `sha256sum`) with:
+You can verify the script download integrity with (requires `sha256sum`):
 
 ```sh
 diff <( curl -s https://repo.jellyfin.org/install-debuntu.sh -o install-debuntu.sh; sha256sum install-debuntu.sh ) <( curl -s https://repo.jellyfin.org/install-debuntu.sh.sha256sum )

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -147,7 +147,7 @@ If you would prefer to install everything manually, the full steps are as follow
 
    :::
 
-   On Debian, you can also enable the `non-free` components of your base repositories for additional FFMpeg dependencies, but this is optional.
+   On Debian, you can also enable the `non-free` components of your base repositories for additional FFmpeg dependencies, but this is optional.
 
 3. Download the GPG signing key (signed by the Jellyfin Team) and install it:
 

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -57,36 +57,8 @@ export const Downloads: Array<Download> = [
             <pre>
               <code>{`curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
             </pre>
-            <p>
-              If you do not have <code>curl</code> installed, you can try <code>wget</code> instead:
-            </p>
-            <pre>
-              <code>{`wget -O- https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
-            </pre>
-            <p>For more advanced users, the full steps are:</p>
-            <pre>
-              <code>
-                {`sudo apt install curl gnupg
-sudo mkdir /etc/apt/keyrings
-DISTRO="$( awk -F'=' '/^ID=/{ print $NF }' /etc/os-release )"
-CODENAME="$( awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release )"
-curl -fsSL https://repo.jellyfin.org/\${DISTRO}/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg
-cat <<EOF | sudo tee /etc/apt/sources.list.d/jellyfin.sources
-Types: deb
-URIs: https://repo.jellyfin.org/\${DISTRO}
-Suites: \${CODENAME}
-Components: main
-Architectures: $( dpkg --print-architecture )
-Signed-By: /etc/apt/keyrings/jellyfin.gpg
-EOF
-sudo apt update
-sudo apt install jellyfin`}
-              </code>
-            </pre>
-            <p>
-              <b>Note:</b>: If you are running a non-Debian, non-Ubuntu derivative, ensure the <code>$DISTRO</code> and{' '}
-              <code>$CODENAME</code> are valid Debian or Ubuntu values!
-            </p>
+            <p>If you do not have <code>curl</code> installed, you can use <code>wget -O-</code> instead of <code>curl</code>.</p>
+            <p>For more advanced users, the full steps can be [found in the docs](https://jellyfin.org/docs/general/installation/linux#debuntu).</p>
             <p className='margin-bottom--none'>
               Once installed, Jellyfin will be running as a service. Manage it with{' '}
               <code>{'sudo systemctl {action} jellyfin.service'}</code> or{' '}

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -57,10 +57,14 @@ export const Downloads: Array<Download> = [
             <pre>
               <code>{`curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
             </pre>
-            <p>If you do not have <code>curl</code> installed, you can use <code>wget -O-</code> instead of{' '}
-            <code>curl</code>.</p>
-            <p>For more advanced users, the full steps can be [found in the
-            docs](https://jellyfin.org/docs/general/installation/linux#debuntu).</p>
+            <p>
+              If you do not have <code>curl</code> installed, you can use <code>wget -O-</code> instead
+              of <code>curl</code>.
+            </p>
+            <p>
+              For more advanced users, the full steps can be [found in the
+              docs](https://jellyfin.org/docs/general/installation/linux#debuntu).
+            </p>
             <p className='margin-bottom--none'>
               Once installed, Jellyfin will be running as a service. Manage it with{' '}
               <code>{'sudo systemctl {action} jellyfin.service'}</code> or{' '}

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -58,8 +58,8 @@ export const Downloads: Array<Download> = [
               <code>{`curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
             </pre>
             <p>
-              If you do not have <code>curl</code> installed, you can use <code>wget -O-</code> instead
-              of <code>curl</code>.
+              If you do not have <code>curl</code> installed, you can use{' '}
+              <code>wget -O-</code> instead of <code>curl</code>.
             </p>
             <p>
               For more advanced users, the full steps can be [found in the

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -57,8 +57,10 @@ export const Downloads: Array<Download> = [
             <pre>
               <code>{`curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
             </pre>
-            <p>If you do not have <code>curl</code> installed, you can use <code>wget -O-</code> instead of <code>curl</code>.</p>
-            <p>For more advanced users, the full steps can be [found in the docs](https://jellyfin.org/docs/general/installation/linux#debuntu).</p>
+            <p>If you do not have <code>curl</code> installed, you can use <code>wget -O-</code> instead of{' '}
+            <code>curl</code>.</p>
+            <p>For more advanced users, the full steps can be [found in the
+            docs](https://jellyfin.org/docs/general/installation/linux#debuntu).</p>
             <p className='margin-bottom--none'>
               Once installed, Jellyfin will be running as a service. Manage it with{' '}
               <code>{'sudo systemctl {action} jellyfin.service'}</code> or{' '}

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -59,7 +59,8 @@ export const Downloads: Array<Download> = [
             </pre>
             <p>
               If you do not have <code>curl</code> installed, you can use{' '}
-              <code>wget -O-</code> instead of <code>curl</code>.
+              <code>wget -O-</code> instead of{' '}
+              <code>curl</code>.
             </p>
             <p>
               For more advanced users, the full steps can be [found in the

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -58,7 +58,7 @@ export const Downloads: Array<Download> = [
               <code>{`curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
             </pre>
             <p>
-              If you do not have <code>curl</code> installed, you can use{' '}
+              If you do not have <code>curl</code> installed, you can use
               <code>wget -O-</code> instead of{' '}
               <code>curl</code>.
             </p>

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -59,7 +59,7 @@ export const Downloads: Array<Download> = [
             </pre>
             <p>
               If you do not have <code>curl</code> installed, you can use
-              <code>wget -O-</code> instead of{' '}
+              <code>wget -O-</code> instead of
               <code>curl</code>.
             </p>
             <p>


### PR DESCRIPTION
This is an attempt to clean up and streamline the various Linux package install instructions.

1. (For Debuntu) The main Downloads page now provides just the most basic instructions for using the script install; users are directed to the docs page for more advanced instructions. We don't need walls of text or commands in the quickstart.

2. The Debian/Ubuntu docs are cleaned up and unified: a) The Debian and Ubuntu sections were mostly identical, so combine them and show only the (single) relevant difference. b) Add a clear command for integrity checking the script. c) Expand some aspects of the manual process for better checking, and link to the script rather than provide a list of codenames that must be constantly updated. d) Cleans up some wording.

3. The Fedora and CentOS docs are cleaned up: a) Use consistent monospace for package names and capitalization elsewhere. b) Clean up the steps a bit. c) Clarify the source and when a repo will come. d) For CentOS mention that the process is "similar" to Fedora (better than the nothing that was there before).

4. Use consistent links to the download repository throughout; linking back to the downloads page, which presumably someone *came from*, is unfriendly. Just link to the right place.