### PR TITLE
fix: mark macOS bundle as custom ffmpeg ready

### DIFF
--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -248,12 +248,12 @@ sudo apt install jellyfin`}
   },
   {
     id: 'macos',
-    name: 'MacOS',
+    name: 'macOS',
     osTypes: [OsType.MacOS],
     status: DownloadStatus.Official,
-    features: [],
+    features: [Feature.CustomFFmpeg],
     platforms: [Platform.MacOS],
-    description: 'Both installers (.dmg) and manual ZIP archives (.tar.gz) are provided.',
+    description: 'Both installers (.dmg) and manual TAR archives (.tar.xz) are provided.',
     stableButtons: [
       {
         id: 'macos-manual-stable-link',

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -60,7 +60,7 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
                   to='/downloads/macos'
                   className={clsx('pills__item', { 'pills__item--active': osType === OsType.MacOS })}
                 >
-                  MacOS
+                  macOS
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
This marks macOS as a ffmpeg-ready platform for upcoming 10.9, should merge after 10.9 is officially stable.