### PR TITLE
Upgrade to @icons-pack/react-simple-icons 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@docusaurus/theme-classic": "3.0.0",
         "@easyops-cn/docusaurus-search-local": "0.38.0",
         "@fontsource/noto-sans": "5.0.17",
-        "@icons-pack/react-simple-icons": "5.11.0",
+        "@icons-pack/react-simple-icons": "9.1.0",
         "@img-comparison-slider/react": "8.0.1",
         "@mdi/js": "7.3.67",
         "@mdi/react": "1.6.1",
@@ -3422,9 +3422,9 @@
       "devOptional": true
     },
     "node_modules/@icons-pack/react-simple-icons": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-5.11.0.tgz",
-      "integrity": "sha512-hFJ4Q4JcYe/wQUab+gIug1BONjBUelaUVFYsZ1FKv5CEX/fP56qGet4CPmx18BqDhxrOehidYNlLyGppXL9/7w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-9.1.0.tgz",
+      "integrity": "sha512-3v6W4SgkYX6bHfKrFvRZrxilv+4wXKYQ2DVRldqaZgcwGK5ajsW4PzLlqF9aw+uT/NeoMklunonoYwZlx9Kbwg==",
       "peerDependencies": {
         "react": "^16.13 || ^17 || ^18"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@docusaurus/theme-classic": "3.0.0",
     "@easyops-cn/docusaurus-search-local": "0.38.0",
     "@fontsource/noto-sans": "5.0.17",
-    "@icons-pack/react-simple-icons": "5.11.0",
+    "@icons-pack/react-simple-icons": "9.1.0",
     "@img-comparison-slider/react": "8.0.1",
     "@mdi/js": "7.3.67",
     "@mdi/react": "1.6.1",

--- a/src/components/common/PlatformIcon.tsx
+++ b/src/components/common/PlatformIcon.tsx
@@ -1,24 +1,24 @@
 import {
-  Amazonfiretv,
-  Android,
-  Apple,
-  Appletv,
-  Archlinux,
-  Centos,
-  Debian,
-  Discord,
-  Docker,
-  Dotnet,
-  Fedora,
-  Gentoo,
-  Ios,
-  Kodi,
-  Lg,
-  Linux,
-  Roku,
-  Sailfishos,
-  Ubuntu,
-  Windows
+  SiAmazonfiretv,
+  SiAndroid,
+  SiApple,
+  SiAppletv,
+  SiArchlinux,
+  SiCentos,
+  SiDebian,
+  SiDiscord,
+  SiDocker,
+  SiDotnet,
+  SiFedora,
+  SiGentoo,
+  SiIos,
+  SiKodi,
+  SiLg,
+  SiLinux,
+  SiRoku,
+  SiSailfishos,
+  SiUbuntu,
+  SiWindows
 } from '@icons-pack/react-simple-icons';
 import Icon from '@mdi/react';
 import { mdiMonitor, mdiWeb } from '@mdi/js';
@@ -42,70 +42,70 @@ const PlatformIcon = ({
     // TODO: AndroidTV should have a unique icon
     case Platform.Android:
     case Platform.AndroidTV:
-      return <Android size={size} className={className} />;
+      return <SiAndroid size={size} className={className} />;
 
     case Platform.Arch:
-      return <Archlinux size={size} className={className} />;
+      return <SiArchlinux size={size} className={className} />;
 
     case Platform.Browser:
       return <Icon path={mdiWeb} size={`${size}px`} className={className} />;
 
     case Platform.CentOS:
-      return <Centos size={size} className={className} />;
+      return <SiCentos size={size} className={className} />;
 
     case Platform.Desktop:
       return <Icon path={mdiMonitor} size={`${size}px`} className={className} />;
 
     case Platform.Debian:
-      return <Debian size={size} className={className} />;
+      return <SiDebian size={size} className={className} />;
 
     case Platform.Discord:
-      return <Discord size={size} className={className} />;
+      return <SiDiscord size={size} className={className} />;
 
     case Platform.Docker:
-      return <Docker size={size} className={className} />;
+      return <SiDocker size={size} className={className} />;
 
     case Platform.DotNet:
-      return <Dotnet size={size} className={className} />;
+      return <SiDotnet size={size} className={className} />;
 
     case Platform.Fedora:
-      return <Fedora size={size} className={className} />;
+      return <SiFedora size={size} className={className} />;
 
     case Platform.FireOS:
-      return <Amazonfiretv size={size} className={className} />;
+      return <SiAmazonfiretv size={size} className={className} />;
 
     case Platform.Gentoo:
-      return <Gentoo size={size} className={className} />;
+      return <SiGentoo size={size} className={className} />;
 
     case Platform.IOS:
-      return <Ios size={size} className={className} />;
+      return <SiIos size={size} className={className} />;
 
     case Platform.Kodi:
-      return <Kodi size={size} className={className} />;
+      return <SiKodi size={size} className={className} />;
 
     case Platform.Linux:
-      return <Linux size={size} className={className} />;
+      return <SiLinux size={size} className={className} />;
 
     case Platform.MacOS:
-      return <Apple size={size} className={className} />;
+      return <SiApple size={size} className={className} />;
 
     case Platform.Roku:
-      return <Roku size={size} className={className} />;
+      return <SiRoku size={size} className={className} />;
 
     case Platform.SailfishOS:
-      return <Sailfishos size={size} className={className} />;
+      return <SiSailfishos size={size} className={className} />;
 
     case Platform.TVOS:
-      return <Appletv size={size} className={className} />;
+      return <SiAppletv size={size} className={className} />;
 
     case Platform.Ubuntu:
-      return <Ubuntu size={size} className={className} />;
+      return <SiUbuntu size={size} className={className} />;
 
     case Platform.WebOS:
-      return <Lg size={size} className={className} />;
+      return <SiLg size={size} className={className} />;
 
     case Platform.Windows:
-      return <Windows size={size} className={className} />;
+      return <SiWindows size={size} className={className} />;
 
     default:
       return null;

--- a/src/components/contact/DiscordCard.tsx
+++ b/src/components/contact/DiscordCard.tsx
@@ -1,4 +1,4 @@
-import { Discord } from '@icons-pack/react-simple-icons';
+import { SiDiscord } from '@icons-pack/react-simple-icons';
 import React from 'react';
 
 import './ContactCard.scss';
@@ -9,7 +9,7 @@ const DiscordCard = () => (
       <h3 className='margin-bottom--none' style={{ flexGrow: 1 }}>
         Discord
       </h3>
-      <Discord />
+      <SiDiscord />
     </div>
     <div className='card__body'>
       The Jellyfin Discord server is bridged to the official Matrix rooms for convenience.

--- a/src/components/contact/MastodonCard.tsx
+++ b/src/components/contact/MastodonCard.tsx
@@ -1,4 +1,4 @@
-import { Mastodon } from '@icons-pack/react-simple-icons';
+import { SiMastodon } from '@icons-pack/react-simple-icons';
 import React from 'react';
 
 import './ContactCard.scss';
@@ -9,7 +9,7 @@ const MastodonCard = () => (
       <h3 className='margin-bottom--none' style={{ flexGrow: 1 }}>
         Mastodon
       </h3>
-      <Mastodon />
+      <SiMastodon />
     </div>
     <div className='card__body'>
       Follow us on Mastodon for release announcements and more, just like our Twitter account.

--- a/src/components/contact/MatrixCard.tsx
+++ b/src/components/contact/MatrixCard.tsx
@@ -1,4 +1,4 @@
-import { Element } from '@icons-pack/react-simple-icons';
+import { SiElement } from '@icons-pack/react-simple-icons';
 import React from 'react';
 
 import './ContactCard.scss';
@@ -10,7 +10,7 @@ const MatrixCard = () => {
         <h3 className='margin-bottom--none' style={{ flexGrow: 1 }}>
           Matrix
         </h3>
-        <Element />
+        <SiElement />
       </div>
       <div className='card__body'>
         We primarily use <a href='https://element.io/get-started'>Element</a> to access the{' '}

--- a/src/components/contact/TwitterCard.tsx
+++ b/src/components/contact/TwitterCard.tsx
@@ -1,4 +1,4 @@
-import { Twitter } from '@icons-pack/react-simple-icons';
+import { SiTwitter } from '@icons-pack/react-simple-icons';
 import React from 'react';
 
 import './ContactCard.scss';
@@ -9,7 +9,7 @@ const TwitterCard = () => (
       <h3 className='margin-bottom--none' style={{ flexGrow: 1 }}>
         Twitter
       </h3>
-      <Twitter />
+      <SiTwitter />
     </div>
     <div className='card__body'>
       Follow us on Twitter for release announcements and other updates, along with general musings.

--- a/src/components/home/ClientSection.tsx
+++ b/src/components/home/ClientSection.tsx
@@ -1,7 +1,7 @@
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
 import React from 'react';
-import { Android, Apple, Roku, Amazon, Kodi } from '@icons-pack/react-simple-icons';
+import { SiAndroid, SiApple, SiRoku, SiAmazon, SiKodi } from '@icons-pack/react-simple-icons';
 import Icon from '@mdi/react';
 import { mdiPlusThick, mdiMonitor, mdiWeb } from '@mdi/js';
 
@@ -38,35 +38,35 @@ export default function ClientSection() {
             to='/downloads/clients?platform=Android,Android TV'
             className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
           >
-            <Android color='#ffffff' size={48} />
+            <SiAndroid color='#ffffff' size={48} />
             <div className='margin-top--sm'>Android</div>
           </Link>
           <Link
             to='/downloads/clients?platform=iOS,tvOS'
             className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
           >
-            <Apple color='#ffffff' size={48} />
+            <SiApple color='#ffffff' size={48} />
             <div className='margin-top--sm'>Apple</div>
           </Link>
           <Link
             to='/downloads/clients?platform=Fire TV'
             className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
           >
-            <Amazon color='#ffffff' size={48} />
+            <SiAmazon color='#ffffff' size={48} />
             <div className='margin-top--sm'>Amazon</div>
           </Link>
           <Link
             to='/downloads/clients?platform=Roku'
             className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
           >
-            <Roku color='#ffffff' size={48} />
+            <SiRoku color='#ffffff' size={48} />
             <div className='margin-top--sm'>Roku</div>
           </Link>
           <Link
             to='/downloads/clients?platform=Kodi'
             className={clsx('col', 'fill--white', styles['client-icon'], 'margin-top--md')}
           >
-            <Kodi color='#ffffff' size={48} />
+            <SiKodi color='#ffffff' size={48} />
             <div className='margin-top--sm'>Kodi</div>
           </Link>
           <Link to='/downloads/clients' className={clsx('col', styles['client-icon'], 'margin-top--md')}>

--- a/src/components/home/FreedomSection.tsx
+++ b/src/components/home/FreedomSection.tsx
@@ -1,5 +1,5 @@
 import Link from '@docusaurus/Link';
-import { Opensourceinitiative } from '@icons-pack/react-simple-icons';
+import { SiOpensourceinitiative } from '@icons-pack/react-simple-icons';
 import Icon from '@mdi/react';
 import { mdiAccountGroup, mdiLock, mdiCurrencyUsdOff } from '@mdi/js';
 import clsx from 'clsx';
@@ -13,7 +13,7 @@ const cards = [
   {
     id: 'free-software',
     title: 'Free Software',
-    icon: <Opensourceinitiative size={ICON_SIZE} />,
+    icon: <SiOpensourceinitiative size={ICON_SIZE} />,
     description:
       'Jellyfin is Free Software, licensed under the GNU GPL. You can use it, study it, modify it, build it, and distribute it for free, as long as your changes are licensed the same way.'
   },

--- a/src/pages/contribute.tsx
+++ b/src/pages/contribute.tsx
@@ -1,5 +1,5 @@
 import Link from '@docusaurus/Link';
-import { Digitalocean, Jetbrains } from '@icons-pack/react-simple-icons';
+import { SiDigitalocean, SiJetbrains } from '@icons-pack/react-simple-icons';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import React from 'react';
@@ -58,7 +58,7 @@ export default function Contribute() {
               className={clsx('button', 'button--lg', styles['button--digitalocean'])}
               style={{ display: 'inline-flex' }}
             >
-              <Digitalocean size={28} className='margin-right--sm' />
+              <SiDigitalocean size={28} className='margin-right--sm' />
               DigitalOcean
             </a>
 
@@ -67,7 +67,7 @@ export default function Contribute() {
               className={clsx('button', 'button--lg', styles['button--jetbrains'])}
               style={{ display: 'inline-flex' }}
             >
-              <Jetbrains size={28} className='margin-right--sm' />
+              <SiJetbrains size={28} className='margin-right--sm' />
               JetBrains
             </a>
           </div>


### PR DESCRIPTION
All icons have been renamed to use the `Si` prefix so we had to update all usages