### PR TITLE
Clarify Linux RKMPP docker instructions

### DIFF
--- a/docs/general/administration/hardware-acceleration/rockchip.md
+++ b/docs/general/administration/hardware-acceleration/rockchip.md
@@ -179,7 +179,7 @@ Root permission is required.
 
 ### Configure With Linux Virtualization
 
-Before proceeding, you should complete the [Configure on Linux Host](#configure-on-linux-host) section above.
+Before proceeding, please complete the [Configure on Linux Host](#configure-on-linux-host) section above.
 
 #### Official Docker
 

--- a/docs/general/administration/hardware-acceleration/rockchip.md
+++ b/docs/general/administration/hardware-acceleration/rockchip.md
@@ -134,8 +134,6 @@ Root permission is required.
 
 4. Add the `jellyfin` user to the `render` and `video` group, then restart the `jellyfin` service:
 
-   You can skip this step if you intend to run Jellyfin in a container (eg. Docker)
-
    :::note
 
    On some distros, the group may be `input`.
@@ -179,7 +177,7 @@ Root permission is required.
 
 ### Configure With Linux Virtualization
 
-Before proceeding, please complete the [Configure on Linux Host](#configure-on-linux-host) section above.
+Before proceeding, please complete **steps 2 and 5** in the [Configure on Linux Host](#configure-on-linux-host) section above.
 
 #### Official Docker
 

--- a/docs/general/administration/hardware-acceleration/rockchip.md
+++ b/docs/general/administration/hardware-acceleration/rockchip.md
@@ -134,6 +134,8 @@ Root permission is required.
 
 4. Add the `jellyfin` user to the `render` and `video` group, then restart the `jellyfin` service:
 
+   You can skip this step if you intend to run Jellyfin in a container (eg. Docker)
+
    :::note
 
    On some distros, the group may be `input`.
@@ -176,6 +178,8 @@ Root permission is required.
 7. Enable RKMPP in Jellyfin and uncheck the unsupported codecs.
 
 ### Configure With Linux Virtualization
+
+Before proceeding, you should complete the [Configure on Linux Host](#configure-on-linux-host) section above.
 
 #### Official Docker
 


### PR DESCRIPTION
Clarify that the normal Linux instructions are also needed when installing via Docker

Fixes https://github.com/jellyfin/jellyfin/issues/11475