### PR TITLE
feat: add hwa doc for apple platforms

### DIFF
--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -11,11 +11,11 @@ This tutorial guides you on setting up full video hardware acceleration on Apple
 
 [VideoToolbox](https://developer.apple.com/documentation/videotoolbox) is the only available method on macOS.
 
-To achieve full acceleration, [Metal](https://developer.apple.com/metal/) and OpenCL is also required.
+To achieve full acceleration, [Metal](https://developer.apple.com/metal/) and OpenCL are also required.
 
 ## Tone-mapping Methods
 
-Hardware accelerated HDR/DV to SDR tone-mapping is supported on most Macs from 2017 and later, with the exception of the MacBook Air (13-inch, 2017).
+Hardware accelerated HDR to SDR tone-mapping is supported on all Macs from 2017 and later, with the exception of the MacBook Air (13-inch, 2017).
 
 There are two different methods that can be used. Pros and cons are listed below:
 
@@ -71,9 +71,7 @@ There is no hardware accelerated path for AV1 on macOS at the moment. Although t
 
 ## macOS Setups
 
-Although there is no hard requirement for the macOS version, we recommend **macOS 12 and later**.
-
-Jellyfin's custom ffmpeg may work on earlier versions, but the functionality cannot be guaranteed.
+**MacOS 12 and later** are officially supported. Older versions might work, but are not supported.
 
 ### Configure
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -73,7 +73,7 @@ On legacy Intel Macs, you may encounter performance issues with tone-mapping usi
 
 <sup>1</sup> Using prefer speed encoder preset.
 
-<sup>2</sup> The simultaneous session count is a soft limit. You can run more sessions if you are willing to accept the per-session performance trade-offs.
+<sup>2</sup> The simultaneous session count is a soft limit. You can run more sessions if you want, but the transcoding performance of each session may be reduced to a point where video playback starts to stutter.
 
 ## macOS Setups
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -43,7 +43,7 @@ To have native Apple Silicon support, Jellyfin server 10.9.0+ and `jellyfin-ffmp
 
 While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
 
-<sup>*</sup> On very old Macs, VideoToolbox may fallback to software decoding/encoding. Macs from 2017 and later is strongly recommend.
+<sup>*</sup> VideoToolbox may fall back to software decoding/encoding when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later are strongly recommended.
 
 ### Transcode H.264
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -43,7 +43,7 @@ To have native Apple Silicon support, Jellyfin server 10.9.0+ and `jellyfin-ffmp
 
 While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
 
-If your Mac does not have an internal display, you may need to connect it to a monitor or use an HDMI dummy plug to prevent the GPU from being throttled.
+If your Mac does not have an internal display, you may need to connect it to a monitor or use a dummy plug to prevent the GPU from being throttled.
 
 <sup>*</sup> VideoToolbox may fallback to software decoding/encoding or stop working when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later, especially Apple Silicon Macs are strongly recommended.
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -43,6 +43,8 @@ To have native Apple Silicon support, Jellyfin server 10.9.0+ and `jellyfin-ffmp
 
 While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
 
+If your Mac does not have an internal display, you may need to connect it to a monitor or use an HDMI dummy plug to prevent the GPU from being throttled.
+
 <sup>*</sup> VideoToolbox may fallback to software decoding/encoding or stop working when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later, especially Apple Silicon Macs are strongly recommended.
 
 ### Transcode H.264

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -63,15 +63,17 @@ There is no hardware accelerated path for AV1 on macOS at the moment. Although t
 
 ### Performance Consideration
 
-An Apple Silicon-based Mac is preferred in most cases. Even an entry-level M1 can handle three 4K 24fps Dolby Vision HEVC 10-bit transcoding tasks simultaneously while performing tone-mapping to SDR.<sup>*</sup>
+An Apple Silicon-based Mac is preferred in most cases. Even an entry-level M1 can handle three 4K 24fps Dolby Vision HEVC 10-bit transcoding tasks simultaneously while performing tone-mapping to SDR.<sup>1</sup> <sup>2</sup>
 
-The "Max" variant chips come with an additional video encoding engine. VideoToolbox can utilize this extra engine even when there is only a single transcoding session, enabling support for 4K 120fps transcoding and tone-mapping.<sup>*</sup>
+The "Max" variant chips come with an additional video encoding engine. VideoToolbox can utilize this extra engine even when there is only a single transcoding session, enabling support for 4K 120fps transcoding and tone-mapping.<sup>1</sup>
 
 The "Ultra" variant chips feature 2 video decoding engines and 4 video encoding engines, effectively doubling the capability compared to the "Max" variant chips.
 
 On legacy Intel Macs, you may encounter performance issues with tone-mapping using Metal on 4K videos if your Mac doesn't have an AMD GPU. However, it is still adequate for transcoding SDR videos.
 
-<sup>*</sup> Using prefer speed encoder preset.
+<sup>1</sup> Using prefer speed encoder preset.
+
+<sup>2</sup> The simultaneous session count is a soft limit. You can run more sessions if you are willing to accept the per-session performance trade-offs.
 
 ## macOS Setups
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -27,9 +27,9 @@ There are two different methods that can be used. Pros and cons are listed below
 
 2. **VideoToolbox Native**
 
-   - Pros - Lower power consumption, more performant, good visual quality without manual fine-tuning.
+   - Pros: Lower power consumption, less dependency on GPU performance, good visual quality without manual fine-tuning.
 
-   - Cons - No tuning options, might work badly on Intel Macs.
+   - Cons: Lack of tuning options, potential performance issues on Intel Macs.
 
 :::note
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -43,7 +43,7 @@ To have native Apple Silicon support, Jellyfin server 10.9.0+ and `jellyfin-ffmp
 
 While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
 
-<sup>*</sup> VideoToolbox may fallback to software decoding/encoding when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later are strongly recommended.
+<sup>*</sup> VideoToolbox may fallback to software decoding/encoding or stop working when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later are strongly recommended.
 
 ### Transcode H.264
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -23,7 +23,7 @@ There are two different methods that can be used. Pros and cons are listed below
 
    - Pros: Supports Dolby Vision P5, detailed fine-tuning options.
 
-   - Cons: Slower on low end GPU, especially on Intel iGPUs.
+   - Cons: Slower on low end GPUs, especially on Intel iGPUs.
 
 2. **VideoToolbox Native**
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -43,7 +43,7 @@ To have native Apple Silicon support, Jellyfin server 10.9.0+ and `jellyfin-ffmp
 
 While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
 
-<sup>*</sup> VideoToolbox may fallback to software decoding/encoding or stop working when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later are strongly recommended.
+<sup>*</sup> VideoToolbox may fallback to software decoding/encoding or stop working when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later, especially Apple Silicon Macs are strongly recommended.
 
 ### Transcode H.264
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -81,8 +81,7 @@ On legacy Intel Macs, you may encounter performance issues with tone-mapping usi
 
 ### Configure
 
-- Enable VideoToolbox in Jellyfin and uncheck unsupported codecs.
-  - Disable `MPEG4`, `MPEG2`, and `VC-1`, as VideoToolbox lacks a hardware-accelerated decoding path for these codecs.
+- Enable VideoToolbox in the Jellyfin Dashboard under the Playback section and deselect unsupported codecs for your Mac.
 - Check `Enable VideoToolbox Tone mapping` if you want to use VideoToolbox native tone-mapping.
 - Check `Enable Tone mapping` if you want to use Metal-based tone-mapping.
 - Optionally, select an `Encoding Preset`. The `veryslow`, `slower`, `slow`, and `medium` presets prioritize quality, while `fast`, `faster`, `veryfast`, `superfast`, and `ultrafast` prioritize speed. The default `Auto` setting prioritizes speed.

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -43,7 +43,7 @@ To have native Apple Silicon support, Jellyfin server 10.9.0+ and `jellyfin-ffmp
 
 While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
 
-<sup>*</sup> VideoToolbox may fall back to software decoding/encoding when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later are strongly recommended.
+<sup>*</sup> VideoToolbox may fallback to software decoding/encoding when the task exceeds its hardware capability. The older your Mac, the more this will occur. Macs from 2017 and later are strongly recommended.
 
 ### Transcode H.264
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -1,0 +1,94 @@
+---
+uid: admin-hardware-acceleration-apple
+title: Apple Mac
+---
+
+# HWA Tutorial On Mac
+
+This tutorial guides you on setting up full video hardware acceleration on Apple Macs via VideoToolbox.
+
+## Acceleration Methods
+
+[VideoToolbox](https://developer.apple.com/documentation/videotoolbox) is the only available method on macOS.
+
+To achieve full acceleration, [Metal](https://developer.apple.com/metal/) and OpenCL is also required.
+
+## Tone-mapping Methods
+
+Hardware accelerated HDR/DV to SDR tone-mapping is supported on most Macs from 2017 and later, with the exception of the MacBook Air (13-inch, 2017).
+
+There are two different methods that can be used. Pros and cons are listed below:
+
+1. **OpenCL**
+
+   - Pros - Supports Dolby Vision P5, detailed fine-tuning options.
+
+   - Cons - Slower, requires more powerful GPUs.
+
+2. **VideoToolbox Native**
+
+   - Pros - Lower power consumption, more performant, good visual quality without manual fine-tuning.
+
+   - Cons - No tuning options, might work badly on Intel Macs.
+
+:::note
+
+When both methods are enabled, VideoToolbox Native will be used for most videos, and OpenCL will only be used as a fallback for Dolby Vision Profile 5 videos.
+
+:::
+
+## Select System Hardware
+
+Hardware accelerated transcoding is supported on all Macs that support [VideoToolbox](https://developer.apple.com/documentation/videotoolbox). This includes most 2011 and later Macs.<sup>*</sup>
+
+Full acceleration is available on most Macs from 2017 and later, with the exception of the MacBook Air (13-inch, 2017).
+
+To have native Apple Silicon support, Jellyfin server 10.9.0+ and the latest `jellyfin-ffmpeg6` is required.
+
+<sup>*</sup> On very old Macs, VideoToolbox may fallback to software decoding/encoding. Macs from 2017 and later is strongly recommend.
+
+:::note
+
+While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
+
+:::
+
+### Transcode H.264
+
+AVC / H.264 8-bit is still widely used due to its excellent compatibility. All Intel GPUs that support QSV can decode and encode it.
+
+Any VideoToolbox-supported Mac supports decoding and encoding H.264 8-bit.
+
+### Transcode HEVC
+
+HEVC / H.265 remains the first choice for storing 4K 10-bit, HDR and Dolby Vision video. It has mature software encoding support thanks to [x265](https://x265.readthedocs.io/en/master/), as well as the widely implemented hardware encoding support in most GPUs released after 2016.
+
+Macs from 2017 and later, excluding the MacBook Air (13-inch, 2017), support decoding and encoding HEVC.
+
+### Transcode AV1
+
+There is no hardware accelerated path for AV1 on macOS at the moment. Although the M3 series added AV1 decoding support, [ffmpeg does not support it yet](https://trac.ffmpeg.org/ticket/10642).
+
+## macOS Setups
+
+Although there is no hard requirement for the macOS version, we recommend **macOS 12 and later**.
+
+Jellyfin's custom ffmpeg may work on earlier versions, but the functionality cannot be guaranteed.
+
+### Configure
+
+- Enable VideoToolbox in Jellyfin and uncheck the unsupported codecs.
+
+### Verify
+
+1. Play a video in the Jellyfin web client and trigger video transcoding by setting a lower resolution or bitrate.
+
+2. Open the "Activity Monitor" and search for ffmpeg.
+
+3. If ffmpeg is not using a few hundred percent CPU, then hardware acceleration is working.
+
+:::note
+
+It would be normal if you see the GPU usage close to 0. For pure transcoding, everything is performed on a dedicated accelerator, and that will not count as GPU usage under macOS.
+
+:::

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -94,10 +94,4 @@ On legacy Intel Macs, you may encounter performance issues with tone-mapping usi
 
 2. Open the "Activity Monitor" and search for ffmpeg.
 
-3. If ffmpeg is not using a few hundred percent CPU, then hardware acceleration is working.
-
-:::note
-
-It would be normal if you see the GPU usage close to 0. For pure transcoding, everything is performed on a dedicated accelerator, and that will not count as GPU usage under macOS.
-
-:::
+3. If ffmpeg is not using a few hundred percent CPU, then hardware acceleration is working. It is normal to see the GPU usage close to 0. For pure transcoding, everything is performed on a dedicated accelerator, and that will not count as GPU usage under macOS.

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -21,21 +21,17 @@ There are two different methods that can be used. Pros and cons are listed below
 
 1. **OpenCL**
 
-   - Pros - Supports Dolby Vision P5, detailed fine-tuning options.
+   - Pros: Supports Dolby Vision P5, detailed fine-tuning options.
 
-   - Cons - Slower, requires more powerful GPUs.
+   - Cons: Slower, requires more powerful GPUs.
 
 2. **VideoToolbox Native**
 
    - Pros: Lower power consumption, less dependency on GPU performance, good visual quality without manual fine-tuning.
 
-   - Cons: Lack of tuning options, potential performance issues on Intel Macs.
-
-:::note
+   - Cons: Lack of tuning options, potential performance issues on Intel Macs, does not support Dolby Vision P5.
 
 When both methods are enabled, VideoToolbox Native will be used for most videos, and OpenCL will only be used as a fallback for Dolby Vision Profile 5 videos.
-
-:::
 
 ## Select System Hardware
 
@@ -45,17 +41,13 @@ Full acceleration is available on most Macs from 2017 and later, with the except
 
 To have native Apple Silicon support, Jellyfin server 10.9.0+ and the latest `jellyfin-ffmpeg6` is required.
 
-<sup>*</sup> On very old Macs, VideoToolbox may fallback to software decoding/encoding. Macs from 2017 and later is strongly recommend.
-
-:::note
-
 While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
 
-:::
+<sup>*</sup> On very old Macs, VideoToolbox may fallback to software decoding/encoding. Macs from 2017 and later is strongly recommend.
 
 ### Transcode H.264
 
-AVC / H.264 8-bit is still widely used due to its excellent compatibility. All Intel GPUs that support QSV can decode and encode it.
+AVC / H.264 8-bit is still widely used due to its excellent compatibility. Most GPUs after 2011 can decode and encode it.
 
 Any VideoToolbox-supported Mac supports decoding and encoding H.264 8-bit.
 

--- a/docs/general/administration/hardware-acceleration/apple.md
+++ b/docs/general/administration/hardware-acceleration/apple.md
@@ -39,7 +39,7 @@ Hardware accelerated transcoding is supported on all Macs that support [VideoToo
 
 Full acceleration is available on most Macs from 2017 and later, with the exception of the MacBook Air (13-inch, 2017).
 
-To have native Apple Silicon support, Jellyfin server 10.9.0+ and the latest `jellyfin-ffmpeg6` is required.
+To have native Apple Silicon support, Jellyfin server 10.9.0+ and `jellyfin-ffmpeg6` 6.0.1-4 or higher is required.
 
 While hardware acceleration via VideoToolbox might work on older series Macs, it is not officially supported.
 

--- a/docs/general/administration/hardware-acceleration/index.md
+++ b/docs/general/administration/hardware-acceleration/index.md
@@ -70,6 +70,7 @@ Partial acceleration may result in slightly higher CPU usage and lower transcodi
 Jellyfin 10.8 supports full acceleration on mainstream Intel, NVIDIA and AMD (Windows only) GPUs.
 
 Jellyfin 10.9 enables full acceleration for:
+
 - AMD Polaris and newer GPUs on Linux via VA-API and Vulkan interop
 - Rockchip VPU of RK3588/3588S
 - Intel and Apple Silicon Macs on macOS 12 and above

--- a/docs/general/administration/hardware-acceleration/index.md
+++ b/docs/general/administration/hardware-acceleration/index.md
@@ -69,11 +69,10 @@ Partial acceleration may result in slightly higher CPU usage and lower transcodi
 
 Jellyfin 10.8 supports full acceleration on mainstream Intel, NVIDIA and AMD (Windows only) GPUs.
 
-<<<<<<< HEAD
-Jellyfin 10.9 enables full acceleration for AMD Polaris and newer GPUs on Linux via VA-API and Vulkan interop and full acceleration for the Rockchip VPU of RK3588/3588S.
-=======
-Jellyfin 10.9 enables full acceleration for AMD Polaris and newer GPUs on Linux via VA-API and Vulkan interop and full acceleration for both Intel and Apple Silicon Macs on macOS 12 and above.
->>>>>>> ea88c92 (feat: add hwa doc for apple platforms)
+Jellyfin 10.9 enables full acceleration for:
+- AMD Polaris and newer GPUs on Linux via VA-API and Vulkan interop
+- Rockchip VPU of RK3588/3588S
+- Intel and Apple Silicon Macs on macOS 12 and above
 
 Using [jellyfin-ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg/releases) with Jellyfin is highly recommended, which has a `-Jellyfin` suffix in the version string.
 

--- a/docs/general/administration/hardware-acceleration/index.md
+++ b/docs/general/administration/hardware-acceleration/index.md
@@ -69,14 +69,18 @@ Partial acceleration may result in slightly higher CPU usage and lower transcodi
 
 Jellyfin 10.8 supports full acceleration on mainstream Intel, NVIDIA and AMD (Windows only) GPUs.
 
+<<<<<<< HEAD
 Jellyfin 10.9 enables full acceleration for AMD Polaris and newer GPUs on Linux via VA-API and Vulkan interop and full acceleration for the Rockchip VPU of RK3588/3588S.
+=======
+Jellyfin 10.9 enables full acceleration for AMD Polaris and newer GPUs on Linux via VA-API and Vulkan interop and full acceleration for both Intel and Apple Silicon Macs on macOS 12 and above.
+>>>>>>> ea88c92 (feat: add hwa doc for apple platforms)
 
 Using [jellyfin-ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg/releases) with Jellyfin is highly recommended, which has a `-Jellyfin` suffix in the version string.
 
 ```shell
 $ /usr/lib/jellyfin-ffmpeg/ffmpeg
 
-ffmpeg version 5.1.2-Jellyfin Copyright (c) 2000-2022 the FFmpeg developers
+ffmpeg version 6.0.1-Jellyfin Copyright (c) 2000-2023 the FFmpeg developers
   built with gcc 12.2.0 (crosstool-NG 1.25.0.90_cf9beb1)
 ...
 ```
@@ -120,6 +124,10 @@ Click [AMD GPU](/docs/general/administration/hardware-acceleration/amd).
 ### NVIDIA NVENC
 
 Click [NVIDIA GPU](/docs/general/administration/hardware-acceleration/nvidia).
+
+### Apple VideoToolbox
+
+Click [Apple Mac](/docs/general/administration/hardware-acceleration/apple).
 
 ### Rockchip RKMPP
 
@@ -172,12 +180,13 @@ Dolby Vision (P5 & P8) to SDR tone-mapping is supported in Jellyfin 10.8 and req
 
 :::
 
-| OS/Platform    | NVIDIA NVENC | AMD AMF | Intel QSV | Intel VA-API | AMD VA-API | Rockchip RKMPP | Software |
-| -------------- | ------------ | ------- | --------- | ------------ | ---------- | -------------- | -------- |
-| Windows        | ✔️            | ✔️       | ✔️         | N/A          | N/A        | N/A            | WIP      |
-| Windows Docker | ✔️            | N/A     | N/A       | N/A          | N/A        | N/A            | WIP      |
-| Linux          | ✔️            | ✔️       | ✔️         | ✔️            | ✔️          | ✔️              | WIP      |
-| Linux Docker   | ✔️            | ✔️       | ✔️         | ✔️            | ✔️          | ✔️              | WIP      |
+| OS/Platform    | NVIDIA NVENC | AMD AMF | Intel QSV | Intel VA-API | AMD VA-API |Apple VideoToolbox| Rockchip RKMPP | Software |
+| -------------- | ------------ | ------- | --------- | ------------ | ---------- | ---------------- | -------------- | -------- |
+| Windows        | ✔️           | ✔️      | ✔️        | N/A          | N/A        | N/A              | N/A           | WIP      |
+| Windows Docker | ✔️           | N/A     | N/A       | N/A          | N/A        | N/A              | N/A            | WIP      |
+| Linux          | ✔️           | ✔️      | ✔️        | ✔️           | ✔️        | N/A              | ✔️             | WIP      |
+| Linux Docker   | ✔️           | ✔️      | ✔️        | ✔️           | ✔️        | N/A              | ✔️             | WIP      |
+| macOS          | N/A          | N/A     | N/A       | N/A          | N/A        | ✔️               | N/A            | WIP      |
 
 ## Tips For Hardware Acceleration
 

--- a/docs/general/administration/hardware-selection.md
+++ b/docs/general/administration/hardware-selection.md
@@ -17,7 +17,7 @@ For a Jellyfin server, the following is recommended:
 - CPU (Without dGPU): Intel Pentium G4560, Intel Core i3-7100 or better. (Intel 7th gen or newer Pentium or better, excluding J and N series)
 - RAM: 8GB or more
 - Storage: 60GB SSD storage for Jellyfin files and transcoding cache.
-- Graphics: Intel HD 6xx (7th gen integrated graphics) or newer, Nvidia GTX 16 / RTX 20 series or newer (excluding GTX 1650). Intel is recommended over Nvidia. AMD and Apple Silicon are not recommended.
+- Graphics: Intel HD 6xx (7th gen integrated graphics) or newer, Nvidia GTX 16 / RTX 20 series or newer (excluding GTX 1650). Intel is recommended over Nvidia. AMD is not recommended.
 
 :::note Intel "Atom" CPUs
 
@@ -43,15 +43,11 @@ Intel ARC GPUs are recommended when upgrading an existing system to be used as a
 
 :::
 
-:::tip Fully Utilizing Intel-based Macs
-
-It is recommended that Intel-based macs be used with Windows or Linux installed to host Jellyfin. Many hardware acceleration features aren't available on MacOS due to the custom [jellyfin-ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg) fork not being available.
-
-:::
-
 ### Low Power Applications
 
 For low power applications, Intel 12th gen or newer Atom CPUs with integrated graphics are recommended. It is also recommended that [Low Power Encoding](/docs/general/administration/hardware-acceleration/intel/#low-power-encoding) be setup.
+
+Alternatively, you can use an Apple Silicon Mac for even lower power consumption.
 
 :::caution SBCs (Single Board Computers)
 
@@ -175,21 +171,23 @@ Please check the product page of your CPU for more info.
 
 Supported codecs are listed below:
 
-| Codec       | M1, M2 Family | M3 Family |
-| ----------- | ------------- | --------- |
-| H.264 8bit  | ✅            | ✅        |
-| H.264 10bit | 🔶            | 🔶        |
-| H.265 8bit  | ✅            | ✅        |
-| H.265 10bit | ✅            | ✅        |
-| VP9 8bit    | 🔶            | 🔶        |
-| VP9 10bit   | 🔶            | 🔶        |
-| AV1         | ❌            | 🔶        |
+| Codec       | M1, M2 Family | M3 Family     |
+| ----------- | ------------- | ---------     |
+| H.264 8bit  | ✅            | ✅            |
+| H.264 10bit | 🔶            | 🔶            |
+| H.265 8bit  | ✅            | ✅            |
+| H.265 10bit | ✅            | ✅            |
+| VP9 8bit    | 🔶            | 🔶            |
+| VP9 10bit   | 🔶            | 🔶            |
+| AV1         | ❌            | ❌<sup>1</sup>|
 
 ✅ = Encode + Decode, 🔶 = Decode Only, ❌ = Not Supported.
 
+<sup>1</sup> Although the hardware does support AV1 decoding, [ffmpeg does not support it yet](https://trac.ffmpeg.org/ticket/10642).
+
 :::caution
 
-Many hardware acceleration features are not available on macOS for Jellyfin, as the custom [jellyfin-ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg) fork isn't available for macOS. No Apple Silicon media engine drivers exist for other operating systems currently. You will NOT be able to use hardware acceleration if you are running [Asahi Linux](https://asahilinux.org/).
+No Apple Silicon media engine drivers currently exist for non-macOS operating systems. You will NOT be able to use hardware acceleration if you are running [Asahi Linux](https://asahilinux.org/).
 
 :::
 

--- a/docs/general/installation/macos.md
+++ b/docs/general/installation/macos.md
@@ -12,8 +12,10 @@ sidebar_position: 5
 macOS Application packages and builds in TAR archive format are available [here](/downloads/macos).
 
 Jellyfin requires macOS 12 or newer to run.
+Jellyfin 10.9 or newer is required for Apple Silicon native support.
 
 ## Packaged Version(dmg)
+=======
 
 ### Install
 

--- a/docs/general/installation/macos.md
+++ b/docs/general/installation/macos.md
@@ -15,7 +15,6 @@ Jellyfin requires macOS 12 or newer to run.
 Jellyfin 10.9 or newer is required for Apple Silicon native support.
 
 ## Packaged Version(dmg)
-=======
 
 ### Install
 


### PR DESCRIPTION
Update the docs to include hardware acceleration docs for Apple platforms in the upcoming 10.9 release.