### PR TITLE
Add warning in dlna.md

### DIFF
--- a/docs/general/networking/dlna.md
+++ b/docs/general/networking/dlna.md
@@ -16,6 +16,12 @@ Setting `Alive message interval (seconds)` to 30 seconds also appears to help di
 
 If a base URL is set, try removing it and restarting the server.
 
+:::warning DLNA on CasaOS
+
+DLNA is broken by default on CasaOS due to the way Jellyfin is packaged by the CasaOS team. Their image uses the Bridged network mode instead of the Host network mode. It will have to be fixed for DLNA to work properly.
+
+:::
+
 ### DLNA Logging
 
 Use these entries in `logging.default.json` to turn on DLNA debug logs.


### PR DESCRIPTION
DLNA is broken on the CasaOS package (as stated in this tweet https://twitter.com/jellyfin/status/1732508814841143542)

This PR adds warning telling users that it is broke