### PR TITLE
Update client requirements page

### DIFF
--- a/docs/general/clients/index.mdx
+++ b/docs/general/clients/index.mdx
@@ -30,14 +30,6 @@ Please verify it meets the requirements below and [submit a pull request](https:
 
 :::
 
-### Requirements for Inclusion as a Recommended Client
-
-- The client must be a first-party client (meaning published and maintained by the Jellyfin team with source freely licensed and available in the [Jellyfin GitHub organization](https://github.com/jellyfin)).
-
-  **OR**
-
-- The client must fill a significant void in the current first-party client offerings. Must be a high-quality client on a popular platform.
-
 ### Requirements for Inclusion in All Clients
 
 - Any client meeting the following requirements:
@@ -48,13 +40,17 @@ Please verify it meets the requirements below and [submit a pull request](https:
     - This includes usage of the Jellyfin name or `org.jellyfin` namespace that could hinder the ability to publish an official client to a store in the future.
   - Must include first rate support for Jellyfin servers. (i.e. Support for Jellyfin should be a primary function or at the same level of integration of any other supported services.)
   - Must **NOT** be specific to or intended to promote a specific hosted Jellyfin server instance.
-  - Must have clear licensing and be void of any known issues related to attribution, copyright, or license violations.
-
-:::info
+  - Must have clear open-source licensing and be void of any known issues related to attribution, copyright, or license violations.
 
 The final decision for inclusion is at the discretion of the Jellyfin Contributor Team following the decision-making guidelines in the [Jellyfin Constitution](https://github.com/jellyfin/jellyfin-meta/blob/master/policies-and-procedures/jellyfin-constitution.md).
 
-:::
+### Requirements for Inclusion as a Recommended Client
+
+- The client must be a first-party client (meaning published and maintained by the Jellyfin team with source freely licensed and available in the [Jellyfin GitHub organization](https://github.com/jellyfin).
+
+  **OR**
+
+- The client must fill a significant void in the current first-party client offerings. Must be a high-quality client on a popular platform.
 
 ## Supported Browsers
 


### PR DESCRIPTION
- Move inclusion as recommended client below inclusion at all
- Fix an extra parentheses in the recommended client section
- Replace the info admonition with a plain paragraph
- Updating wording for license requirement