### PR TITLE
doc: add packaged Jellyfin.app data path

### DIFF
--- a/docs/general/testing/server/macos.md
+++ b/docs/general/testing/server/macos.md
@@ -14,6 +14,7 @@ Before running the unstable builds, make sure to backup your current data from t
 ```shell
 ~/.config/jellyfin/
 ~/.local/share/jellyfin/
+~/Library/Application Support/Jellyfin/
 ```
 
 ## Get Unstable Server


### PR DESCRIPTION
This add an additional path where the packaged Jellyfin.app will use.

And if this is not backed up, there will potentially be a problem when user switched back to the packaged version, as the packaged version will attempt to perform a migration from the `~/.local` path, which could potentially break current install.