### PR TITLE
Add TubeArchivistMetadata plugin to the docs

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -289,14 +289,6 @@ Plugin for Jellyfin that adds theme songs to movies and tv shows using ThemerrDB
 
 - [GitHub](https://github.com/LizardByte/themerr-jellyfin)
 
-#### TubeArchivistMetadata
-
-A plugin to integrate your TubeArchivist library with Jellyfin, providing metadata and organizing media.
-
-**Links:**
-
-- [GitHub](https://github.com/DarkFighterLuke/TubeArchivistMetadata)
-
 #### YouTube Metadata
 
 Downloads metadata of YouTube videos with a YouTube API key.
@@ -304,6 +296,14 @@ Downloads metadata of YouTube videos with a YouTube API key.
 **Links:**
 
 - [GitHub](https://github.com/ankenyr/jellyfin-youtube-metadata-plugin)
+
+#### TubeArchivistMetadata
+
+A plugin to integrate your TubeArchivist library with Jellyfin, providing metadata and organizing media.
+
+**Links:**
+
+- [GitHub](https://github.com/DarkFighterLuke/TubeArchivistMetadata)
 
 ## Repositories
 

--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -289,6 +289,14 @@ Plugin for Jellyfin that adds theme songs to movies and tv shows using ThemerrDB
 
 - [GitHub](https://github.com/LizardByte/themerr-jellyfin)
 
+#### TubeArchivistMetadata
+
+A plugin to integrate your TubeArchivist library with Jellyfin, providing metadata and organizing media.
+
+**Links:**
+
+- [GitHub](https://github.com/DarkFighterLuke/TubeArchivistMetadata)
+
 #### YouTube Metadata
 
 Downloads metadata of YouTube videos with a YouTube API key.

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -97,5 +97,13 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     includes: {
       Shokofin: 'https://github.com/ShokoAnime/Shokofin'
     }
+  },
+  {
+    id: 'gh:DarkFighterLuke/TubeArchivistMetadata',
+    name: "DarkFighterLuke's Repo",
+    url: 'https://raw.githubusercontent.com/DarkFighterLuke/TubeArchivistMetadata/master/manifest.json',
+    includes: {
+      TubeArchivistMetadata: 'https://github.com/DarkFighterLuke/TubeArchivistMetadata'
+    }
   }
 ];


### PR DESCRIPTION
This pull request adds the new [TubeArchivistMetadata](https://github.com/DarkFighterLuke/TubeArchivistMetadata) plugin to the docs page https://jellyfin.org/docs/general/server/plugins/ in the 3rd party plugins and repositories sections.