### PR TITLE
Updating user docs regarding easy pins

### DIFF
--- a/docs/general/server/users/adding-managing-users.md
+++ b/docs/general/server/users/adding-managing-users.md
@@ -130,19 +130,3 @@ Allows you to set or change the user's password. Note that users can change thei
 `Reset Password` will allow the user to log in without giving a password.
 
 If the user has a password, additional options are shown.
-
-`Easy Pin Code` The user's easy pin code is used for offline access with supported clients, and can also be used for easy in-network sign in.
-
-:::note
-
-Easy pins were deprecated starting in server version 10.9 due to security concerns.
-
-:::
-
-`Enable in-network sign in with my easy pin code` If enabled, the user will be able to use their easy pin code to sign in to Jellyfin apps from inside the local network. Their regular password will only be needed outside the local network. If the pin code is left blank, they won't need a password within the local network. By default, the local network will only be the subnet assigned to your network, but more can be added.
-
-:::note
-
-[Pin-less Sign in Bug](https://github.com/jellyfin/jellyfin/issues/2125#issuecomment-566400711)
-
-:::


### PR DESCRIPTION
Easy pins were deprecated in 10.9.  Updating docs to reflect that.