### PR TITLE
Move plugin repositories to src/data

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -299,70 +299,13 @@ Downloads metadata of YouTube videos with a YouTube API key.
 
 ## Repositories
 
+import { OfficialPluginRepositories, ThirdPartyRepositories } from '../../../../src/data/pluginRepositories';
+import PluginRepositoryList from '../../../../src/components/plugins/PluginRepositoryList';
+
 ### Official Jellyfin Plugin Repositories
 
-#### Default Repository
-
-- Manifest
-  - [https://repo.jellyfin.org/releases/plugin/manifest-stable.json](https://repo.jellyfin.org/releases/plugin/manifest-stable.json)
+<PluginRepositoryList repositories={OfficialPluginRepositories} />
 
 ### 3rd-Party Plugin Repositories
 
-#### 9p4's Single-Sign-On (SSO) Repo
-
-- Manifest
-  - [https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/manifest-release/manifest.json](https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/manifest-release/manifest.json)
-- Included Plugins
-  - [9p4's Single Sign On Plugin](https://github.com/9p4/jellyfin-plugin-sso)
-
-#### Ani-Sync Repo
-
-- Manifest
-  - [https://raw.githubusercontent.com/vosmiic/jellyfin-ani-sync/master/manifest.json](https://raw.githubusercontent.com/vosmiic/jellyfin-ani-sync/master/manifest.json)
-- Included Plugins
-  - [Ani-Sync](https://github.com/vosmiic/jellyfin-ani-sync)
-
-#### danieladov's Repo
-
-- Manifest
-  - [https://raw.githubusercontent.com/danieladov/JellyfinPluginManifest/master/manifest.json](https://raw.githubusercontent.com/danieladov/JellyfinPluginManifest/master/manifest.json)
-- Included Plugins
-  - [Merge Versions](https://github.com/danieladov/jellyfin-plugin-mergeversions)
-  - [Skin Manager](https://github.com/danieladov/jellyfin-plugin-skin-manager)
-  - [Theme Songs](https://github.com/danieladov/jellyfin-plugin-themesongs)
-
-#### dkanada's Repo
-
-- Manifest
-  - [https://raw.githubusercontent.com/dkanada/jellyfin-plugin-intros/master/manifest.json](https://raw.githubusercontent.com/dkanada/jellyfin-plugin-intros/master/manifest.json)
-- Included Plugins
-  - [Intros](https://github.com/dkanada/jellyfin-plugin-intros)
-
-#### k-matti's Repo
-
-- Manifest
-  - [https://raw.githubusercontent.com/k-matti/jellyfin-plugin-repository/master/manifest.json](https://raw.githubusercontent.com/k-matti/jellyfin-plugin-repository/master/manifest.json)
-- Included Plugins
-  - [SMS Notifications](https://github.com/k-matti/jellyfin-plugin-sms)
-  - [NapiSub](https://github.com/k-matti/jellyfin-plugin-napi)
-
-#### LinFor's Repo
-
-- Manifest
-  - [https://raw.githubusercontent.com/LinFor/jellyfin-plugin-kinopoisk/master/dist/manifest.json](https://raw.githubusercontent.com/LinFor/jellyfin-plugin-kinopoisk/master/dist/manifest.json)
-- Included Plugins
-  - [Kinopoisk metadata plugin](https://github.com/LinFor/jellyfin-plugin-kinopoisk)
-
-#### LizardByte's Repo
-
-- Manifest
-  - [https://app.lizardbyte.dev/jellyfin-plugin-repo/manifest.json](https://app.lizardbyte.dev/jellyfin-plugin-repo/manifest.json)
-- Included Plugins
-  - [Themerr](https://github.com/LizardByte/themerr-jellyfin)
-
-#### ShokoAnime's Repo
-
-- Manifest
-  - [https://raw.githubusercontent.com/ShokoAnime/Shokofin/master/manifest.json](https://raw.githubusercontent.com/ShokoAnime/Shokofin/master/manifest.json)
-- Included Plugins
-  - [Shokofin](https://github.com/ShokoAnime/Shokofin)
+<PluginRepositoryList repositories={ThirdPartyRepositories} />

--- a/src/components/plugins/PluginRepositoryDetails.tsx
+++ b/src/components/plugins/PluginRepositoryDetails.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import DetailsCard from '../common/DetailsCard';
+import { PluginRepository } from '../../data/pluginRepositories';
+
+const PluginRepositoryDetails = ({ repository }: { repository: PluginRepository }) => (
+  <DetailsCard
+    id={repository.id}
+    title={repository.name}
+    badges={
+      <>
+        {repository.official ? (
+          <span className='badge badge--primary margin-right--sm'>Official</span>
+        ) : (
+          <span className='badge badge--secondary margin-right--sm'>Third Party</span>
+        )}
+        {repository.unstable && <span className='badge badge--warning margin-right--sm'>Unstable</span>}
+      </>
+    }
+    description={
+      <>
+        <span>Repository URL</span>
+        <pre>{repository.url}</pre>
+
+        {Object.entries(repository.includes).length > 0 && (
+          <>
+            <h4>Includes</h4>
+            <ul>
+              {Object.entries(repository.includes).map(([name, url]) => (
+                <li key={url}>
+                  <a href={url} target='_blank' rel='noreferrer'>
+                    {name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </>
+    }
+  />
+);
+
+export default PluginRepositoryDetails;

--- a/src/components/plugins/PluginRepositoryList.tsx
+++ b/src/components/plugins/PluginRepositoryList.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { PluginRepository } from '../../data/pluginRepositories';
+import PluginRepositoryDetails from './PluginRepositoryDetails';
+
+const PluginRepositoryList = ({ repositories }: { repositories: Array<PluginRepository> }) => (
+  <>
+    {repositories.map((repository) => (
+      <PluginRepositoryDetails key={repository.id} repository={repository} />
+    ))}
+  </>
+);
+
+export default PluginRepositoryList;

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -1,0 +1,101 @@
+export type PluginRepository = {
+  id: string;
+  official?: boolean;
+  unstable?: boolean;
+  name: string;
+  url: string;
+  includes: Record<string, string>;
+};
+
+export type PluginRepositoryIncluded = {
+  name: string;
+  url: string;
+};
+
+export const OfficialPluginRepositories: Array<PluginRepository> = [
+  {
+    id: 'jellyfin',
+    name: 'Jellyfin',
+    official: true,
+    url: 'https://repo.jellyfin.org/releases/plugin/manifest-stable.json',
+    includes: {}
+  },
+  {
+    id: 'jellyfin-unstable',
+    name: 'Jellyfin Unstable',
+    official: true,
+    unstable: true,
+    url: 'https://repo.jellyfin.org/releases/plugin/manifest-unstable.json',
+    includes: {}
+  }
+];
+
+export const ThirdPartyRepositories: Array<PluginRepository> = [
+  {
+    id: 'gh:9p4/jellyfin-plugin-sso',
+    name: "9p4's Single-Sign-On (SSO) Repo",
+    url: 'https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/manifest-release/manifest.json',
+    includes: {
+      "9p4's Single Sign On Plugin": 'https://github.com/9p4/jellyfin-plugin-sso'
+    }
+  },
+  {
+    id: 'gh:vosmiic/jellyfin-ani-sync',
+    name: 'Ani-Sync Repo',
+    url: 'https://raw.githubusercontent.com/vosmiic/jellyfin-ani-sync/master/manifest.json',
+    includes: {
+      'Ani-Sync': 'https://github.com/vosmiic/jellyfin-ani-sync'
+    }
+  },
+  {
+    id: 'gh:danieladov/JellyfinPluginManifest',
+    name: "danieladov's Repo",
+    url: 'https://raw.githubusercontent.com/danieladov/JellyfinPluginManifest/master/manifest.json',
+    includes: {
+      'Merge Versions': 'https://github.com/danieladov/jellyfin-plugin-mergeversions',
+      'Skin Manager': 'https://github.com/danieladov/jellyfin-plugin-skin-manager',
+      'Theme Songs': 'https://github.com/danieladov/jellyfin-plugin-themesongs'
+    }
+  },
+  {
+    id: 'gh:dkanada/jellyfin-plugin-intros',
+    name: "dkanada's Repo",
+    url: 'https://raw.githubusercontent.com/dkanada/jellyfin-plugin-intros/master/manifest.json',
+    includes: {
+      Intros: 'https://github.com/dkanada/jellyfin-plugin-intros'
+    }
+  },
+  {
+    id: 'gh:k-matti/jellyfin-plugin-repository',
+    name: "k-matti's Repo",
+    url: 'https://raw.githubusercontent.com/k-matti/jellyfin-plugin-repository/master/manifest.json',
+    includes: {
+      'SMS Notifications': 'https://github.com/k-matti/jellyfin-plugin-sms',
+      NapiSub: 'https://github.com/k-matti/jellyfin-plugin-napi'
+    }
+  },
+  {
+    id: 'gh:LinFor/jellyfin-plugin-kinopoisk',
+    name: "LinFor's Repo",
+    url: 'https://raw.githubusercontent.com/LinFor/jellyfin-plugin-kinopoisk/master/dist/manifest.json',
+    includes: {
+      'Kinopoisk metadata plugin': 'https://github.com/LinFor/jellyfin-plugin-kinopoisk'
+    }
+  },
+  {
+    id: 'lizardbyte.dev',
+    name: "LizardByte's Repo",
+    url: 'https://app.lizardbyte.dev/jellyfin-plugin-repo/manifest.json',
+    includes: {
+      Themerr: 'https://github.com/LizardByte/themerr-jellyfin'
+    }
+  },
+  {
+    id: 'gh:ShokoAnime/Shokofin',
+    name: "ShokoAnime's Repo",
+    url: 'https://raw.githubusercontent.com/ShokoAnime/Shokofin/master/manifest.json',
+    includes: {
+      Shokofin: 'https://github.com/ShokoAnime/Shokofin'
+    }
+  }
+];


### PR DESCRIPTION
Move information about plugin repositories to a structured file (pluginRepositories.ts), just like the clients and server downloads.

End-goal is to generate the plugins from this information with support for filtering. Still figuring out how I want to do that though (either on Docusaurus build or a GH actions workflow updating the data).

How the plugins documentation page it will look with this PR:

![Untitled](https://github.com/jellyfin/jellyfin.org/assets/2305178/e82ea610-966d-4440-9691-9418fea5c4e5)
