### PR TITLE
Add ALAC to codec list

### DIFF
--- a/docs/general/clients/codec-support.md
+++ b/docs/general/clients/codec-support.md
@@ -68,6 +68,7 @@ If the audio codec is unsupported or incompatible (such as playing a 5.1 channel
 |                             VORBIS<sup>3</sup>                              |       ✅       |  ✅  |   ✅    |       ❌       |   ✅    |     ❌     |       ❌       |       ✅       |       ✅       |  ✅  |   ✅    |
 |                               DTS<sup>4</sup>                               |       ❌       |  ❌  |   ❌    |       ❌       |   ✅    |     ✅     |       ❌       |       ✅       | ✅<sup>6</sup> |  ✅  |   ✅    |
 |                                    OPUS                                     |       ✅       |  ✅  |   ✅    | 🔶<sup>5</sup> |   ✅    |     ✅     | 🔶<sup>5</sup> |       ✅       |       ✅       |  ✅  |   ✅    |
+|                                    ALAC                                     |       ❌       |  ❌  |   ❌    |       ✅       |   ❌    |     ❌     |       ✅       |                |                |      |   ✅    |
 
 [Format Cheatsheet:](https://en.wikipedia.org/wiki/Moving_Picture_Experts_Group#External_links)
 


### PR DESCRIPTION
Adds ALAC (Apple Lossless) to codec list
ALAC will be used if ripping CDs in iTunes with the Lossless Compression option.