### PR TITLE
Fix download artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  actions: read
 
 jobs:
   build:
@@ -42,7 +41,7 @@ jobs:
         if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          path: ./build
+          path: build
 
   deploy:
     if: github.event_name == 'push'
@@ -81,7 +80,7 @@ jobs:
           comment_tag: CFPages-deployment
           mode: recreate
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: jellyfin-org__build
           path: build


### PR DESCRIPTION
I have no idea why the exact same action is working in web, but it should probably be changed also. Perhaps there is an issue that only arises with larger artifact sizes?? :man_shrugging: 