### PR TITLE
Fixed 2 Typos in Hardware Acceleration Docs

### DIFF
--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -217,7 +217,7 @@ Alternatively, rebuild the Mesa driver with these options added to restore the s
 
 The `jellyfin-ffmpeg6` deb package required by Jellyfin 10.9 comes with all necessary user mode Mesa drivers.
 
-Besides that you only need to configure the the permission of the `jellyfin` user.
+Besides that you only need to configure the permission of the `jellyfin` user.
 
 :::note
 

--- a/docs/general/administration/hardware-acceleration/nvidia.md
+++ b/docs/general/administration/hardware-acceleration/nvidia.md
@@ -169,7 +169,7 @@ A 64-bit Linux distribution is required. **In Jellyfin 10.9 the minimum required
 
 The `jellyfin-ffmpeg6` deb package required by Jellyfin 10.9 doesn't include any NVIDIA proprietary driver.
 
-You have to install the NVIDIA driver from the distro and configure the the permission of the `jellyfin` user.
+You have to install the NVIDIA driver from the distro and configure the permission of the `jellyfin` user.
 
 :::note
 


### PR DESCRIPTION
Removed the repeated usage of the word "the" in the AMD and NVIDIA hardware acceleration documentation