### PR TITLE
Fix: link from shows to movies#3d-movies

### DIFF
--- a/docs/general/server/media/shows.md
+++ b/docs/general/server/media/shows.md
@@ -171,7 +171,7 @@ Trailers support a special option if you only have a single file of that type pe
 
 ## 3D Videos
 
-Please refer to ['3D Movies' in the movies section](/docs/general/server/media/movies#3D-Movies)
+Please refer to ['3D Movies' in the movies section](/docs/general/server/media/movies#3d-movies)
 
 ## Images
 


### PR DESCRIPTION
Fixes the link from `docs/general/server/media/shows#3d-videos` to `docs/general/server/media/movies#3d-movies`