### PR TITLE
Add warning for RPi 5

### DIFF
--- a/docs/general/administration/hardware-acceleration/index.md
+++ b/docs/general/administration/hardware-acceleration/index.md
@@ -25,6 +25,12 @@ The supported and validated video [hardware acceleration (HWA)](https://trac.ffm
 
 - **Raspberry Pi** Video4Linux2 (V4L2, Linux only)
 
+:::danger RPi5
+
+Please AVOID Rapsberry Pi 5 for Jellyfin. The Raspberry Pi 5 lacks hardware encoders altogether. The Raspberry Pi Foundation has also not responded to requests for official comment from the Jellyfin team.
+
+:::
+
 :::caution
 
 While hardware acceleration is supported on Raspberry Pi hardware, it is recommended that Jellyfin NOT be hosted on Raspberry Pis or other SBCs. Many hardware acceleration features are not supported and will fallback to software. In addition, they are generally too slow to provide a good experience when transcoding is needed. Please consider getting a more powerful system to host Jellyfin.

--- a/docs/general/administration/hardware-selection.md
+++ b/docs/general/administration/hardware-selection.md
@@ -47,6 +47,12 @@ It is recommended that Intel-based macs be used with Windows or Linux installed 
 
 For low power applications, Intel 12th gen or newer Atom CPUs with integrated graphics are recommended. It is also recommended that [Low Power Encoding](/docs/general/administration/hardware-acceleration/intel/#low-power-encoding) be setup.
 
+:::caution SBCs (Single Board Computers)
+
+Most SBCs use low powered chipsets, often with less than ideal driver support from the chipset vendors. They are generally too slow for a good experience and/or have broken hardware acceleration support. Please avoid using SBCs such as Raspberry Pis to run Jellyfin.
+
+:::
+
 ## Detailed Guide
 
 ### CPU

--- a/docs/general/administration/hardware-selection.md
+++ b/docs/general/administration/hardware-selection.md
@@ -49,7 +49,7 @@ For low power applications, Intel 12th gen or newer Atom CPUs with integrated gr
 
 :::caution SBCs (Single Board Computers)
 
-Most SBCs use low powered chipsets, often with less than ideal driver support from the chipset vendors. They are generally too slow for a good experience and/or have broken hardware acceleration support. Please avoid using SBCs such as Raspberry Pis to run Jellyfin.
+Most SBCs use low powered chipsets, often with less than ideal driver support from the chipset vendors. They are generally too slow for a good experience and/or have broken hardware acceleration support. Please avoid using SBCs such as Raspberry Pis (Including newer Raspberry Pi 5 Models) to run Jellyfin.
 
 :::
 


### PR DESCRIPTION
RPi 5 lacks hardware encoders altogether. This PR documents that