### PR TITLE
Add dedicated page for hwa issues

### DIFF
--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -123,7 +123,7 @@ Windows 10 64-bit and newer is recommeded. **AMF is not available in Windows Doc
 
 ### Known Issues And Limitations On Windows
 
-Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#windows) for known issues and limitations
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#windows) for known issues and limitations.
 
 ### Configure On Windows Host
 
@@ -181,7 +181,7 @@ A 64-bit Linux distribution is required. **The supported GPU varies by kernel an
 
 ### Known Issues And Limitations On Linux
 
-Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#linux) for known issues and limitations
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#linux) for known issues and limitations.
 
 ### Configure On Linux Host
 

--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -123,13 +123,7 @@ Windows 10 64-bit and newer is recommeded. **AMF is not available in Windows Doc
 
 ### Known Issues And Limitations On Windows
 
-:::caution
-
-There are some known Windows driver issues that can affect the AMD hardware transcoding. Some of them can be fixed by downgrading or upgrading your graphics driver.
-
-:::
-
-1. AMD Radeon RX 5000 and newer RDNA series integrated and discrete GPUs have an Windows graphics driver issue ranging from **Adrenalin 24.1.1 to 24.4.1**. You may experience **playback failure** and observe an **error code of `-60`** in the FFmpeg log when transcoding and playing videos. The driver **Adrenalin 24.5.1** and newer drivers fix this issue.
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#windows) for known issues and limitations
 
 ### Configure On Windows Host
 
@@ -187,29 +181,7 @@ A 64-bit Linux distribution is required. **The supported GPU varies by kernel an
 
 ### Known Issues And Limitations On Linux
 
-:::caution
-
-Some Linux distros intentionally disabled the H.264 and HEVC codecs from the Mesa VA-API driver.
-
-:::
-
-Known affected distros:
-
-- [Fedora](https://www.phoronix.com/news/Fedora-Disable-Bad-VA-API)
-
-- [OpenSUSE](https://www.webpronews.com/fedora-and-opensuse-disable-gpu-accelerated-video-over-patent-concerns/)
-
-- [Manjaro](https://forum.manjaro.org/t/stable-update-2022-12-06-kernels-mesa-plasma-cinnamon-nvidia-libreoffice-pipewire-virtualbox/128453)
-
-This prevents you from using the AMD VA-API transcoding **on the host system**.
-
-You can use our Docker image instead or install third-party Mesa driver package.
-
-Alternatively, rebuild the Mesa driver with these options added to restore the stripped hardware codecs:
-
-```shell
--D video-codecs=all
-```
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#linux) for known issues and limitations
 
 ### Configure On Linux Host
 

--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -436,7 +436,7 @@ Root permission is required.
          image: jellyfin/jellyfin
          user: 1000:1000
          group_add:
-           - '122' # Change this to match your "render" host group id and remove this comment
+           - "122" # Change this to match your "render" host group id and remove this comment
          network_mode: 'host'
          volumes:
            - /path/to/config:/config

--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -123,7 +123,7 @@ Windows 10 64-bit and newer is recommeded. **AMF is not available in Windows Doc
 
 ### Known Issues And Limitations On Windows
 
-Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#windows) for known issues and limitations.
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#amd-on-windows) for known issues and limitations.
 
 ### Configure On Windows Host
 
@@ -181,7 +181,7 @@ A 64-bit Linux distribution is required. **The supported GPU varies by kernel an
 
 ### Known Issues And Limitations On Linux
 
-Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#linux) for known issues and limitations.
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#amd-on-linux) for known issues and limitations.
 
 ### Configure On Linux Host
 
@@ -257,17 +257,17 @@ Root permission is required.
 
    `VAEntrypointVLD` means that your card is capable to decode this format, `VAEntrypointEncSlice` means that you can encode to this format.
 
-   | Jellyfin Setting | VA-API Profil                                                                                         |
-   |------------------|-------------------------------------------------------------------------------------------------------|
-   | H264             | VAProfileH264Baseline<br/>VAProfileH264Main<br/>VAProfileH264High<br/>VAProfileH264ConstrainedBaseline   |
-   | HEVC             | VAProfileHEVCMain                                                                                     |
+   | Jellyfin Setting | VA-API Profil                                                                                          |
+   | ---------------- | ------------------------------------------------------------------------------------------------------ |
+   | H264             | VAProfileH264Baseline<br/>VAProfileH264Main<br/>VAProfileH264High<br/>VAProfileH264ConstrainedBaseline |
+   | HEVC             | VAProfileHEVCMain                                                                                      |
    | MPEG2            | VAProfileMPEG2Simple<br/>VAProfileMPEG2Main                                                            |
-   | VC1              | VAProfileVC1Simple<br/>VAProfileVC1Main<br/>VAProfileVC1Advanced                                        |
-   | VP8              | VAProfileVP8Version0<br/>VAProfileVP8Version1<br/>VAProfileVP8Version2<br/>VAProfileVP8Version3          |
-   | VP9              | VAProfileVP9Profile0                                                                                  |
-   | AV1              | VAProfileAV1Profile0                                                                                  |
-   | HEVC 10bit       | VAProfileHEVCMain10                                                                                   |
-   | VP9 10bit        | VAProfileVP9Profile2                                                                                  |
+   | VC1              | VAProfileVC1Simple<br/>VAProfileVC1Main<br/>VAProfileVC1Advanced                                       |
+   | VP8              | VAProfileVP8Version0<br/>VAProfileVP8Version1<br/>VAProfileVP8Version2<br/>VAProfileVP8Version3        |
+   | VP9              | VAProfileVP9Profile0                                                                                   |
+   | AV1              | VAProfileAV1Profile0                                                                                   |
+   | HEVC 10bit       | VAProfileHEVCMain10                                                                                    |
+   | VP9 10bit        | VAProfileVP9Profile2                                                                                   |
 
 6. Check the Vulkan runtime status:
 
@@ -436,7 +436,7 @@ Root permission is required.
          image: jellyfin/jellyfin
          user: 1000:1000
          group_add:
-           - "122" # Change this to match your "render" host group id and remove this comment
+           - '122' # Change this to match your "render" host group id and remove this comment
          network_mode: 'host'
          volumes:
            - /path/to/config:/config

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -589,19 +589,19 @@ The devices in Kubernetes are added as host path mounts, they are not separated 
            supplementalGroups:
              - 122 # Change this to match your "render" host group id and remove this comment
          containers:
-           - name: 'jellyfin'
+           - name: "jellyfin"
              image: ...
              ports: ...
              env: ...
              securityContext:
                privileged: true # Container must run as privileged inside of the pod
              volumeMounts:
-               - name: 'render-device'
-                 mountPath: '/dev/dri/renderD128'
+               - name: "render-device"
+                 mountPath: "/dev/dri/renderD128"
          volumes:
-           - name: 'render-device'
+           - name: "render-device"
              hostPath:
-               path: '/dev/dri/renderD128'
+               path: "/dev/dri/renderD128"
    ```
 
 2. When the pod starts, you can check the QSV and VA-API codecs.

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -528,7 +528,7 @@ What you need to do is pass the host's `render` group id to Docker and modify th
          image: jellyfin/jellyfin
          user: 1000:1000
          group_add:
-           - '122' # Change this to match your "render" host group id and remove this comment
+           - "122" # Change this to match your "render" host group id and remove this comment
          network_mode: 'host'
          volumes:
            - /path/to/config:/config

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -277,56 +277,7 @@ A 64-bit Linux distribution is required. **The supported GPU varies by kernel an
 
 ### Known Issues And Limitations On Linux
 
-:::caution
-
-There are some known upstream Linux Kernel and firmware issues that can affect the Intel hardware transcoding. Some of them can be fixed by upgrading your Linux distro, kernel and firmware packages, or adding the required kernel parameters.
-
-:::
-
-1. Intel Gen 11 [**Jasper Lake**](https://ark.intel.com/content/www/us/en/ark/products/codename/128823/products-formerly-jasper-lake.html) and [**Elkhart Lake**](https://ark.intel.com/content/www/us/en/ark/products/codename/128825/products-formerly-elkhart-lake.html) platforms (e.g. N5095, N5105, N6005, J6412) have quirks when using video encoders on Linux. The [Low-Power Encoding](/docs/general/administration/hardware-acceleration/intel#low-power-encoding) mode MUST be configured and enabled for correct VBR and CBR bitrate control that is required by Jellyfin.
-
-   - Ticket: [https://gitlab.freedesktop.org/drm/intel/-/issues/8080](https://gitlab.freedesktop.org/drm/intel/-/issues/8080)
-
-2. The default kernel 5.15 that comes with Ubuntu 22.04 LTS has a regression on Intel Gen 11 graphics (ICL, JSL and EHL) that prevent you from using the Low-Power encoding mode. Linux 5.16+ is not affected.
-
-   - Ticket: [https://gitlab.freedesktop.org/drm/intel/-/issues/4067](https://gitlab.freedesktop.org/drm/intel/-/issues/4067)
-
-   - Fixed by: [drm/i915/gen11: Moving WAs to icl_gt_workarounds_init()](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=52255ef662a5d490678fbad64a735f88fcba564d)
-
-   - You can fix this by switching to the [Hardware Enablement Stack](https://wiki.ubuntu.com/Kernel/LTSEnablementStack) and rebooting your system
-
-   ```shell
-   sudo apt install --install-recommends linux-generic-hwe-22.04
-   ```
-
-   :::caution
-
-   This will move you off a 5.15 kernel which could have other implications. If it breaks something you can return to the normal kernel by installing the linux-generic package.
-
-   :::
-
-3. The kernel range from 5.18 to 6.1.3 have an issue that locks up and resets the i915 kernel driver when using OpenCL based HDR/DV tone-mapping. Linux 5.18-, 6.0.18+, 6.1.4+ are not affected.
-
-   - Ticket: [https://gitlab.freedesktop.org/drm/intel/-/issues/7627](https://gitlab.freedesktop.org/drm/intel/-/issues/7627)
-
-   - Fixed by: [drm/i915: improve the catch-all evict to handle lock contention](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3f882f2d4f689627c1566c2c92087bc3ff734953)
-
-4. The current Debian 11 and Ubuntu 22.04 LTS may not have the required GPU firmware for Intel 12th Gen processors and ARC GPU. Ubuntu 22.04 LTS can be switched to use Ubuntu's Hardware Enablement Stack (see #2 above) which uses a newer kernel that supports Intel 12th Gen+ and ARC GPUs.
-
-5. The kernel support for Intel Gen 12 TGL graphics is incomplete before Linux 5.9.
-
-6. The kernel support for Intel Gen 12 DG1 is incomplete in upstream. Intel DKMS and custom iHD driver are required.
-
-7. The kernel support for Intel Gen 12 ADL graphics is incomplete before Linux 5.17.
-
-8. The kernel support for Intel Gen 12.5 DG2 / ARC A-series is incomplete before Linux 6.2.
-
-9. The kernel support for Intel Gen 12.7 MTL is incomplete before Linux 6.7.
-
-10. The LTS kernel range 6.6.26 - 6.6.32 and the stable kernel range 6.8.5 - 6.9.3 have i915 driver bugs, which may cause problems on Intel Gen 12.5 DG2 / ARC A-series GPUs. If you are affected, please upgrade to kernel 6.6.33+ (LTS) or 6.9.4+. Ubuntu 24.04 with kernel versions 6.8.0-38+ are also affected by this issue, please downgrade to 6.8.0-36 until a fix is released.
-
-    - Issue: [https://github.com/jellyfin/jellyfin/issues/11380](https://github.com/jellyfin/jellyfin/issues/11380)
-    - Ubuntu bug: [https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2072755](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2072755)
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#linux-1) for known issues and limitations
 
 ### Configure On Linux Host
 

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -221,7 +221,7 @@ Windows 10 64-bit and newer is recommeded. **QSV is not available on Windows Doc
 
 ### Known Issues And Limitations On Windows
 
-Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#windows-1) for known issues and limitations
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#intel-on-windows) for known issues and limitations
 
 ### Configure On Windows Host
 
@@ -277,7 +277,7 @@ A 64-bit Linux distribution is required. **The supported GPU varies by kernel an
 
 ### Known Issues And Limitations On Linux
 
-Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#linux-1) for known issues and limitations
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#intel-on-linux) for known issues and limitations
 
 ### Configure On Linux Host
 
@@ -528,7 +528,7 @@ What you need to do is pass the host's `render` group id to Docker and modify th
          image: jellyfin/jellyfin
          user: 1000:1000
          group_add:
-           - "122" # Change this to match your "render" host group id and remove this comment
+           - '122' # Change this to match your "render" host group id and remove this comment
          network_mode: 'host'
          volumes:
            - /path/to/config:/config
@@ -589,19 +589,19 @@ The devices in Kubernetes are added as host path mounts, they are not separated 
            supplementalGroups:
              - 122 # Change this to match your "render" host group id and remove this comment
          containers:
-           - name: "jellyfin"
+           - name: 'jellyfin'
              image: ...
              ports: ...
              env: ...
              securityContext:
                privileged: true # Container must run as privileged inside of the pod
              volumeMounts:
-               - name: "render-device"
-                 mountPath: "/dev/dri/renderD128"
+               - name: 'render-device'
+                 mountPath: '/dev/dri/renderD128'
          volumes:
-           - name: "render-device"
+           - name: 'render-device'
              hostPath:
-               path: "/dev/dri/renderD128"
+               path: '/dev/dri/renderD128'
    ```
 
 2. When the pod starts, you can check the QSV and VA-API codecs.

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -221,13 +221,7 @@ Windows 10 64-bit and newer is recommeded. **QSV is not available on Windows Doc
 
 ### Known Issues And Limitations On Windows
 
-:::caution
-
-There are some known Windows driver issues that can affect the Intel hardware transcoding. Some of them can be fixed by downgrading or upgrading your graphics driver.
-
-:::
-
-1. Intel 11th Gen and newer UHD, Xe and ARC series integrated and discrete GPUs have an Windows graphics driver issue ranging from **31.0.101.5186 / 31.0.101.5234 to 31.0.101.5534**. You may encounter a **green screen but normal sound** when transcoding and playing HDR videos that **require tone-mapping**. The **31.0.101.5590** and newer drivers fix this issue.
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#windows-1) for known issues and limitations
 
 ### Configure On Windows Host
 

--- a/docs/general/administration/hardware-acceleration/known-issues.md
+++ b/docs/general/administration/hardware-acceleration/known-issues.md
@@ -3,3 +3,33 @@ uid: admin-hardware-acceleration-issues
 title: Known Issues
 ---
 # Known Hardware Acceleration Issues and Limitations
+
+This page lists all known issues and limitations of hardware acceleration with Jellyfin.
+
+## AMD
+
+### Windows
+
+1. AMD Radeon RX 5000 and newer RDNA series integrated and discrete GPUs have an Windows graphics driver issue ranging from **Adrenalin 24.1.1 to 24.4.1**. You may experience **playback failure** and observe an **error code of `-60`** in the FFmpeg log when transcoding and playing videos. The driver **Adrenalin 24.5.1** and newer drivers fix this issue.
+
+### Linux
+
+1. Some Linux distros intentionally disabled the H.264 and HEVC codecs from the Mesa VA-API driver.
+
+    Known affected distros:
+
+    - [Fedora](https://www.phoronix.com/news/Fedora-Disable-Bad-VA-API)
+
+    - [OpenSUSE](https://www.webpronews.com/fedora-and-opensuse-disable-gpu-accelerated-video-over-patent-concerns/)
+
+    - [Manjaro](https://forum.manjaro.org/t/stable-update-2022-12-06-kernels-mesa-plasma-cinnamon-nvidia-libreoffice-pipewire-virtualbox/128453)
+
+    This prevents you from using the AMD VA-API transcoding **on the server system**.
+
+    You can use our Docker image instead or install third-party Mesa driver package.
+
+    Alternatively, rebuild the Mesa driver with these options added to restore the stripped hardware codecs:
+
+    ```shell
+    -D video-codecs=all
+    ```

--- a/docs/general/administration/hardware-acceleration/known-issues.md
+++ b/docs/general/administration/hardware-acceleration/known-issues.md
@@ -33,3 +33,12 @@ This page lists all known issues and limitations of hardware acceleration with J
     ```shell
     -D video-codecs=all
     ```
+
+## Intel
+
+### Windows
+
+1. Intel 11th Gen and newer UHD, Xe and ARC series integrated and discrete GPUs have an Windows graphics driver issue ranging from **31.0.101.5186 / 31.0.101.5234 to 31.0.101.5534**. You may encounter a **green or blue screen but normal sound** when transcoding and playing HDR videos that **require tone-mapping**. The **31.0.101.5590** and newer drivers fix this issue.
+
+### Linux
+

--- a/docs/general/administration/hardware-acceleration/known-issues.md
+++ b/docs/general/administration/hardware-acceleration/known-issues.md
@@ -42,3 +42,43 @@ This page lists all known issues and limitations of hardware acceleration with J
 
 ### Linux
 
+1. Intel Gen 11 [**Jasper Lake**](https://ark.intel.com/content/www/us/en/ark/products/codename/128823/products-formerly-jasper-lake.html) and [**Elkhart Lake**](https://ark.intel.com/content/www/us/en/ark/products/codename/128825/products-formerly-elkhart-lake.html) platforms (e.g. N5095, N5105, N6005, J6412) have quirks when using video encoders on Linux. The [Low-Power Encoding](/docs/general/administration/hardware-acceleration/intel#low-power-encoding) mode MUST be configured and enabled for correct VBR and CBR bitrate control that is required by Jellyfin.
+
+   - Ticket: [https://gitlab.freedesktop.org/drm/intel/-/issues/8080](https://gitlab.freedesktop.org/drm/intel/-/issues/8080)
+
+2. The default kernel 5.15 that comes with Ubuntu 22.04 LTS has a regression on Intel Gen 11 graphics (ICL, JSL and EHL) that prevent you from using the Low-Power encoding mode. Linux 5.16+ is not affected.
+
+   - Ticket: [https://gitlab.freedesktop.org/drm/intel/-/issues/4067](https://gitlab.freedesktop.org/drm/intel/-/issues/4067)
+
+   - Fixed by: [drm/i915/gen11: Moving WAs to icl_gt_workarounds_init()](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=52255ef662a5d490678fbad64a735f88fcba564d)
+
+   - You can fix this by switching to the [Hardware Enablement Stack](https://wiki.ubuntu.com/Kernel/LTSEnablementStack) and rebooting your system
+
+   ```shell
+   sudo apt install --install-recommends linux-generic-hwe-22.04
+   ```
+
+   This will move you off a 5.15 kernel which could have other implications. If it breaks something you can return to the normal kernel by installing the linux-generic package.
+
+3. The kernel range from 5.18 to 6.1.3 have an issue that locks up and resets the i915 kernel driver when using OpenCL based HDR/DV tone-mapping. Linux 5.18-, 6.0.18+, 6.1.4+ are not affected.
+
+   - Ticket: [https://gitlab.freedesktop.org/drm/intel/-/issues/7627](https://gitlab.freedesktop.org/drm/intel/-/issues/7627)
+
+   - Fixed by: [drm/i915: improve the catch-all evict to handle lock contention](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3f882f2d4f689627c1566c2c92087bc3ff734953)
+
+4. The current Debian 11 and Ubuntu 22.04 LTS may not have the required GPU firmware for Intel 12th Gen processors and ARC GPU. Ubuntu 22.04 LTS can be switched to use Ubuntu's Hardware Enablement Stack (see #2 above) which uses a newer kernel that supports Intel 12th Gen+ and ARC GPUs.
+
+5. The kernel support for Intel Gen 12 TGL graphics is incomplete before Linux 5.9.
+
+6. The kernel support for Intel Gen 12 DG1 is incomplete in upstream. Intel DKMS and custom iHD driver are required.
+
+7. The kernel support for Intel Gen 12 ADL graphics is incomplete before Linux 5.17.
+
+8. The kernel support for Intel Gen 12.5 DG2 / ARC A-series is incomplete before Linux 6.2.
+
+9. The kernel support for Intel Gen 12.7 MTL is incomplete before Linux 6.7.
+
+10. The LTS kernel range 6.6.26 - 6.6.32 and the stable kernel range 6.8.5 - 6.9.3 have i915 driver bugs, which may cause problems on Intel Gen 12.5 DG2 / ARC A-series GPUs. If you are affected, please upgrade to kernel 6.6.33+ (LTS) or 6.9.4+. Ubuntu 24.04 with kernel versions 6.8.0-38+ are also affected by this issue, please downgrade to 6.8.0-36 until a fix is released.
+
+    - Issue: [https://github.com/jellyfin/jellyfin/issues/11380](https://github.com/jellyfin/jellyfin/issues/11380)
+    - Ubuntu bug: [https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2072755](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2072755)

--- a/docs/general/administration/hardware-acceleration/known-issues.md
+++ b/docs/general/administration/hardware-acceleration/known-issues.md
@@ -9,7 +9,7 @@ This page lists all known issues and limitations of hardware acceleration with J
 
 ## AMD on Windows
 
-1. AMD Radeon RX 5000 and newer RDNA series integrated and discrete GPUs have an Windows graphics driver issue ranging from **Adrenalin 24.1.1 to 24.4.1**. You may experience **playback failure** and observe an **error code of `-60`** in the FFmpeg log when transcoding and playing videos. The driver **Adrenalin 24.5.1** and newer drivers fix this issue.
+1. AMD Radeon RX 5000 and newer RDNA series integrated and discrete GPUs have a Windows graphics driver issue ranging from **Adrenalin 24.1.1 to 24.4.1**. You may experience **playback failure** and observe an **error code of `-60`** in the FFmpeg log when transcoding and playing videos. The driver **Adrenalin 24.5.1** and newer drivers fix this issue.
 
 ## AMD on Linux
 
@@ -25,7 +25,7 @@ This page lists all known issues and limitations of hardware acceleration with J
 
    This prevents you from using the AMD VA-API transcoding **on the server system**.
 
-   You can use our Docker image instead or install third-party Mesa driver package.
+   You can use our Docker image instead or install a third-party Mesa driver package.
 
    Alternatively, rebuild the Mesa driver with these options added to restore the stripped hardware codecs:
 
@@ -35,7 +35,7 @@ This page lists all known issues and limitations of hardware acceleration with J
 
 ## Intel on Windows
 
-1. Intel 11th Gen and newer UHD, Xe and ARC series integrated and discrete GPUs have an Windows graphics driver issue ranging from **31.0.101.5186 / 31.0.101.5234 to 31.0.101.5534**. You may encounter a **green or blue screen but normal sound** when transcoding and playing HDR videos that **require tone-mapping**. The **31.0.101.5590** and newer drivers fix this issue.
+1. Intel 11th Gen and newer UHD, Xe and ARC series integrated and discrete GPUs have a Windows graphics driver issue ranging from **31.0.101.5186 / 31.0.101.5234 to 31.0.101.5534**. You may encounter a **green or blue screen but normal sound** when transcoding and playing HDR videos that **require tone-mapping**. The **31.0.101.5590** and newer drivers fix this issue.
 
 ## Intel on Linux
 
@@ -43,7 +43,7 @@ This page lists all known issues and limitations of hardware acceleration with J
 
    - Ticket: [https://gitlab.freedesktop.org/drm/intel/-/issues/8080](https://gitlab.freedesktop.org/drm/intel/-/issues/8080)
 
-2. The default kernel 5.15 that comes with Ubuntu 22.04 LTS has a regression on Intel Gen 11 graphics (ICL, JSL and EHL) that prevent you from using the Low-Power encoding mode. Linux 5.16+ is not affected.
+2. The default kernel 5.15 that comes with Ubuntu 22.04 LTS has a regression on Intel Gen 11 graphics (ICL, JSL and EHL) that prevents you from using the Low-Power encoding mode. Linux 5.16+ is not affected.
 
    - Ticket: [https://gitlab.freedesktop.org/drm/intel/-/issues/4067](https://gitlab.freedesktop.org/drm/intel/-/issues/4067)
 

--- a/docs/general/administration/hardware-acceleration/known-issues.md
+++ b/docs/general/administration/hardware-acceleration/known-issues.md
@@ -2,45 +2,42 @@
 uid: admin-hardware-acceleration-issues
 title: Known Issues
 ---
+
 # Known Hardware Acceleration Issues and Limitations
 
 This page lists all known issues and limitations of hardware acceleration with Jellyfin.
 
-## AMD
-
-### Windows
+## AMD on Windows
 
 1. AMD Radeon RX 5000 and newer RDNA series integrated and discrete GPUs have an Windows graphics driver issue ranging from **Adrenalin 24.1.1 to 24.4.1**. You may experience **playback failure** and observe an **error code of `-60`** in the FFmpeg log when transcoding and playing videos. The driver **Adrenalin 24.5.1** and newer drivers fix this issue.
 
-### Linux
+## AMD on Linux
 
 1. Some Linux distros intentionally disabled the H.264 and HEVC codecs from the Mesa VA-API driver.
 
-    Known affected distros:
+   Known affected distros:
 
-    - [Fedora](https://www.phoronix.com/news/Fedora-Disable-Bad-VA-API)
+   - [Fedora](https://www.phoronix.com/news/Fedora-Disable-Bad-VA-API)
 
-    - [OpenSUSE](https://www.webpronews.com/fedora-and-opensuse-disable-gpu-accelerated-video-over-patent-concerns/)
+   - [OpenSUSE](https://www.webpronews.com/fedora-and-opensuse-disable-gpu-accelerated-video-over-patent-concerns/)
 
-    - [Manjaro](https://forum.manjaro.org/t/stable-update-2022-12-06-kernels-mesa-plasma-cinnamon-nvidia-libreoffice-pipewire-virtualbox/128453)
+   - [Manjaro](https://forum.manjaro.org/t/stable-update-2022-12-06-kernels-mesa-plasma-cinnamon-nvidia-libreoffice-pipewire-virtualbox/128453)
 
-    This prevents you from using the AMD VA-API transcoding **on the server system**.
+   This prevents you from using the AMD VA-API transcoding **on the server system**.
 
-    You can use our Docker image instead or install third-party Mesa driver package.
+   You can use our Docker image instead or install third-party Mesa driver package.
 
-    Alternatively, rebuild the Mesa driver with these options added to restore the stripped hardware codecs:
+   Alternatively, rebuild the Mesa driver with these options added to restore the stripped hardware codecs:
 
-    ```shell
-    -D video-codecs=all
-    ```
+   ```shell
+   -D video-codecs=all
+   ```
 
-## Intel
-
-### Windows
+## Intel on Windows
 
 1. Intel 11th Gen and newer UHD, Xe and ARC series integrated and discrete GPUs have an Windows graphics driver issue ranging from **31.0.101.5186 / 31.0.101.5234 to 31.0.101.5534**. You may encounter a **green or blue screen but normal sound** when transcoding and playing HDR videos that **require tone-mapping**. The **31.0.101.5590** and newer drivers fix this issue.
 
-### Linux
+## Intel on Linux
 
 1. Intel Gen 11 [**Jasper Lake**](https://ark.intel.com/content/www/us/en/ark/products/codename/128823/products-formerly-jasper-lake.html) and [**Elkhart Lake**](https://ark.intel.com/content/www/us/en/ark/products/codename/128825/products-formerly-elkhart-lake.html) platforms (e.g. N5095, N5105, N6005, J6412) have quirks when using video encoders on Linux. The [Low-Power Encoding](/docs/general/administration/hardware-acceleration/intel#low-power-encoding) mode MUST be configured and enabled for correct VBR and CBR bitrate control that is required by Jellyfin.
 
@@ -87,8 +84,8 @@ This page lists all known issues and limitations of hardware acceleration with J
 
 Consumer targeted [Geforce and some entry-level Quadro](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new) cards have an artificial limit on the number of concurrent NVENC encoding sessions. This restriction can be circumvented by applying an [unofficial patch](https://github.com/keylase/nvidia-patch) to the NVIDIA Linux and Windows driver.
 
-| NVIDIA driver  | NVENC concurrent sessions |
-| -------------- | ------------------------- |
-| 550 and newer  | Up to 8 encoding sessions |
-| 530 to 546     | Up to 5 encoding sessions |
-| pre-530        | Up to 3 encoding sessions |
+| NVIDIA driver | NVENC concurrent sessions |
+| ------------- | ------------------------- |
+| 550 and newer | Up to 8 encoding sessions |
+| 530 to 546    | Up to 5 encoding sessions |
+| pre-530       | Up to 3 encoding sessions |

--- a/docs/general/administration/hardware-acceleration/known-issues.md
+++ b/docs/general/administration/hardware-acceleration/known-issues.md
@@ -1,0 +1,5 @@
+---
+uid: admin-hardware-acceleration-issues
+title: Known Issues
+---
+# Known Hardware Acceleration Issues and Limitations

--- a/docs/general/administration/hardware-acceleration/known-issues.md
+++ b/docs/general/administration/hardware-acceleration/known-issues.md
@@ -82,3 +82,13 @@ This page lists all known issues and limitations of hardware acceleration with J
 
     - Issue: [https://github.com/jellyfin/jellyfin/issues/11380](https://github.com/jellyfin/jellyfin/issues/11380)
     - Ubuntu bug: [https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2072755](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2072755)
+
+## Nvidia
+
+Consumer targeted [Geforce and some entry-level Quadro](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new) cards have an artificial limit on the number of concurrent NVENC encoding sessions. This restriction can be circumvented by applying an [unofficial patch](https://github.com/keylase/nvidia-patch) to the NVIDIA Linux and Windows driver.
+
+| NVIDIA driver  | NVENC concurrent sessions |
+| -------------- | ------------------------- |
+| 550 and newer  | Up to 8 encoding sessions |
+| 530 to 546     | Up to 5 encoding sessions |
+| pre-530        | Up to 3 encoding sessions |

--- a/docs/general/administration/hardware-acceleration/nvidia.md
+++ b/docs/general/administration/hardware-acceleration/nvidia.md
@@ -15,17 +15,7 @@ On Windows and Linux **NVENC** is the only available method.
 
 The NVENC/NVDEC are the proprietary video codec APIs of NVIDIA GPUs, which can be used with CUDA to achieve full hardware acceleration.
 
-:::caution
-
-Consumer targeted [Geforce and some entry-level Quadro](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new) cards have an artificial limit on the number of concurrent NVENC encoding sessions. This restriction can be circumvented by applying an [unofficial patch](https://github.com/keylase/nvidia-patch) to the NVIDIA Linux and Windows driver.
-
-| NVIDIA driver  | NVENC concurrent sessions |
-| -------------- | ------------------------- |
-| 550 and newer  | Up to 8 encoding sessions |
-| 530 to 546     | Up to 5 encoding sessions |
-| pre-530        | Up to 3 encoding sessions |
-
-:::
+Please refer to [this section](/docs/general/administration/hardware-acceleration/known-issues#nvidia) for known issues and limitations.
 
 :::note
 


### PR DESCRIPTION
the list of known issues and limitations can make the page hard to read if it gets too long.
This PR moves those things into a dedicated page.