### PR TITLE
Clarify that the recommended specs aren't the required bare minimum

### DIFF
--- a/docs/general/administration/hardware-selection.md
+++ b/docs/general/administration/hardware-selection.md
@@ -19,6 +19,12 @@ For a Jellyfin server, the following is recommended:
 - Storage: 60GB SSD storage for Jellyfin files and transcoding cache.
 - Graphics: Intel HD 6xx (7th gen integrated graphics) or newer, Nvidia GTX 16 / RTX 20 series or newer (excluding GTX 1650). Intel recommended over Nvidia, AMD and Apple Silicon not recommended.
 
+:::note These are Recommended Specs
+
+These specs are the **recommended** specs to run Jellyfin. They are not minimum requirements, and it is certainly possible to run Jellyfin on lower end hardware.
+
+:::
+
 :::caution Pre-built NAS Devices
 
 Many pre-built NAS devices are underpowered. Please check your specs against the above recommendations for a good experience.


### PR DESCRIPTION
I don't really know why this is needed but apparently people mistake these for the bare minimum required to run Jellyfin.

Updating this so that (hopefully) less people get confused.