### PR TITLE
Add warning for containers on not linux

### DIFF
--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -24,6 +24,12 @@ Additionally, there are several third parties providing unofficial container ima
 
 [Docker](https://www.docker.com/) allows you to run containers on Linux, Windows and MacOS.
 
+:::warning
+
+While it is possible to run Docker on Windows or macOS, it is an **UNSUPPORTED** configuration for Jellyfin. Please install Jellyfin natively if you wish to use Windows or macOS.
+
+:::
+
 The basic steps to create and run a Jellyfin container using Docker are as follows.
 
 1. Follow the [official installation guide to install Docker](https://docs.docker.com/engine/install).

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -26,7 +26,14 @@ Additionally, there are several third parties providing unofficial container ima
 
 :::warning
 
-While it is possible to run Jellyfin in Docker on a Windows or macOS host, it is not supported. Docker on Windows or macOS runs a Linux virtual machine, then runs containers in that VM. Because of this, some features will not work properly, notably hardware acceleration. Please install Jellyfin natively if you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos).
+If you wish to use Windows or macOS, please install Jellyfin natively instead. [Windows](/docs/general/installation/windows) [macOS](/docs/general/installation/macos).
+
+While it is possible to run Jellyfin in Docker on a Windows or macOS host, it is NOT supported. Some features are known to be broken when running in Docker on platforms other than Linux, Notably:
+
+- Hardware Accelerated Transcoding
+- [Scanning on macOS in Docker](https://github.com/jellyfin/jellyfin/issues/13093)
+
+You WILL NOT receive any support for running Jellyfin in Docker on platforms other than Linux.
 
 :::
 

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -26,7 +26,7 @@ Additionally, there are several third parties providing unofficial container ima
 
 :::warning
 
-While it is possible to run Jellyfin in Docker on Windows or macOS, it is not supported. Please install Jellyfin natively if you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos).
+While it is possible to run Jellyfin in Docker on a Windows or macOS host, it is not supported. Please install Jellyfin natively if you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos).
 
 :::
 

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -26,7 +26,7 @@ Additionally, there are several third parties providing unofficial container ima
 
 :::warning
 
-While it is possible to run Docker on Windows or macOS, it is not recommended for Jellyfin, as certain features, notably hardware acceleration, would be unavailable. Please install Jellyfin natively if you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos).
+While it is possible to run Jellyfin in Docker on Windows or macOS, it is not supported. Please install Jellyfin natively if you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos).
 
 :::
 

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -26,7 +26,7 @@ Additionally, there are several third parties providing unofficial container ima
 
 :::warning
 
-While it is possible to run Jellyfin in Docker on a Windows or macOS host, it is not supported. Please install Jellyfin natively if you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos).
+While it is possible to run Jellyfin in Docker on a Windows or macOS host, it is not supported. Docker on Windows or macOS runs a Linux virtual machine, then runs containers in that VM. Because of this, some features will not work properly, notably hardware acceleration. Please install Jellyfin natively if you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos).
 
 :::
 

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -26,7 +26,7 @@ Additionally, there are several third parties providing unofficial container ima
 
 :::warning
 
-While it is possible to run Docker on Windows or macOS, it is an **UNSUPPORTED** configuration for Jellyfin. Please install Jellyfin natively if you wish to use Windows or macOS.
+While it is possible to run Docker on Windows or macOS, it is not recommended for Jellyfin, as certain features would be unavailable. Please install Jellyfin natively if you wish to use Windows or macOS.
 
 :::
 

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -26,7 +26,7 @@ Additionally, there are several third parties providing unofficial container ima
 
 :::warning
 
-While it is possible to run Docker on Windows or macOS, it is not recommended for Jellyfin, as certain features would be unavailable. Please install Jellyfin natively if you wish to use Windows or macOS.
+While it is possible to run Docker on Windows or macOS, it is not recommended for Jellyfin, as certain features, notably hardware acceleration, would be unavailable. Please install Jellyfin natively if you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos).
 
 :::
 


### PR DESCRIPTION
Explicitly tell users to not use containers on Windows or macOS.

Using containers on these platforms can be hard to troubleshoot and will lead to an inferior setup (eg. no hw accel)