### PR TITLE
Remove HD 500 from suggestions

### DIFF
--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -151,7 +151,7 @@ Intel improves the speed and video quality of its fixed-function encoders betwee
 
 They can be divided into 4 tiers by their performance：
 
-- **Entry-Level** - HD / UHD 500, 600, 605 and 61x
+- **Entry-Level** - HD / UHD 600, 605 and 61x
 
   :::tip
 


### PR DESCRIPTION
This section suggests that HD500 can transcode10bit HEVC which is not the case.
HD500 doesn't support 10bit HEVC.
The CPUs that come with HD500 are all low end models that will struggle to software decode 10bit HEVC