### PR TITLE
Require core to approve blog posts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
+blog/                                  @jellyfin/core
 docs/general/about.md                  @jellyfin/core
 docs/general/community-standards.md    @joshuaboniface


### PR DESCRIPTION
Probably a good practice in general as the blog is a face of the project.