### PR TITLE
http2 deprecated

### DIFF
--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -35,8 +35,9 @@ server {
 #}
 
 #server {
-    # listen 443 ssl http2;
-    # listen [::]:443 ssl http2;
+    # listen 443 ssl;
+    # listen [::]:443 ssl;
+    http2 on;
     server_name DOMAIN_NAME;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.


### PR DESCRIPTION
listen http2 directive is deprecated.

nginx -t will throw a warning