### PR TITLE
fix typo: `BluRay` -> `Blu-ray`

### DIFF
--- a/blog/2024/05-11-jellyfin-release-10.9.0/index.mdx
+++ b/blog/2024/05-11-jellyfin-release-10.9.0/index.mdx
@@ -96,7 +96,7 @@ This release has been over two years in the making, so we're really glad to fina
 
 * FFmpeg segments can now be automatically deleted after the client requests them, significantly reducing the space requirements of the transcoding temporary directory. This optional feature is disabled by default and can be enabled in the transcoding settings.
 
-* Support for direct stream playback of DVD and BluRay data folders, preferred over ISOs.
+* Support for direct stream playback of DVD and Blu-ray data folders, preferred over ISOs.
 
 * Support for AV1 hardware and software encoding.
 


### PR DESCRIPTION
Context:

- https://us.blu-raydisc.com/faqs/
- https://www.blu-ray.com/faq/#bluray_name