### PR TITLE
add demo user & password under the "See it in action" button

### DIFF
--- a/src/components/common/Hero.scss
+++ b/src/components/common/Hero.scss
@@ -67,6 +67,13 @@
   margin-bottom: 0;
 }
 
+#demo_userpass_span {
+  opacity: 0.75;
+  line-height: 1.7;
+  font-size: 0.9em;
+  font-style: italic;
+}
+
 .hero__buttons {
   display: flex;
   justify-content: center;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,6 +28,9 @@ export default function Home() {
             Download Now
           </Link>
         </div>
+        <span id="demo_userpass_span" className='hero__text margin-vert--lg'>
+          Note: To signin to the demo, the user is "demo" (without quotes) and leave password field blank
+        </span>
       </Hero>
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
the user and password wasn't mentioned near the demo button causing confusion.

In the index page, the demo button is present, however when clicking it, neither it show the user and password to the user, nor the demo server shows the user and password. For first time user, it will be very confusing. I also had to guess the credentials.