### PR TITLE
Revamp the Server Downloads page for 10.9.0 prerelease

### DIFF
--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -24,7 +24,7 @@ The AUR also offers each separately at [`jellyfin-server-git`](https://aur.archl
 
 ## Fedora
 
-Fedora builds in RPM package format are available [in the main download repository](https://repo.jellyfin.org/releases/server/). We do not yet have an official Fedora repository, but one is planned for the future.  
+Fedora builds in RPM package format are available [in the main download repository](https://repo.jellyfin.org/?path=/server/). We do not yet have an official Fedora repository, but one is planned for the future.  
 However [`rpmfusion`](https://rpmfusion.org/) provides both `jellyfin-server` and `jellyfin-web` for Fedora version `38` and above.
 
 ### RPM Fusion
@@ -100,7 +100,7 @@ However [`rpmfusion`](https://rpmfusion.org/) provides both `jellyfin-server` an
 
 ## CentOS
 
-CentOS/RHEL 7 builds in RPM package format are available [in the main download repository](https://repo.jellyfin.org/releases/server/). We do not yet have an official CentOS/RHEL repository, but one is planned for the future.
+CentOS/RHEL 7 builds in RPM package format are available [in the main download repository](https://repo.jellyfin.org/?path=/server/). We do not yet have an official CentOS/RHEL repository, but one is planned for the future.
 
 The default CentOS/RHEL repositories don't provide FFmpeg, which the RPM requires.
 You will need to add a third-party repository which provide FFmpeg, such as [RPM Fusion's Free repository](https://rpmfusion.org/Configuration).
@@ -143,7 +143,7 @@ sudo bash install-debuntu.sh
 
 :::note
 
-The script tries to handle as many common derivatives as possible, including, at least, Linux Mint (Ubuntu and Debian editions), Raspbian/Raspberry Pi OS, and KDE Neon. We welcome PRs [to the script](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L52) for any other common derivatives, or you can use the steps below instead.
+The script tries to handle as many common derivatives as possible, including, at least, Linux Mint (Ubuntu and Debian editions), Raspbian/Raspberry Pi OS, and KDE Neon. We welcome PRs [to the script](https://github.com/jellyfin/jellyfin-repo-helper-scripts/blob/master/install-debuntu.sh) for any other common derivatives, or you can use the steps below instead.
 
 :::
 
@@ -200,8 +200,8 @@ If you would prefer to install everything manually, the full steps are as follow
    The supported values for the above variables are:
 
    * `${VERSION_OS}`: One of `debian` or `ubuntu`; if it is not, use the closest one for your distribution.
-   * `${VERSION_CODENAME}`: One of our supported [Debian](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L7) or [Ubuntu](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L8) release codenames. These can change as new releases come out and old releases are dropped, so check the script to be sure yours is supported.
-   * `${DPKG_ARCHITECTURE}`: One of our [supported architectures](https://github.com/jellyfin/jellyfin-metapackages/blob/master/install-debuntu.sh#L6). Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is **not** supported on the `i386` architecture.
+   * `${VERSION_CODENAME}`: One of our supported [Debian](https://github.com/jellyfin/jellyfin-repo-helper-scripts/blob/master/install-debuntu.sh#L7) or [Ubuntu](https://github.com/jellyfin/jellyfin-repo-helper-scripts/blob/master/install-debuntu.sh#L8) release codenames. These can change as new releases come out and old releases are dropped, so check the script to be sure yours is supported.
+   * `${DPKG_ARCHITECTURE}`: One of our [supported architectures](https://github.com/jellyfin/jellyfin-repo-helper-scripts/blob/master/install-debuntu.sh#L6). Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is **not** supported on the `i386` architecture.
 
    :::
 
@@ -238,7 +238,7 @@ If you would prefer to install everything manually, the full steps are as follow
 
 ### `.deb` Packages (Very Manual)
 
-Raw `.deb` packages, including old versions, source packages, and `dpkg` meta files, are available [in the main download repository](https://repo.jellyfin.org/releases/server/).
+Raw `.deb` packages, including old versions, source packages, and `dpkg` meta files, are available [in the main download repository](https://repo.jellyfin.org/?path=/server/).
 
 :::note
 
@@ -298,7 +298,7 @@ The Gentoo ebuild repository includes the Jellyfin package which can be installe
 
 ## Linux (generic amd64)
 
-Generic `amd64`, `arm64`, and `armhf` Linux builds in TAR archive format are available [in the main download repository](https://repo.jellyfin.org/releases/server/).
+Generic `amd64`, `arm64`, and `armhf` Linux builds in TAR archive format are available [in the main download repository](https://repo.jellyfin.org/?path=/server/).
 
 ### Base Installation Process
 
@@ -314,7 +314,7 @@ The rest of these instructions assume version 10.8.13 is being installed (i.e. `
 Download the generic build, then extract the archive:
 
 ```sh
-sudo wget https://repo.jellyfin.org/releases/server/linux/stable/combined/jellyfin_10.8.13_amd64.tar.gz
+sudo wget https://repo.jellyfin.org/?path=/server/linux/stable/combined/jellyfin_10.8.13_amd64.tar.gz
 sudo tar xvzf jellyfin_10.8.13_amd64.tar.gz
 ```
 
@@ -341,13 +341,7 @@ Not being able to use `jellyfin-ffmpeg` will most likely break hardware accelera
 
 :::
 
-If you are running Debian or a derivative, you should [download](https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/) and install a `ffmpeg` release built specifically for Jellyfin.
-Be sure to download the latest release that matches your OS (`5.1.3-2` for Debian Bookworm assumed below).
-
-```sh
-sudo wget https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.1.3-2/jellyfin-ffmpeg5_5.1.3-2-bookworm_amd64.deb
-sudo dpkg --install jellyfin-ffmpeg5_5.1.3-2-bookworm_amd64.deb
-```
+If you are running Debian or a derivative, you should [download](https://repo.jellyfin.org/?path=/ffmpeg/debian/) and install an `ffmpeg` `.deb` package built specifically for Jellyfin.
 
 If you run into any dependency errors, run this and it will install them and `jellyfin-ffmpeg`.
 

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -201,40 +201,6 @@ sudo apt install jellyfin`}
     otherButtons: []
   },
   {
-    id: 'fedora-centos',
-    name: 'Fedora and CentOS',
-    osTypes: [OsType.Linux],
-    status: DownloadStatus.Official,
-    features: [],
-    platforms: [Platform.Fedora, Platform.CentOS],
-    description: 'RPM archives for both Fedora and CentOS are provided.',
-    stableButtons: [
-      {
-        id: 'fedora-manual-stable-link',
-        name: 'Downloads (Fedora)',
-        url: 'https://repo.jellyfin.org/?path=/server/fedora/latest-stable'
-      },
-      {
-        id: 'centos-manual-stable-link',
-        name: 'Downloads (CentOS/etc.)',
-        url: 'https://repo.jellyfin.org/?path=/server/centos/latest-stable'
-      }
-    ],
-    unstableButtons: [
-      {
-        id: 'fedora-manual-unstable-link',
-        name: 'Downloads (Fedora)',
-        url: 'https://repo.jellyfin.org/?path=/server/fedora/latest-unstable'
-      },
-      {
-        id: 'centos-manual-unstable-link',
-        name: 'Downloads (CentOS/etc.)',
-        url: 'https://repo.jellyfin.org/?path=/server/centos/latest-unstable'
-      }
-    ],
-    otherButtons: []
-  },
-  {
     id: 'generic-linux',
     name: 'Generic Linux',
     osTypes: [OsType.Linux],
@@ -327,42 +293,6 @@ sudo apt install jellyfin`}
     otherButtons: []
   },
   {
-    id: 'flatpak',
-    name: 'Flatpak',
-    osTypes: [OsType.Linux],
-    status: DownloadStatus.Community,
-    features: [Feature.CustomFFmpeg],
-    platforms: [Platform.Linux],
-    description: 'Install Jellyfin via Flathub.',
-    stableButtons: [
-      {
-        id: 'flatpak-stable-button',
-        name: 'Install Instructions',
-        details: (
-          <>
-            <pre>
-              <code>{`flatpak install flathub org.jellyfin.JellyfinServer`}</code>
-            </pre>
-            <p>
-              <b>Note:</b> If you are running on an Intel GPU an additional extension is required for HDR Tone mapping.
-            </p>
-            <pre>
-              <code>{`flatpak install flathub org.jellyfin.JellyfinServer.Plugin.IntelComputeRuntime`}</code>
-            </pre>
-          </>
-        )
-      },
-      {
-        id: 'flatpak-flathub-link',
-        name: 'Flathub',
-        url: 'https://flathub.org/apps/org.jellyfin.JellyfinServer'
-      }
-    ],
-    unstableButtons: [],
-    otherButtons: [
-    ]
-  },
-  {
     id: 'arch',
     name: 'Arch Linux',
     osTypes: [OsType.Linux],
@@ -403,6 +333,74 @@ makepkg -si`}
       }
     ],
     otherButtons: []
+  },
+  {
+    id: 'fedora-centos',
+    name: 'Fedora/CentOS Linux',
+    osTypes: [OsType.Linux],
+    status: DownloadStatus.OsPackage,
+    features: [],
+    platforms: [Platform.Fedora, Platform.CentOS],
+    description: 'Install Jellyfin via the RPMFusion Repository (Free).',
+    stableButtons: [
+      {
+        id: 'rpmfusion-stable-button',
+        name: 'Install Instructions',
+        details: (
+          <>
+            <p>
+              <a href="https://rpmfusion.org/Configuration">Configure the RPMFusion repository</a>
+            </p>
+            <pre>
+              <code>{`dnf install jellyfin`}</code>
+            </pre>
+          </>
+        )
+      },
+      {
+        id: 'rpmfusion-stable-link',
+        name: 'RPMFusion',
+        url: 'https://admin.rpmfusion.org/pkgdb/package/free/jellyfin/'
+      }
+    ],
+    unstableButtons: [],
+    otherButtons: []
+  },
+  {
+    id: 'flatpak',
+    name: 'Flatpak',
+    osTypes: [OsType.Linux],
+    status: DownloadStatus.Community,
+    features: [Feature.CustomFFmpeg],
+    platforms: [Platform.Linux],
+    description: 'Install Jellyfin via Flathub.',
+    stableButtons: [
+      {
+        id: 'flatpak-stable-button',
+        name: 'Install Instructions',
+        details: (
+          <>
+            <pre>
+              <code>{`flatpak install flathub org.jellyfin.JellyfinServer`}</code>
+            </pre>
+            <p>
+              <b>Note:</b> If you are running on an Intel GPU an additional extension is required for HDR Tone mapping.
+            </p>
+            <pre>
+              <code>{`flatpak install flathub org.jellyfin.JellyfinServer.Plugin.IntelComputeRuntime`}</code>
+            </pre>
+          </>
+        )
+      },
+      {
+        id: 'flatpak-flathub-link',
+        name: 'Flathub',
+        url: 'https://flathub.org/apps/org.jellyfin.JellyfinServer'
+      }
+    ],
+    unstableButtons: [],
+    otherButtons: [
+    ]
   },
   {
     id: 'gentoo',

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -41,6 +41,67 @@ export type Download = {
 
 export const Downloads: Array<Download> = [
   {
+    id: 'docker',
+    name: 'Docker',
+    osTypes: [OsType.Docker],
+    status: DownloadStatus.Official,
+    features: [Feature.CustomFFmpeg],
+    platforms: [Platform.Docker],
+    description: (
+      <>
+        Run Jellyfin in Docker. Example commands store data in <code>/srv/jellyfin</code> and assume your media is
+        stored under <code>/media</code>.
+      </>
+    ),
+    stableButtons: [
+      {
+        id: 'docker-stable-button',
+        name: 'Install Instructions',
+        details: (
+          <pre className='margin-bottom--none'>
+            <code>{`docker pull jellyfin/jellyfin:latest  # or docker pull ghcr.io/jellyfin/jellyfin:latest
+mkdir -p /srv/jellyfin/{config,cache}
+docker run -d -v /srv/jellyfin/config:/config -v /srv/jellyfin/cache:/cache -v /media:/media --net=host jellyfin/jellyfin:latest`}</code>
+          </pre>
+        )
+      },
+      {
+        id: 'docker-hub-link',
+        name: 'Docker Hub',
+        url: 'https://hub.docker.com/r/jellyfin/jellyfin/'
+      },
+      {
+        id: 'docker-hub-link',
+        name: 'GHCR',
+        url: 'https://ghcr.io/jellyfin/jellyfin'
+      }
+    ],
+    unstableButtons: [
+      {
+        id: 'docker-unstable-button',
+        name: 'Install Instructions',
+        details: (
+          <pre className='margin-bottom--none'>
+            <code>{`docker pull jellyfin/jellyfin:unstable  # or docker pull ghcr.io/jellyfin/jellyfin:unstable
+mkdir -p /srv/jellyfin/{config,cache}
+docker run -d -v /srv/jellyfin/config:/config -v /srv/jellyfin/cache:/cache -v /media:/media --net=host jellyfin/jellyfin:unstable`}</code>
+          </pre>
+        )
+      },
+      {
+        id: 'docker-hub-link',
+        name: 'Docker Hub',
+        url: 'https://hub.docker.com/r/jellyfin/jellyfin/'
+      },
+      {
+        id: 'docker-hub-link',
+        name: 'GHCR',
+        url: 'https://ghcr.io/jellyfin/jellyfin'
+      }
+    ],
+    otherButtons: []
+  },
+  {
     id: 'debuntu',
     name: 'Debian and Ubuntu',
     osTypes: [OsType.Linux],
@@ -73,6 +134,16 @@ export const Downloads: Array<Download> = [
             </p>
           </>
         )
+      },
+      {
+        id: 'debian-manual-stable-link',
+        name: 'Manual Downloads (Debian)',
+        url: 'https://repo.jellyfin.org/?path=/server/debian/latest-stable'
+      },
+      {
+        id: 'ubuntu-manual-stable-link',
+        name: 'Manual Downloads (Ubuntu)',
+        url: 'https://repo.jellyfin.org/?path=/server/ubuntu/latest-stable'
       }
     ],
     unstableButtons: [
@@ -115,20 +186,145 @@ sudo apt install jellyfin`}
             </p>
           </>
         )
-      }
-    ],
-    otherButtons: [
-      {
-        id: 'debian-all-link',
-        name: 'All Debian Versions',
-        url: 'https://repo.jellyfin.org/releases/server/debian/versions'
       },
       {
-        id: 'ubuntu-all-link',
-        name: 'All Ubuntu Versions',
-        url: 'https://repo.jellyfin.org/releases/server/ubuntu/versions'
+        id: 'debian-manual-unstable-link',
+        name: 'Manual Downloads (Debian)',
+        url: 'https://repo.jellyfin.org/?path=/server/debian/latest-unstable'
+      },
+      {
+        id: 'ubuntu-manual-unstable-link',
+        name: 'Manual Downloads (Ubuntu)',
+        url: 'https://repo.jellyfin.org/?path=/server/ubuntu/latest-unstable'
       }
-    ]
+    ],
+    otherButtons: []
+  },
+  {
+    id: 'fedora-centos',
+    name: 'Fedora and CentOS',
+    osTypes: [OsType.Linux],
+    status: DownloadStatus.Official,
+    features: [],
+    platforms: [Platform.Fedora, Platform.CentOS],
+    description: 'RPM archives for both Fedora and CentOS are provided.',
+    stableButtons: [
+      {
+        id: 'fedora-manual-stable-link',
+        name: 'Manual Downloads (Fedora)',
+        url: 'https://repo.jellyfin.org/?path=/server/fedora/latest-stable'
+      },
+      {
+        id: 'centos-manual-stable-link',
+        name: 'Manual Downloads (CentOS/etc.)',
+        url: 'https://repo.jellyfin.org/?path=/server/centos/latest-stable'
+      }
+    ],
+    unstableButtons: [
+      {
+        id: 'fedora-manual-unstable-link',
+        name: 'Manual Downloads (Fedora)',
+        url: 'https://repo.jellyfin.org/?path=/server/fedora/latest-unstable'
+      },
+      {
+        id: 'centos-manual-unstable-link',
+        name: 'Manual Downloads (CentOS/etc.)',
+        url: 'https://repo.jellyfin.org/?path=/server/centos/latest-unstable'
+      }
+    ],
+    otherButtons: []
+  },
+  {
+    id: 'generic-linux',
+    name: 'Generic Linux',
+    osTypes: [OsType.Linux],
+    status: DownloadStatus.Official,
+    features: [],
+    platforms: [Platform.Linux],
+    description: 'Linux self-contained binary TAR archives (.tar.gz) are provided.',
+    stableButtons: [
+      {
+        id: 'linux-manual-stable-link',
+        url: 'https://repo.jellyfin.org/?path=/server/linux/latest-stable'
+      }
+    ],
+    unstableButtons: [
+      {
+        id: 'linux-manual-unstable-link',
+        url: 'https://repo.jellyfin.org/?path=/server/linux/latest-unstable'
+      }
+    ],
+    otherButtons: []
+  },
+  {
+    id: 'windows',
+    name: 'Windows',
+    osTypes: [OsType.Windows],
+    status: DownloadStatus.Official,
+    features: [Feature.CustomFFmpeg],
+    platforms: [Platform.Windows],
+    description: 'Both installers (.exe) and manual ZIP archives (.zip) are provided.',
+    stableButtons: [
+      {
+        id: 'windows-manual-stable-link',
+        name: "Manual Downloads",
+        url: 'https://repo.jellyfin.org/?path=/server/windows/latest-stable'
+      }
+    ],
+    unstableButtons: [
+      {
+        id: 'windows-unstable-link',
+        name: "Manual Downloads",
+        url: 'https://repo.jellyfin.org/?path=/server/windows/latest-unstable'
+      }
+    ],
+    otherButtons: []
+  },
+  {
+    id: 'macos',
+    name: 'MacOS',
+    osTypes: [OsType.MacOS],
+    status: DownloadStatus.Official,
+    features: [],
+    platforms: [Platform.MacOS],
+    description: 'Both installers (.dmg) and manual ZIP archives (.tar.gz) are provided.',
+    stableButtons: [
+      {
+        id: 'macos-manual-stable-link',
+        name: "Manual Downloads",
+        url: 'https://repo.jellyfin.org/?path=/server/macos/latest-stable'
+      }
+    ],
+    unstableButtons: [
+      {
+        id: 'macos-manual-unstable-link',
+        name: "Manual Downloads",
+        url: 'https://repo.jellyfin.org/?path=/server/macos/latest-unstable'
+      }
+    ],
+    otherButtons: []
+  },
+  {
+    id: 'portable',
+    name: 'Portable',
+    osTypes: [OsType.Linux, OsType.MacOS, OsType.Windows],
+    status: DownloadStatus.Official,
+    features: [],
+    platforms: [Platform.DotNet],
+    description: 'The portable version can be run on any system with a .NET Core runtime.',
+    stableButtons: [
+      {
+        id: 'portable-manual-stable-link',
+        url: 'https://repo.jellyfin.org/?path=/server/portable/latest-stable'
+      }
+    ],
+    unstableButtons: [
+      {
+        id: 'portable-manual-unstable-link',
+        url: 'https://repo.jellyfin.org/?path=/server/portable/latest-unstable'
+      },
+    ],
+    otherButtons: []
   },
   {
     id: 'flatpak',
@@ -155,15 +351,15 @@ sudo apt install jellyfin`}
             </pre>
           </>
         )
-      }
-    ],
-    unstableButtons: [],
-    otherButtons: [
+      },
       {
         id: 'flatpak-flathub-link',
         name: 'Flathub',
         url: 'https://flathub.org/apps/org.jellyfin.JellyfinServer'
       }
+    ],
+    unstableButtons: [],
+    otherButtons: [
     ]
   },
   {
@@ -179,6 +375,11 @@ sudo apt install jellyfin`}
         id: 'arch-stable-link',
         name: 'Arch Downloads',
         url: 'https://archlinux.org/packages/?q=jellyfin'
+      },
+      {
+        id: 'arch-aur-link',
+        name: 'AUR Downloads',
+        url: 'https://aur.archlinux.org/packages/?K=jellyfin'
       }
     ],
     unstableButtons: [
@@ -194,60 +395,14 @@ makepkg -si`}
             </code>
           </pre>
         )
-      }
-    ],
-    otherButtons: [
+      },
       {
         id: 'arch-aur-link',
-        name: 'AUR',
+        name: 'AUR Downloads',
         url: 'https://aur.archlinux.org/packages/?K=jellyfin'
       }
-    ]
-  },
-  {
-    id: 'fedora-centos',
-    name: 'Fedora and CentOS',
-    osTypes: [OsType.Linux],
-    status: DownloadStatus.Official,
-    features: [],
-    platforms: [Platform.Fedora, Platform.CentOS],
-    description: 'RPM archives for both Fedora and CentOS are provided.',
-    stableButtons: [
-      {
-        id: 'fedora-stable-link',
-        name: 'Fedora Downloads',
-        url: 'https://repo.jellyfin.org/releases/server/fedora/stable'
-      },
-      {
-        id: 'centos-stable-link',
-        name: 'CentOS Downloads',
-        url: 'https://repo.jellyfin.org/releases/server/centos/stable'
-      }
     ],
-    unstableButtons: [
-      {
-        id: 'fedora-unstable-link',
-        name: 'Fedora Downloads',
-        url: 'https://repo.jellyfin.org/releases/server/fedora/unstable'
-      },
-      {
-        id: 'centos-unstable-link',
-        name: 'CentOS Downloads',
-        url: 'https://repo.jellyfin.org/releases/server/centos/unstable'
-      }
-    ],
-    otherButtons: [
-      {
-        id: 'fedora-all-link',
-        name: 'All Fedora Versions',
-        url: 'https://repo.jellyfin.org/releases/server/fedora/versions'
-      },
-      {
-        id: 'centos-all-link',
-        name: 'All CentOS Versions',
-        url: 'https://repo.jellyfin.org/releases/server/centos/versions'
-      }
-    ]
+    otherButtons: []
   },
   {
     id: 'gentoo',
@@ -277,98 +432,5 @@ makepkg -si`}
     ],
     unstableButtons: [],
     otherButtons: []
-  },
-  {
-    id: 'generic-linux',
-    name: 'Generic Linux',
-    osTypes: [OsType.Linux],
-    status: DownloadStatus.Official,
-    features: [],
-    platforms: [Platform.Linux],
-    description: 'Linux self-contained binary TAR archives (.tar.gz) are provided.',
-    stableButtons: [{ id: 'linux-stable-link', url: 'https://repo.jellyfin.org/releases/server/linux/stable' }],
-    unstableButtons: [{ id: 'linux-unstable-link', url: 'https://repo.jellyfin.org/releases/server/linux/unstable' }],
-    otherButtons: [{ id: 'linux-all-link', url: 'https://repo.jellyfin.org/releases/server/linux/versions' }]
-  },
-  {
-    id: 'windows',
-    name: 'Windows',
-    osTypes: [OsType.Windows],
-    status: DownloadStatus.Official,
-    features: [Feature.CustomFFmpeg],
-    platforms: [Platform.Windows],
-    description: 'Both installers (.exe) and manual ZIP archives (.zip) are provided.',
-    stableButtons: [{ id: 'windows-stable-link', url: 'https://repo.jellyfin.org/releases/server/windows/stable' }],
-    unstableButtons: [
-      { id: 'windows-unstable-link', url: 'https://repo.jellyfin.org/releases/server/windows/unstable' }
-    ],
-    otherButtons: [{ id: 'windows-all-link', url: 'https://repo.jellyfin.org/releases/server/windows/versions' }]
-  },
-  {
-    id: 'macos',
-    name: 'MacOS',
-    osTypes: [OsType.MacOS],
-    status: DownloadStatus.Official,
-    features: [],
-    platforms: [Platform.MacOS],
-    description: 'Both installers (.dmg) and manual ZIP archives (.tar.gz) are provided.',
-    stableButtons: [{ id: 'macos-stable-link', url: 'https://repo.jellyfin.org/releases/server/macos/stable' }],
-    unstableButtons: [{ id: 'macos-unstable-link', url: 'https://repo.jellyfin.org/releases/server/macos/unstable' }],
-    otherButtons: [{ id: 'macos-all-link', url: 'https://repo.jellyfin.org/releases/server/macos/versions' }]
-  },
-  {
-    id: 'docker',
-    name: 'Docker',
-    osTypes: [OsType.Docker],
-    status: DownloadStatus.Official,
-    features: [Feature.CustomFFmpeg],
-    platforms: [Platform.Docker],
-    description: (
-      <>
-        Run Jellyfin in Docker. Example commands store data in <code>/srv/jellyfin</code> and assume your media is
-        stored under <code>/media</code>.
-      </>
-    ),
-    stableButtons: [
-      {
-        id: 'docker-stable-button',
-        name: 'Install Instructions',
-        details: (
-          <pre className='margin-bottom--none'>
-            <code>{`docker pull jellyfin/jellyfin:latest
-mkdir -p /srv/jellyfin/{config,cache}
-docker run -d -v /srv/jellyfin/config:/config -v /srv/jellyfin/cache:/cache -v /media:/media --net=host jellyfin/jellyfin:latest`}</code>
-          </pre>
-        )
-      }
-    ],
-    unstableButtons: [
-      {
-        id: 'docker-unstable-button',
-        name: 'Install Instructions',
-        details: (
-          <pre className='margin-bottom--none'>
-            <code>{`docker pull jellyfin/jellyfin:unstable
-mkdir -p /srv/jellyfin/{config,cache}
-docker run -d -v /srv/jellyfin/config:/config -v /srv/jellyfin/cache:/cache -v /media:/media --net=host jellyfin/jellyfin:unstable`}</code>
-          </pre>
-        )
-      }
-    ],
-    otherButtons: [{ id: 'docker-hub-link', name: 'Docker Hub', url: 'https://hub.docker.com/r/jellyfin/jellyfin/' }]
-  },
-  {
-    id: 'portable',
-    name: 'Portable',
-    osTypes: [OsType.Linux, OsType.MacOS, OsType.Windows],
-    status: DownloadStatus.Official,
-    features: [],
-    platforms: [Platform.DotNet],
-    description: 'The portable version can be run on any system with a .NET Core runtime.',
-    stableButtons: [{ id: 'portable-stable-link', url: 'https://repo.jellyfin.org/releases/server/portable/stable' }],
-    unstableButtons: [
-      { id: 'portable-unstable-link', url: 'https://repo.jellyfin.org/releases/server/portable/unstable' }
-    ],
-    otherButtons: [{ id: 'portable-all-link', url: 'https://repo.jellyfin.org/releases/server/portable/versions' }]
   }
 ];

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -116,7 +116,7 @@ docker run -d -v /srv/jellyfin/config:/config -v /srv/jellyfin/cache:/cache -v /
         details: (
           <>
             <pre>
-              <code>{`curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
+              <code>{`curl https://repo.jellyfin.org/files/install-debuntu.sh | sudo bash`}</code>
             </pre>
             <p>
               If you do not have <code>curl</code> installed, you can use{' '}

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -116,7 +116,7 @@ docker run -d -v /srv/jellyfin/config:/config -v /srv/jellyfin/cache:/cache -v /
         details: (
           <>
             <pre>
-              <code>{`curl https://repo.jellyfin.org/files/install-debuntu.sh | sudo bash`}</code>
+              <code>{`curl https://repo.jellyfin.org/install-debuntu.sh | sudo bash`}</code>
             </pre>
             <p>
               If you do not have <code>curl</code> installed, you can use{' '}

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -137,12 +137,12 @@ docker run -d -v /srv/jellyfin/config:/config -v /srv/jellyfin/cache:/cache -v /
       },
       {
         id: 'debian-manual-stable-link',
-        name: 'Manual Downloads (Debian)',
+        name: 'Downloads (Debian)',
         url: 'https://repo.jellyfin.org/?path=/server/debian/latest-stable'
       },
       {
         id: 'ubuntu-manual-stable-link',
-        name: 'Manual Downloads (Ubuntu)',
+        name: 'Downloads (Ubuntu)',
         url: 'https://repo.jellyfin.org/?path=/server/ubuntu/latest-stable'
       }
     ],
@@ -189,12 +189,12 @@ sudo apt install jellyfin`}
       },
       {
         id: 'debian-manual-unstable-link',
-        name: 'Manual Downloads (Debian)',
+        name: 'Downloads (Debian)',
         url: 'https://repo.jellyfin.org/?path=/server/debian/latest-unstable'
       },
       {
         id: 'ubuntu-manual-unstable-link',
-        name: 'Manual Downloads (Ubuntu)',
+        name: 'Downloads (Ubuntu)',
         url: 'https://repo.jellyfin.org/?path=/server/ubuntu/latest-unstable'
       }
     ],
@@ -211,24 +211,24 @@ sudo apt install jellyfin`}
     stableButtons: [
       {
         id: 'fedora-manual-stable-link',
-        name: 'Manual Downloads (Fedora)',
+        name: 'Downloads (Fedora)',
         url: 'https://repo.jellyfin.org/?path=/server/fedora/latest-stable'
       },
       {
         id: 'centos-manual-stable-link',
-        name: 'Manual Downloads (CentOS/etc.)',
+        name: 'Downloads (CentOS/etc.)',
         url: 'https://repo.jellyfin.org/?path=/server/centos/latest-stable'
       }
     ],
     unstableButtons: [
       {
         id: 'fedora-manual-unstable-link',
-        name: 'Manual Downloads (Fedora)',
+        name: 'Downloads (Fedora)',
         url: 'https://repo.jellyfin.org/?path=/server/fedora/latest-unstable'
       },
       {
         id: 'centos-manual-unstable-link',
-        name: 'Manual Downloads (CentOS/etc.)',
+        name: 'Downloads (CentOS/etc.)',
         url: 'https://repo.jellyfin.org/?path=/server/centos/latest-unstable'
       }
     ],
@@ -267,14 +267,14 @@ sudo apt install jellyfin`}
     stableButtons: [
       {
         id: 'windows-manual-stable-link',
-        name: "Manual Downloads",
+        name: "Downloads",
         url: 'https://repo.jellyfin.org/?path=/server/windows/latest-stable'
       }
     ],
     unstableButtons: [
       {
         id: 'windows-unstable-link',
-        name: "Manual Downloads",
+        name: "Downloads",
         url: 'https://repo.jellyfin.org/?path=/server/windows/latest-unstable'
       }
     ],
@@ -291,14 +291,14 @@ sudo apt install jellyfin`}
     stableButtons: [
       {
         id: 'macos-manual-stable-link',
-        name: "Manual Downloads",
+        name: "Downloads",
         url: 'https://repo.jellyfin.org/?path=/server/macos/latest-stable'
       }
     ],
     unstableButtons: [
       {
         id: 'macos-manual-unstable-link',
-        name: "Manual Downloads",
+        name: "Downloads",
         url: 'https://repo.jellyfin.org/?path=/server/macos/latest-unstable'
       }
     ],

--- a/src/pages/downloads/clients/index.tsx
+++ b/src/pages/downloads/clients/index.tsx
@@ -99,6 +99,9 @@ export default function ClientsPage({ recommended = true }: { recommended?: bool
                 <Link to='/downloads/server' className='pills__item'>
                   Server
                 </Link>
+                <Link to='https://repo.jellyfin.org' className='pills__item pills__item'>
+                  Full Repository
+                </Link>
               </div>
             </div>
 

--- a/src/pages/downloads/clients/index.tsx
+++ b/src/pages/downloads/clients/index.tsx
@@ -99,7 +99,7 @@ export default function ClientsPage({ recommended = true }: { recommended?: bool
                 <Link to='/downloads/server' className='pills__item'>
                   Server
                 </Link>
-                <Link to='https://repo.jellyfin.org' className='pills__item pills__item'>
+                <Link to='https://repo.jellyfin.org' className='pills__item'>
                   Full Repository
                 </Link>
               </div>

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -68,15 +68,6 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
             <div className={clsx('col', 'margin-bottom--md', styles['header-pills-end'])}>
               <ul className={clsx('pills', 'margin-bottom--none', styles['stable-links'])}>
                 <Pill
-                  active={isStableLinks}
-                  onClick={() => {
-                    setIsStableLinks(true);
-                    setActiveButton(null);
-                  }}
-                >
-                  Stable
-                </Pill>
-                <Pill
                   active={!isStableLinks}
                   onClick={() => {
                     setIsStableLinks(false);
@@ -84,6 +75,15 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
                   }}
                 >
                   Unstable
+                </Pill>
+                <Pill
+                  active={isStableLinks}
+                  onClick={() => {
+                    setIsStableLinks(true);
+                    setActiveButton(null);
+                  }}
+                >
+                  Stable
                 </Pill>
               </ul>
 

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -110,10 +110,11 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
           {isStableHelpVisible && (
             <Admonition type='tip' title='Stable or Unstable?'>
               <p>
-                Generally, if you&apos;re a new user or value stability use the stable version. It won&apos;t change
-                very often. If you want to help test the latest improvements and features and can handle some occasional
-                breakage, use the unstable version. Always back up your existing configuration before testing unstable
-                releases.
+                Generally, if you&apos;re a new user or don't want your server to change often, use the Stable version.
+                If you want to help test the latest improvements and features and can handle some occasional breakage,
+                use the Unstable version. New Unstable releases are published Weekly on Monday mornings (~midnight GMT-5).
+                NOTE: Always back up your existing configuration before testing Unstable releases as there is NO
+                DOWNGRADE PATH; you must restore your Stable configuration from a backup.
               </p>
             </Admonition>
           )}

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -30,7 +30,7 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
                 <Link to='/downloads/server' className='pills__item pills__item--active'>
                   Server
                 </Link>
-                <Link to='https://repo.jellyfin.org' className='pills__item pills__item'>
+                <Link to='https://repo.jellyfin.org' className='pills__item'>
                   Full Repository
                 </Link>
               </div>

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -110,7 +110,7 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
           {isStableHelpVisible && (
             <Admonition type='tip' title='Stable or Unstable?'>
               <p>
-                Generally, if you&apos;re a new user or don't want your server to change often, use the Stable version.
+                Generally, if you&apos;re a new user or don&apos;t want your server to change often, use the Stable version.
                 If you want to help test the latest improvements and features and can handle some occasional breakage,
                 use the Unstable version. New Unstable releases are published Weekly on Monday mornings (~midnight GMT-5).
                 NOTE: Always back up your existing configuration before testing Unstable releases as there is NO

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -30,6 +30,9 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
                 <Link to='/downloads/server' className='pills__item pills__item--active'>
                   Server
                 </Link>
+                <Link to='https://repo.jellyfin.org' className='pills__item pills__item'>
+                  Full Repository
+                </Link>
               </div>
             </div>
 
@@ -42,6 +45,12 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
                   Linux
                 </Link>
                 <Link
+                  to='/downloads/docker'
+                  className={clsx('pills__item', { 'pills__item--active': osType === OsType.Docker })}
+                >
+                  Docker
+                </Link>
+                <Link
                   to='/downloads/windows'
                   className={clsx('pills__item', { 'pills__item--active': osType === OsType.Windows })}
                 >
@@ -52,12 +61,6 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
                   className={clsx('pills__item', { 'pills__item--active': osType === OsType.MacOS })}
                 >
                   MacOS
-                </Link>
-                <Link
-                  to='/downloads/docker'
-                  className={clsx('pills__item', { 'pills__item--active': osType === OsType.Docker })}
-                >
-                  Docker
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
1. Remove the "All Downloads" buttons everywhere in favour of a global link to the new repository browser.
2. Move manual downloads to the right buttons, linking to the new repo browser pages.
3. Reorganize the platforms to reflect our official support (first) followed by unofficial builds (last). Also move Docker over beside Linux in the top pill list.
4. Revamp the wording of the "Stable vs. Unstable" help to be a bit clearer and advise backups in a better way, as well as announce when new unstables will be made (Weekly).

Merge alongside #884 when cutting over the new repo.