### PR TITLE
Update portable installation instructions for macOS

### DIFF
--- a/docs/general/installation/macos.md
+++ b/docs/general/installation/macos.md
@@ -44,11 +44,12 @@ This will delete all settings and user information. This applies for the .app pa
 
 **Portable Version**
 
-1. Download the latest version
-2. Extract it into the Applications folder
-3. Open Terminal and type `cd` followed with a space then drag the jellyfin folder into the terminal.
-4. Type `./jellyfin` to run jellyfin.
-5. Open your browser at [http://localhost:8096](http://localhost:8096)
+1. Install the `.NET Runtime` and `ASP.NET Core Runtime` version 6.0. This can also be accomplished by installing the `.NET SDK` which includes both of these runtimes. Links to the official download page can be found [here](https://dotnet.microsoft.com/en-us/download/dotnet/6.0). Ensure you add the installation directory to your `PATH` variable.
+2. Download the latest version of Jellyfin.
+3. Extract it into the Applications folder.
+4. Open Terminal and type `cd` followed with a space then drag the jellyfin folder into the terminal.
+5. Type `dotnet jellyfin.dll` to run jellyfin.
+6. Open your browser at [http://localhost:8096](http://localhost:8096).
 
 Closing the terminal window will end Jellyfin. Running Jellyfin in screen or tmux can prevent this from happening.
 


### PR DESCRIPTION
While installing the portable version, I found that the installation instructions were out of date and referred to when a precompiled binary was [distributed back in version 10.7 of Jellyfin](https://github.com/jellyfin/jellyfin-server-macos/releases/). Since that is no longer up to date, I've updated the instructions for the current provided source. I figured this out through some trial and error, so it might not line up with the existing installation instructions, so please let me know if anything needs to be changed :)