### PR TITLE
Add dedicated dotnet tab for dotnet portable build

### DIFF
--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -16,7 +16,8 @@ export enum OsType {
   Docker,
   Linux,
   MacOS,
-  Windows
+  Windows,
+  DotNet,
 }
 
 export type Button = {
@@ -275,11 +276,11 @@ sudo apt install jellyfin`}
   {
     id: 'portable',
     name: 'Portable',
-    osTypes: [OsType.Linux, OsType.MacOS, OsType.Windows],
+    osTypes: [OsType.DotNet],
     status: DownloadStatus.Official,
     features: [],
     platforms: [Platform.DotNet],
-    description: 'The portable version can be run on any system with a .NET Core runtime.',
+    description: 'The portable version can be run on any system with a .NET runtime.',
     stableButtons: [
       {
         id: 'portable-manual-stable-link',

--- a/src/pages/downloads/dotnet.tsx
+++ b/src/pages/downloads/dotnet.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import DownloadsPage from './server';
+import { OsType } from '../../data/downloads';
+
+export default function DotNetDownloads() {
+  return <DownloadsPage osType={OsType.DotNet} />;
+}

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -62,6 +62,12 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
                 >
                   macOS
                 </Link>
+                <Link
+                  to='/downloads/dotnet'
+                  className={clsx('pills__item', { 'pills__item--active': osType === OsType.DotNet })}
+                >
+                  DotNet
+                </Link>
               </div>
             </div>
 


### PR DESCRIPTION
We are listing these portable builds under all OS tabs, which may confuse users because each OS also has its own platform-specific builds that we refer to as “portable” in our documentation. To avoid confusion, separate the tabs accordingly.

This also updated the description as the .NET Core runtime is now just .NET runtime