### PR TITLE
Fix spacing and link in downloads

### DIFF
--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -58,13 +58,13 @@ export const Downloads: Array<Download> = [
               <code>{`curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
             </pre>
             <p>
-              If you do not have <code>curl</code> installed, you can use
-              <code>wget -O-</code> instead of
+              If you do not have <code>curl</code> installed, you can use{' '}
+              <code>wget -O-</code> instead of{' '}
               <code>curl</code>.
             </p>
             <p>
-              For more advanced users, the full steps can be [found in the
-              docs](https://jellyfin.org/docs/general/installation/linux#debuntu).
+              For more advanced users, the full steps can be <a href="https://jellyfin.org/docs/general/installation/linux#debuntu-debian-ubuntu-and-derivatives-using-apt">
+              found in the docs</a>.
             </p>
             <p className='margin-bottom--none'>
               Once installed, Jellyfin will be running as a service. Manage it with{' '}


### PR DESCRIPTION
Corrects some faults with #716 

1. Missing spaces between the words "use" and "wget" and between "of" and "curl". Prettier insists I remove this extra space but that is nonsensical.
2. Link should be an `<a>` tag as markdown-style did not work.