### PR TITLE
remove outdated note about image extractor

### DIFF
--- a/docs/general/administration/storage.md
+++ b/docs/general/administration/storage.md
@@ -26,8 +26,6 @@ For storage, a moderate size library database can grow anywhere from 10 to 100 G
 
 A popular choice for cloud storage has been the program [rclone](https://rclone.org/downloads/). It is supported on most Operating Systems. To facilitate combining local and cloud filesystems, rclone can be paired with another program such as [mergerfs](https://github.com/trapexit/mergerfs). For cloud storage, it is recommended to disable image extraction as this requires downloading the entire file to perform this task.
 
-- animostiy22's [repo](https://github.com/animosity22/homescripts) about rclone and mergerfs.
-
 ### MergerFS
 
 MergerFS isn't meant for everything, [see here](https://github.com/trapexit/mergerfs#what-should-mergerfs-not-be-used-for) for more.

--- a/docs/general/administration/storage.md
+++ b/docs/general/administration/storage.md
@@ -26,12 +26,6 @@ For storage, a moderate size library database can grow anywhere from 10 to 100 G
 
 A popular choice for cloud storage has been the program [rclone](https://rclone.org/downloads/). It is supported on most Operating Systems. To facilitate combining local and cloud filesystems, rclone can be paired with another program such as [mergerfs](https://github.com/trapexit/mergerfs). For cloud storage, it is recommended to disable image extraction as this requires downloading the entire file to perform this task.
 
-:::note
-
-The image extractor can't be [turned off](https://github.com/jellyfin/jellyfin/issues/2355) in Jellyfin at the moment which is causing [performance issues](https://github.com/jellyfin/jellyfin/issues/2600).
-
-:::
-
 - animostiy22's [repo](https://github.com/animosity22/homescripts) about rclone and mergerfs.
 
 ### MergerFS


### PR DESCRIPTION
There were two parts to the note:
1. The image extractor can't be [turned off](https://github.com/jellyfin/jellyfin/issues/2355) in Jellyfin at the moment 
2. which is causing [performance issues](https://github.com/jellyfin/jellyfin/issues/2600).

The first one, has since been renamed and it [says that the extractor can be turned off](https://github.com/jellyfin/jellyfin/issues/2355#issuecomment-853934544). The second one is closed.

Overall, I think it doesn't add anything to the docs to link to these issues here because there is already a great note warning to turn off image extraction. 

Edit: Also removed note to animostiy22's repo as the github account is 404 now.


Thanks to the maintainers for all your hard work!