### PR TITLE
Add Subtitle Extract plugin

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -163,6 +163,18 @@ Download subtitles from the internet to use with your media files from [Open Sub
 
 - [GitHub](https://github.com/jellyfin/jellyfin-plugin-opensubtitles)
 
+#### Subtitle Extract
+
+[![Language](https://img.shields.io/github/languages/top/jellyfin/jellyfin-plugin-subtitleextract.svg)](https://github.com/jellyfin/jellyfin-plugin-subtitleextract)
+[![Contributors](https://img.shields.io/github/contributors/jellyfin/jellyfin-plugin-subtitleextract.svg)](https://github.com/jellyfin/jellyfin-plugin-subtitleextract)
+[![License](https://img.shields.io/github/license/jellyfin/jellyfin-plugin-subtitleextract.svg)](https://github.com/jellyfin/jellyfin-plugin-subtitleextract)
+
+Plugin to automatically extract embedded subtitles in media. This avoids delayed subtitles during streaming if the client does not support direct play and requests subtitles.
+
+**Links:**
+
+- [GitHub](https://github.com/jellyfin/jellyfin-plugin-subtitleextract)
+
 #### Playback Reporting
 
 [![Language](https://img.shields.io/github/languages/top/jellyfin/jellyfin-plugin-playbackreporting.svg)](https://github.com/jellyfin/jellyfin-plugin-playbackreporting)


### PR DESCRIPTION
From https://github.com/jellyfin/jellyfin-plugin-subtitleextract/issues/22

This PR adds the Subtitle Extract plugin to the documentation and also encourages new Jellyfin administrators to install them.

Honestly I think the SE plugin should be integrated into Jellyfin given the horrible experience users will get without it, but I remember seeing a PR that integrated it into Jellyfin getting closed because it relied on some side effect? Can't find the URL for it at the moment but I remember @crobibero commented on it, and he did spin it out to the SE plugin.

Finally, I'm not sure about the wording for recommending individual plugins -- I do get that some people will find this recommendation useless, but I honestly do believe that a majority if not all Jellyfin admins would want to have this plugin by default. Without it, the UX of enabling and viewing subtitles becomes really annoying for viewers as it can take more than a couple of seconds to sometimes a couple of minutes (depending on server load, file size that impacts how long ffmpeg takes to map the subtitle stream out from the container, etc.) for the subtitle to show. Please suggest any alternative wording if you think there's a better option!