### PR TITLE
docs: update to .NET 8

### DIFF
--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -75,7 +75,7 @@ This is the directory where the Jellyfin logs will be stored. It is set from the
 
 ## Main Configuration
 
-The main server configuration is built upon the ASP .NET [configuration framework](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1), which provides a tiered approach to loading configuration. The base directory to locate the configuration files is set using the [configuration directory](#configuration-directory) setting. The configuration sources are as follows, with later sources having higher priority and overwriting the values in earlier sources.
+The main server configuration is built upon the ASP .NET [configuration framework](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0), which provides a tiered approach to loading configuration. The base directory to locate the configuration files is set using the [configuration directory](#configuration-directory) setting. The configuration sources are as follows, with later sources having higher priority and overwriting the values in earlier sources.
 
 1. **Hard-coded default values**: These defaults are specified in the Jellyfin [source code](https://github.com/jellyfin/jellyfin/blob/master/Emby.Server.Implementations/ConfigurationOptions.cs) and cannot be changed.
 2. **Default logging configuration file** (`logging.default.json`): This file should not be modified manually by users. It is reserved by the server to be overwritten with new settings on each new release.
@@ -87,7 +87,7 @@ The main server configuration is built upon the ASP .NET [configuration framewor
 
    :::
 
-4. **Environment variables**: The [documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1#environment-variables) provided by Microsoft explains how to set these configuration options via environment variables. Jellyfin uses its own custom `JELLYFIN_` prefix for these variables. For example, to set a value for the `HttpListenerHost:DefaultRedirectPath` setting, you would set a value for the `JELLYFIN_HttpListenerHost__DefaultRedirectPath` environment variable.
+4. **Environment variables**: The [documentation](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#non-prefixed-environment-variables) provided by Microsoft explains how to set these configuration options via environment variables. Jellyfin uses its own custom `JELLYFIN_` prefix for these variables. For example, to set a value for the `HttpListenerHost:DefaultRedirectPath` setting, you would set a value for the `JELLYFIN_HttpListenerHost__DefaultRedirectPath` environment variable.
 5. **Command line options**: Certain command line options are loaded into the configuration system and have the highest priority. The following command line options are mapped to associated configuration options.
 
    - `--nowebclient` sets the `hostwebclient` configuration setting to false

--- a/docs/general/contributing/development.md
+++ b/docs/general/contributing/development.md
@@ -187,7 +187,7 @@ Run each command on a separate line. The container we'll test in is named `jftes
 
 ```sh
 docker exec -ti jftest bash
-apt-get update && apt-get install -y git gnupg curl autoconf g++ make libpng-dev gifsicle automake libtool make gcc musl-dev nasm ca-certificates
+apt-get update && apt-get install -y git gnupg curl autoconf g++ make libpng-dev gifsicle automake libtool gcc musl-dev nasm ca-certificates
 curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 curl -LO https://packages.microsoft.com/config/debian/12/prod.list && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 apt-get update && apt-get install -y dotnet-sdk-8.0
@@ -197,6 +197,7 @@ apt-get update && apt-get install -y nodejs
 cd /opt && git clone https://github.com/jellyfin/jellyfin.git && git clone https://github.com/jellyfin/jellyfin-web.git
 cd jellyfin/ && DOTNET_CLI_TELEMETRY_OPTOUT=1 && DOTNET_CLI_HOME="/tmp/" dotnet publish Jellyfin.Server --configuration Debug --output="/jellyfin" --self-contained --runtime linux-x64
 cd /opt/jellyfin-web && npm install && npm run build:development && cp -r /opt/jellyfin-web/dist /jellyfin/jellyfin-web
+apt-get remove -y gnupg curl && apt-get clean -y autoclean && apt-get autoremove -y
 kill -15 $(pidof jellyfin)
 ```
 

--- a/docs/general/contributing/development.md
+++ b/docs/general/contributing/development.md
@@ -12,7 +12,7 @@ This page details how our repositories are organized, how to get started editing
 There are many projects within the [organization](https://github.com/jellyfin) to browse through for contributions.
 Summarized here are the two biggest ones, one for backend devs and another for frontend devs.
 
-- [Jellyfin Server](https://github.com/jellyfin/jellyfin): The server portion, built using .NET 7 and C#.
+- [Jellyfin Server](https://github.com/jellyfin/jellyfin): The server portion, built using .NET 8 and C#.
 - [Jellyfin Web](https://github.com/jellyfin/jellyfin-web): The main client application built for browsers, but also used in some of our other clients that are just wrappers.
 
 Note that each of the repositories also has its own documentation on how to get started with that project, generally found in the repository README. You can also view the organization [source tree](/docs/general/contributing/source-tree) to see how some of the bigger projects are structured.
@@ -187,13 +187,16 @@ Run each command on a separate line. The container we'll test in is named `jftes
 
 ```sh
 docker exec -ti jftest bash
-apt-get update && apt-get install git gnupg wget apt-transport-https curl autoconf g++ make libpng-dev gifsicle automake libtool make gcc musl-dev nasm
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
-wget -q https://packages.microsoft.com/config/debian/10/prod.list && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
-apt-get update && apt-get install dotnet-sdk-7.0 npm
+apt-get update && apt-get install -y git gnupg wget apt-transport-https curl autoconf g++ make libpng-dev gifsicle automake libtool make gcc musl-dev nasm ca-certificates
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+wget -q https://packages.microsoft.com/config/debian/12/prod.list && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
+apt-get update && apt-get install -y dotnet-sdk-8.0
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+apt-get update && apt-get install -y nodejs
 cd /opt && git clone https://github.com/jellyfin/jellyfin.git && git clone https://github.com/jellyfin/jellyfin-web.git
 cd jellyfin/ && DOTNET_CLI_TELEMETRY_OPTOUT=1 && DOTNET_CLI_HOME="/tmp/" dotnet publish --disable-parallel Jellyfin.Server --configuration Debug --output="/jellyfin" --self-contained --runtime linux-x64
-cd /opt/jellyfin-web && npm install && cp -r /opt/jellyfin-web/dist /jellyfin/jellyfin-web
+cd /opt/jellyfin-web && npm install && npm run build:development && cp -r /opt/jellyfin-web/dist /jellyfin/jellyfin-web
 kill -15 $(pidof jellyfin)
 ```
 

--- a/docs/general/contributing/development.md
+++ b/docs/general/contributing/development.md
@@ -195,7 +195,7 @@ curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dea
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 apt-get update && apt-get install -y nodejs
 cd /opt && git clone https://github.com/jellyfin/jellyfin.git && git clone https://github.com/jellyfin/jellyfin-web.git
-cd jellyfin/ && DOTNET_CLI_TELEMETRY_OPTOUT=1 && DOTNET_CLI_HOME="/tmp/" dotnet publish --disable-parallel Jellyfin.Server --configuration Debug --output="/jellyfin" --self-contained --runtime linux-x64
+cd jellyfin/ && DOTNET_CLI_TELEMETRY_OPTOUT=1 && DOTNET_CLI_HOME="/tmp/" dotnet publish Jellyfin.Server --configuration Debug --output="/jellyfin" --self-contained --runtime linux-x64
 cd /opt/jellyfin-web && npm install && npm run build:development && cp -r /opt/jellyfin-web/dist /jellyfin/jellyfin-web
 kill -15 $(pidof jellyfin)
 ```

--- a/docs/general/contributing/development.md
+++ b/docs/general/contributing/development.md
@@ -189,7 +189,7 @@ Run each command on a separate line. The container we'll test in is named `jftes
 docker exec -ti jftest bash
 apt-get update && apt-get install -y git gnupg curl autoconf g++ make libpng-dev gifsicle automake libtool make gcc musl-dev nasm ca-certificates
 curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-wget -q https://packages.microsoft.com/config/debian/12/prod.list && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
+curl -LO https://packages.microsoft.com/config/debian/12/prod.list && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 apt-get update && apt-get install -y dotnet-sdk-8.0
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list

--- a/docs/general/contributing/development.md
+++ b/docs/general/contributing/development.md
@@ -187,7 +187,7 @@ Run each command on a separate line. The container we'll test in is named `jftes
 
 ```sh
 docker exec -ti jftest bash
-apt-get update && apt-get install -y git gnupg wget apt-transport-https curl autoconf g++ make libpng-dev gifsicle automake libtool make gcc musl-dev nasm ca-certificates
+apt-get update && apt-get install -y git gnupg curl autoconf g++ make libpng-dev gifsicle automake libtool make gcc musl-dev nasm ca-certificates
 curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 wget -q https://packages.microsoft.com/config/debian/12/prod.list && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 apt-get update && apt-get install -y dotnet-sdk-8.0

--- a/docs/general/installation/source.md
+++ b/docs/general/installation/source.md
@@ -72,7 +72,7 @@ This will very likely be split out into a separate repository at some point in t
 
 ## Windows
 
-3. Install dotnet SDK 7.0 from [Microsoft's Website](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) and [install Git for Windows](https://gitforwindows.org/).
+3. Install dotnet SDK 8.0 from [Microsoft's Website](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) and [install Git for Windows](https://gitforwindows.org/).
    You must be on Powershell 3 or higher.
 
 4. From Powershell set the execution policy to unrestricted.


### PR DESCRIPTION
- Docs updated for .NET 8
- Additional Node 20 installation steps added (web project requires it and the docker image still has LTS 18.x in it)
- Add missing frontend build step