### PR TITLE
Update docker volume passthrough info

### DIFF
--- a/docs/general/administration/hardware-acceleration/nvidia.md
+++ b/docs/general/administration/hardware-acceleration/nvidia.md
@@ -372,6 +372,7 @@ Root permission is required.
    /dev/nvidia-modeset:/dev/nvidia-modeset
    /dev/nvidia-uvm:/dev/nvidia-uvm
    /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
+   /dev/nvidia-caps:/dev/nvidia-caps
    ```
 
    :::


### PR DESCRIPTION
I don't actually know what update changed this (might be nvidia drivers update, or whatever) as I updated my distro from one bi-yearly stable version to another (NixOS) and a lot has changed since then, but I recently have to add `nvidia-caps` to the volumes for it to work again. Would be great for someone with better knowledge of how nvidia/docker/jellyfin works to repro what update specifically adds the `/dev/nvidia-caps` volume requirement.