### PR TITLE
doc: add warnings about broken driver for DG2

### DIFF
--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -331,6 +331,10 @@ There are some known upstream Linux Kernel and firmware issues that can affect t
 
 9. The kernel support for Intel Gen 12.7 MTL is incomplete before Linux 6.7.
 
+10. The LTS kernel 6.6.26+ and the stable kernel 6.8.5+ have unresolved i915 driver bugs, which break HDR/DV tone-mapping on Intel Gen 12.5 DG2 / ARC A-series GPUs. If you are affected, please refrain from upgrading to those kernel versions.
+
+   - Issue: [https://github.com/jellyfin/jellyfin/issues/11380](https://github.com/jellyfin/jellyfin/issues/11380)
+
 ### Configure On Linux Host
 
 #### Debian And Ubuntu Linux

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -333,7 +333,7 @@ There are some known upstream Linux Kernel and firmware issues that can affect t
 
 10. The LTS kernel 6.6.26+ and the stable kernel 6.8.5+ have unresolved i915 driver bugs, which break HDR/DV tone-mapping on Intel Gen 12.5 DG2 / ARC A-series GPUs. If you are affected, please refrain from upgrading to those kernel versions.
 
-   - Issue: [https://github.com/jellyfin/jellyfin/issues/11380](https://github.com/jellyfin/jellyfin/issues/11380)
+    - Issue: [https://github.com/jellyfin/jellyfin/issues/11380](https://github.com/jellyfin/jellyfin/issues/11380)
 
 ### Configure On Linux Host
 


### PR DESCRIPTION
In the bleeding-edge kernels, the DG2 tone-mapping is broken due to Intel driver changes. This PR added a notice about this issue to warn DG2 users not to upgrade to affected versions, as there are a few distros already pushing those versions.

Ideally, I would like compatibility issues like this to be announced in a more accessible way so that more users could see them. Kernel upgrades can happen at any time with a regular system update, and if users are unaware of this issue, they may find out that the tone-mapping is broken after upgrading and would think it is a Jellyfin issue. 