### PR TITLE
Updated docs for Intel & AMD GPU Windows driver issues

### DIFF
--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -129,9 +129,7 @@ There are some known Windows driver issues that can affect the AMD hardware tran
 
 :::
 
-1. AMD Radeon RX 5000 and newer RDNA series integrated and discrete GPUs have an Windows graphics driver issue in `Adrenalin 24.1.1` and newer. You may experience **playback failure** and observe an **error code of `-60`** in the FFmpeg log when transcoding and playing videos. The last known working driver is [`Adrenalin 23.12.1`](https://www.amd.com/en/support/kb/release-notes/rn-rad-win-23-12-1), and the problem can be solved by downgrading to it and disabling automatic updates. Note that if `Adrenalin 23.12.1` driver does not resolve the problem, you may need to try an older one such as `Adrenalin 23.11.1`. You can follow the status of this driver issue through the ticket below.
-
-   - Ticket: [https://github.com/ROCm/clr/issues/50](https://github.com/ROCm/clr/issues/50)
+1. AMD Radeon RX 5000 and newer RDNA series integrated and discrete GPUs have an Windows graphics driver issue ranging from **Adrenalin 24.1.1 to 24.4.1**. You may experience **playback failure** and observe an **error code of `-60`** in the FFmpeg log when transcoding and playing videos. The driver **Adrenalin 24.5.1** and newer drivers fix this issue.
 
 ### Configure On Windows Host
 

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -227,9 +227,7 @@ There are some known Windows driver issues that can affect the Intel hardware tr
 
 :::
 
-1. Intel 11th Gen and newer UHD, Xe and ARC series integrated and discrete GPUs have an Windows graphics driver issue in `31.0.101.5186 / 31.0.101.5234` and newer. You may encounter a **green screen but normal sound** when transcoding and playing HDR videos that **require tone-mapping**. The last known working driver is [`31.0.101.5085 / 31.0.101.5122`](https://www.intel.com/content/www/us/en/download/785597/813048/intel-arc-iris-xe-graphics-windows.html), and the problem can be solved by downgrading to it and disabling automatic updates. You can follow the status of this driver issue through the ticket below.
-
-   - Ticket: [https://github.com/IGCIT/Intel-GPU-Community-Issue-Tracker-IGCIT/issues/680](https://github.com/IGCIT/Intel-GPU-Community-Issue-Tracker-IGCIT/issues/680)
+1. Intel 11th Gen and newer UHD, Xe and ARC series integrated and discrete GPUs have an Windows graphics driver issue ranging from **31.0.101.5186 / 31.0.101.5234 to 31.0.101.5534**. You may encounter a **green screen but normal sound** when transcoding and playing HDR videos that **require tone-mapping**. The **31.0.101.5590** and newer drivers fix this issue.
 
 ### Configure On Windows Host
 


### PR DESCRIPTION
The two OpenCL interop issues on Windows have been fixed recently.
- Intel 31.0.101.5590 and newer
- AMD Adrenalin 24.5.1 and newer