### PR TITLE
Remove Antennas

### DIFF
--- a/docs/general/server/plugins/index.md
+++ b/docs/general/server/plugins/index.md
@@ -225,14 +225,6 @@ Manage TVHeadEnd from Jellyfin. Click [here](/docs/general/server/plugins/tvhead
 
 ### 3rd-Party Plugins
 
-#### Antennas
-
-Takes your tuners in TVHeadEnd and emulates a HDHomeRun, in order to connect to Jellyfin's Live TV and DVR features. It requires additional setup and configuration, but is a useful alternative to the TVHeadEnd plugin.
-
-**Links:**
-
-- [GitHub](https://github.com/TheJF/antennas)
-
 #### Merge Versions
 
 Automatically group every repeated movie.


### PR DESCRIPTION
Antennas is a a utility, not a plugin. That said, it's no longer needed since it is possible to integrate TVHeadend directly without using any plugins at all. I may write a guide in the forum for that, based off of a post from [Owen Ashurst](https://owenashurst.com/post/setting-up-live-tv-with-jellyfin-with-a-usb-august-t210-v2-tv-receiver).