### PR TITLE
Add warning for network path deprecation in Kodi native mode documentation

### DIFF
--- a/docs/general/clients/kodi.md
+++ b/docs/general/clients/kodi.md
@@ -95,6 +95,12 @@ Native mode accesses your media files directly from the filesystem, bypassing th
 
 To use Native mode, first set up your libraries in Jellyfin with a remote path.
 
+:::caution
+
+Starting from Jellyfin 10.9 it is no longer possible to set the shared network folder.
+
+:::
+
 1. In the Jellyfin server, navigate to the Libraries section of the admin dashboard.
    - Select an existing library (or create a new one)
    - Select the media folder


### PR DESCRIPTION
Considered removing the entire section but that would be confusing as the client still contains the native mode.