### PR TITLE
Replace `Open Media Database` by `Open Movie Database`

### DIFF
--- a/docs/general/server/metadata/index.md
+++ b/docs/general/server/metadata/index.md
@@ -8,10 +8,10 @@ title: Metadata
 Jellyfin can get metadata for your media through multiple sources. By default, Jellyfin ships with the following providers:
 
 - The Movie Database (TMDb)
-- Open Media Database (OMDb)[^1]
+- The Open Movie Database API (OMDb API)[^1]
 - [Local .nfo files](nfo)
 
-[^1]: OMDb only provides English metadata.
+[^1]: [OMDb API](https://www.omdbapi.com/) only provides English metadata.
 
 There are more official providers available in our [Plugin Catalog](/docs/general/server/plugins#official-plugins), like TheTVDB, fanart.tv or AniDB. If you still can't find the provider you are looking for, you could even develop your own with our Plugin API.
 


### PR DESCRIPTION
Based on the source file `jellyfin/jellyfin/MediaBrowser.Providers/Plugins/Omdb/OmdbProvider.csJellyfin`, Jellyfin uses `omdbapi.com` as a metadata provider. (And in the rest of the repo it is called `The Open Movie Database`, like in `jellyfin/jellyfin/MediaBrowser.Providers/Plugins/Omdb/OmdbItemProvider.cs`.)

[`omdbapi.com`](https://www.omdbapi.com/) calls themselves "The Open **Movie** Database".

This seems to be not affiliated with "Open **Media** Database", [omdb.org](https://www.omdb.org/).

I found it incredibly difficult to figure out who is who.

I found [this comment](https://github.com/omdbapi/OMDb-API/issues/89#issuecomment-412158872) from a guy who works for a company — JustWatch — which is in Berlin and whose product is embedded on `omdb.org` (which has roots in Germany too — I know, it's quite light, but it's all I've got).

This comment says _OMDBAPI is an open wrapper around IMDB data_. But, on `omdbapi.com`, it is said _all content and images on the site are contributed and maintained by our users_, which seems to contradict the comment (and it doesn't seems to be open source). BUT, there seems to be no way on `omdbapi.com` to contribute, or create an account, or anything :exploding_head: 

If anyone has more information about all this, please share!