### PR TITLE
Change TubeArchivistMetadata plugin repository references

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -315,7 +315,7 @@ A plugin to integrate your TubeArchivist library with Jellyfin, providing metada
 
 **Links:**
 
-- [GitHub](https://github.com/DarkFighterLuke/TubeArchivistMetadata)
+- [GitHub](https://github.com/tubearchivist/tubearchivist-jf-plugin)
 
 ## Repositories
 

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -99,11 +99,11 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     }
   },
   {
-    id: 'gh:DarkFighterLuke/TubeArchivistMetadata',
-    name: "DarkFighterLuke's Repo",
-    url: 'https://raw.githubusercontent.com/DarkFighterLuke/TubeArchivistMetadata/master/manifest.json',
+    id: 'gh:tubearchivist/tubearchivist-jf-plugin',
+    name: "TubeArchivist's Repo",
+    url: 'https://raw.githubusercontent.com/tubearchivist/tubearchivist-jf-plugin/master/manifest.json',
     includes: {
-      TubeArchivistMetadata: 'https://github.com/DarkFighterLuke/TubeArchivistMetadata'
+      TubeArchivistMetadata: 'https://github.com/tubearchivist/tubearchivist-jf-plugin'
     }
   }
 ];


### PR DESCRIPTION
This pull request changes TubeArchivistMetadata pointings to the new GitHub repository, since  TubeArchivist developers appreciated the work and wanted to include it in the organization itself.