### PR TITLE
Add minimum macOS version

### DIFF
--- a/docs/general/installation/macos.md
+++ b/docs/general/installation/macos.md
@@ -11,6 +11,9 @@ sidebar_position: 5
 
 macOS Application packages and builds in TAR archive format are available [here](/downloads/macos).
 
+:::note
+Jellyfin requires macOS 10.15 or newer to run.
+
 **Install**
 
 1. Download the latest version.


### PR DESCRIPTION
Adds the minimum macOS version enforced by .NET 6. All current indications for .NET 8 show the same version, so this will remain current for future builds.