### PR TITLE
Update docker compose example with bind mounts

### DIFF
--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -98,8 +98,13 @@ services:
     volumes:
       - /path/to/config:/config
       - /path/to/cache:/cache
-      - /path/to/media:/media
-      - /path/to/media2:/media2:ro
+      - type: bind
+        source: /path/to/media
+        target: /media
+      - type: bind
+        source: /path/to/media2
+        target: /media2
+        read_only: true
     restart: 'unless-stopped'
     # Optional - alternative address used for autodiscovery
     environment:


### PR DESCRIPTION
Bind mounts are better because if i manually add a file inside the mounted folder, with volumes i would need to restart the container, with bind mounts i see the new files without restarting it.
In the docker run command example we are rightfully using bind mounts, i don't know why we were not doing so with docker-compose.