### PR TITLE
Add the revised version of chat room rules to the docs

### DIFF
--- a/docs/general/community-standards/_category_.yml
+++ b/docs/general/community-standards/_category_.yml
@@ -1,0 +1,1 @@
+label: Community Standards

--- a/docs/general/community-standards/chat.md
+++ b/docs/general/community-standards/chat.md
@@ -1,0 +1,67 @@
+---
+uid: community-standards-chat-rules
+title: Chat Room Rules
+---
+
+# Jellyfin Chat Room Rules
+
+Version 2.0
+
+## Basics
+
+1. You **shall** abide by our [Community Standards](/docs/general/community-standards) at all times.
+
+2. You **shall not** do any of the following things:
+
+   - Antagonize, flame, insult, demean, abuse, or harass other users or those outside of the community.
+   - Dox or otherwise share others' private information, even if it is available publicly.
+   - Post offensive, sexual, or otherwise inappropriate content - keep it "Safe For Work" in all channels.
+   - Discuss media acquisition or related tools, regardless of its legality. Where your media comes from or how to get it is none of our or our community's business.
+   - Spam the chat rooms in any way, including but not limited to Telegram short links and Self advertisement.
+   - Post verbatim replies from "AI" Chat systems (e.g. ChatGPT) as answers.
+   - Engage in the discussion of media acquisition or related tools, regardless of its legality. Please note that this is different from what is allowed on the [forum](https://forum.jellyfin.org).
+
+3. Your username and profile fields **shall** be appropriate with respect to our above standards and **shall not** contain swearing, slurs, piracy, or attempts to impersonate others.
+
+4. You **shall** ensure you are posting in the correct channel before making a post. Do **NOT** post the same question in multiple channels.
+
+5. Please write in English if at all possible, as English is the working language of the Jellyfin project. If you cannot, please write in your native language (with or without attempted English) and ask for a translation if required.
+
+6. If you are using Jellyfin for commercial purposes or within a business setting, please review our [Commercial Support Policy](/docs/general/community-standards/commercial-support).
+
+7. Considering that the chat rooms are more likely to see users less experienced with tech, there are additional rules about technical misinformation. Please see the [Technical Misinformation Rules](#technical-misinformation-rules) below.
+
+8. There are cases where the rules don't cover. Please act in good faith under all circumstances. Moderation will be done **at the team's discretion** when not covered by the rules.
+
+## Chat Rooms Specifics
+
+1. This chat lives primarily on Matrix, and is bridged to Discord and IRC. Because of this, you will see the following:
+
+   - On Discord, you will see many people, including most of our team members, with "BOT" next to their names. Most of these are humans, not bots. Our actual bots are called `Jeff (Bot)` and `jeffbridges`.
+   - On Matrix, you will see many accounts with the IDs `@jfdiscord_<some numbers>:im.jellyfin.org`. These are bridged users from Discord.
+   - On Discord and Matrix, you will see messages sent from `jeffbridges`. These are users from IRC.
+   - On IRC, you will see messages sent from `jeffbridges`. These are users from other platforms.
+
+2. In rare cases, your first message from Discord to the chat may be dropped by the Matrix bridge. Please send a general "Hello" message in #offtopic before posting your questions to ⁠#troubleshooting, or else we may miss it.
+
+3. Do NOT directly message team members or fellow users or send them friend requests unless you have been asked to do so. Please ask all questions in the wider community channels instead. If you wish to contact the team privately, please refer to the [Contact and Punishments](#contact-and-punishments) section
+
+## Technical Misinformation Rules
+
+Since the chat rooms are much more likely to see users less experienced with tech, there are additional rules about technical misinformation specific to the chat rooms.
+
+1. Definition of Technical Misinformation: Information about technology that can be objectively proven wrong.
+
+2. You will generally **NOT** face punishment for simply saying something wrong occasionally. This rule is reserved for users who repeatedly demonstrate their unwillingness / inability to do basic research and / or take corrections from the community.
+
+3. You may **NOT** spread information that may violate the ToS (Terms of services) of other services (eg. Hosting JF behind CloudFlare). When the ToS is unclear, you should assume that it is against the ToS.
+
+4. Discussion of topics related to technical misinformation should be limited to #offtopic only.
+
+## Contact and Punishments
+
+1. If you see something against the rules, or something that makes you feel unsafe, let our staff know. We want this server to be a welcoming space for all users of Jellyfin.
+
+2. If you wish to contact moderators privately, please send an E-mail to [team@jellyfin.org](mailto:team@jellyfin.org) containing all the relevant info on your matter.
+
+3. Violation of these rules may result in the following punishments: an informal warning, a formal warning or a ban. If a formal warning has been issued, the next violation will result in a ban. See [Community Standards: Dispute Resolution and Moderation](/docs/general/community-standards/#dispute-resolution-and-moderation) for more info.

--- a/docs/general/community-standards/chat.md
+++ b/docs/general/community-standards/chat.md
@@ -54,7 +54,7 @@ Since the chat rooms are much more likely to see users less experienced with tec
 
 2. You will generally **NOT** face punishment for simply saying something wrong occasionally. This rule is reserved for users who repeatedly demonstrate their unwillingness / inability to do basic research and / or take corrections from the community.
 
-3. You may **NOT** spread information that may violate the ToS (Terms of services) of other services (eg. Hosting JF behind CloudFlare). When the ToS is unclear, you should assume that it is against the ToS.
+3. You may **NOT** spread information that may violate the ToS (Terms of services) of other services (eg. Hosting Jellyfin behind CloudFlare). When the ToS is unclear, you should assume that it is against the ToS.
 
 4. Discussion of topics related to technical misinformation should be limited to #offtopic only.
 

--- a/docs/general/community-standards/chat.md
+++ b/docs/general/community-standards/chat.md
@@ -62,6 +62,6 @@ Since the chat rooms are much more likely to see users less experienced with tec
 
 1. If you see something against the rules, or something that makes you feel unsafe, let our staff know. We want this server to be a welcoming space for all users of Jellyfin.
 
-2. If you wish to contact moderators privately, please send an E-mail to [team@jellyfin.org](mailto:team@jellyfin.org) containing all the relevant info on your matter.
+2. If you wish to contact moderators privately, please send an E-mail to us containing all the relevant info on your matter. Contact info can be found on the [contacts page](/contact).
 
 3. Violation of these rules may result in the following punishments: an informal warning, a formal warning or a ban. If a formal warning has been issued, the next violation will result in a ban. See [Community Standards: Dispute Resolution and Moderation](/docs/general/community-standards/#dispute-resolution-and-moderation) for more info.

--- a/docs/general/community-standards/commercial-support.md
+++ b/docs/general/community-standards/commercial-support.md
@@ -1,0 +1,20 @@
+---
+uid: community-standards-commercial-support
+title: Commercial Support Policy
+---
+
+# Commercial Support Policy
+
+Jellyfin is an explicitly anti-commercial project; that is to say that we:
+
+- Are volunteer- and best-effort-only.
+- Will not commercialize the software ourselves.
+- Do not provide payment for development.
+- Do not support bug bounties or other such systems of paid support.
+- Collect donations purely to cover infrastructure and other incidental costs.
+
+Because of this policy, many within the project have mixed feelings about supporting commercial instances of Jellyfin. For example, a streaming service built on it, or a large deployment for business use.
+
+Thus, while Jellyfin is a GNU GPL-licensed project which does not prevent or preclude commercial uses, please be aware that some members of our community do not look kindly on this and, as is their choice under our volunteer-only policy, may not be willing to provide support for commercial implementations. Not everyone feels this way, and such discussions are allowed here (subject to all other rules), but we want to ensure this is explicitly stated to avoid any misunderstandings or misaligned expectations.
+
+In short, if you are expecting support for the commercialization of Jellyfin, please do so respectfully and with the mutual understanding that this is not something everyone might wish to endorse, and no member of the team nor forum community is under any obligation to assist if they do not want to.

--- a/docs/general/community-standards/index.md
+++ b/docs/general/community-standards/index.md
@@ -1,5 +1,5 @@
 ---
-uid: community-standards
+uid: community-standards-index
 title: Community Standards
 ---
 
@@ -53,5 +53,5 @@ Questions or comments regarding these standards should be forwarded to the [Proj
 
 This document represents official Jellyfin project policy. Any changes to this document require a changelog entry here and approval by a Project Leader.
 
-- 2020-09-14, Joshua Boniface: Initial version of the community standards document. Based *very* loosely on several CoCs including the Contributor Covenant, and various Forum rules I've read and written over the years.
+- 2020-09-14, Joshua Boniface: Initial version of the community standards document. Based _very_ loosely on several CoCs including the Contributor Covenant, and various Forum rules I've read and written over the years.
 - 2022-09-03, Joshua Boniface: Update header and footer sections; reduce redundant wording; make rules clearer.


### PR DESCRIPTION
As discussed here https://github.com/jellyfin/jellyfin-meta/discussions/69 and in Matrix chat, adding the new version of rules to be part of the docs which can them be linked on Matrix, Discord and IRC.