### PR TITLE
Fix typo in podman hardware acceleration section

### DIFF
--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -231,9 +231,9 @@ As always it is recommended to run the container rootless. Therefore we want to 
 
 ### With hardware acceleration
 
-To use hardware acceleration, you need to allow the container to access the render device. If you are using container-selinux-2.226 or later, you have to set the `container_use_dri_device` flag in selinux or the container will not be able to use it:
+To use hardware acceleration, you need to allow the container to access the render device. If you are using container-selinux-2.226 or later, you have to set the `container_use_dri_devices` flag in selinux or the container will not be able to use it:
 
-`sudo setsebool -P container_use_dri_device 1`
+`sudo setsebool -P container_use_dri_devices 1`
 
 On older versions of container-selinux, you have to disable the selinux confinement for the container by adding `--security-opt label=disable` to the podman command.
 


### PR DESCRIPTION
`setsebool` is reporting `container_use_dri_device` as an invalid boolean

`getsebool -a` shows the plural `container_use_dri_devices` as valid

container-selinux version is 2.229