### PR TITLE
Correcting and adjusting Nginx docs

### DIFF
--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -61,7 +61,7 @@ server {
     add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
     add_header X-Content-Type-Options "nosniff";
 
-    # Permissions policy. May cause issues on some clients
+    # Permissions policy. May cause issues with some clients
     add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
 
     # Content Security Policy
@@ -105,7 +105,7 @@ server {
 
 :::tip
 
-If you are planning on exposing your server over the Internet you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/). Using only HTTP will expose passwords and API keys.
+If you are planning on exposing your server over the Internet, you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/). Using only HTTP will expose passwords and API keys.
 
 :::
 
@@ -133,7 +133,7 @@ server {
     add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
     add_header X-Content-Type-Options "nosniff";
 
-    # Permissions policy. May cause issues on some clients
+    # Permissions policy. May cause issues with some clients
     add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
 
     # Content Security Policy
@@ -230,7 +230,7 @@ server {
     add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
     add_header X-Content-Type-Options "nosniff";
 
-    # Permissions policy. May cause issues on some clients
+    # Permissions policy. May cause issues with some clients
     add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
 
     # Content Security Policy
@@ -307,7 +307,7 @@ server {
     add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
     add_header X-Content-Type-Options "nosniff";
 
-    # Permissions policy. May cause issues on some clients
+    # Permissions policy. May cause issues with some clients
     add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
 
     # Content Security Policy
@@ -317,7 +317,7 @@ server {
     # NOTE: The default CSP headers may cause issues with the webOS app
     add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 
-    # Uncomment and create directory to also host static content
+    # Uncomment and create a directory to also host static content
     #root /srv/http/media;
     index index.html;
 

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -261,6 +261,8 @@ server {
 
 HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS (see below for HTTPS configuration example). [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
 
+:::
+
 <details>
   <summary>Expand HTTP Example</summary>
 

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -25,6 +25,8 @@ Create the file `/etc/nginx/sites-available/jellyfin` which will forward request
 
 Note that a server listening on http port 80 is required for the Certbot / Let's Encrypt certificate renewal process.
 
+### HTTPS config example
+
 ```config
 server {
     listen 80;
@@ -105,7 +107,7 @@ server {
 }
 ```
 
-### HTTP Example
+### HTTP config example
 
 <details>
   <summary>Expand HTTP Example</summary>

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -32,8 +32,14 @@ server {
 }
 
 server {
+    # Nginx versions prior to 1.25
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
+
+    # Nginx versions 1.25+
+    #listen 443 ssl;
+    #listen [::]:443 ssl;
+    #http2 on;    
     server_name jellyfin.DOMAIN.TLD;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
@@ -195,8 +201,14 @@ server {
 }
 
 server {
+    # Nginx versions prior to 1.25
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
+
+    # Nginx versions 1.25+
+    #listen 443 ssl;
+    #listen [::]:443 ssl;
+    #http2 on;
 
     server_name DOMAIN.TLD;
     # You can specify multiple domain names if you want

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -39,7 +39,15 @@ server {
     # Nginx versions 1.25+
     #listen 443 ssl;
     #listen [::]:443 ssl;
-    #http2 on;    
+    #http2 on;
+
+    ## QUIC/HTTP3, requires Nginx 1.25+ w/http3 module
+    ## Can be used alongside http2 and http1.1
+    #listen 443 quic reuseport;
+    #listen [::]:443 quic reuseport;
+    ## required for browsers to direct them to quic port
+    #add_header Alt-Svc 'h3=":443"; ma=86400';
+
     server_name jellyfin.DOMAIN.TLD;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
@@ -209,6 +217,13 @@ server {
     #listen 443 ssl;
     #listen [::]:443 ssl;
     #http2 on;
+
+    ## QUIC/HTTP3, requires Nginx 1.25+ w/http3 module
+    ## Can be used alongside http2 and http1.1
+    #listen 443 quic reuseport;
+    #listen [::]:443 quic reuseport;
+    ## required for browsers to direct them to quic port
+    #add_header Alt-Svc 'h3=":443"; ma=86400';
 
     server_name DOMAIN.TLD;
     # You can specify multiple domain names if you want

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -35,9 +35,8 @@ server {
 #}
 
 #server {
-    # listen 443 ssl;
-    # listen [::]:443 ssl;
-    http2 on;
+    # listen 443 ssl http2;
+    # listen [::]:443 ssl http2;
     server_name DOMAIN_NAME;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
@@ -64,6 +63,7 @@ server {
     # Security / XSS Mitigation Headers
     # NOTE: X-Frame-Options may cause issues with the webOS app
     add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
     add_header X-Content-Type-Options "nosniff";
 
     # Permissions policy. May cause issues on some clients
@@ -179,7 +179,7 @@ server {
 
 ### HTTPS config example
 
-The following config is meant to work with Certbot / Let's Encrypt.
+The following config is meant to work with Certbot / Let's Encrypt.  Note that a server listening on http port 80 is required for the Certbot / Let's Encrypt certification creation / renewal process.
 
 ```conf
 # Jellyfin hosted on https://DOMAIN_NAME/jellyfin

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -41,13 +41,6 @@ server {
     #listen [::]:443 ssl;
     #http2 on;
 
-    ## QUIC/HTTP3, requires Nginx 1.25+ w/http3 module
-    ## Can be used alongside http2 and http1.1
-    #listen 443 quic reuseport;
-    #listen [::]:443 quic reuseport;
-    ## required for browsers to direct them to quic port
-    #add_header Alt-Svc 'h3=":443"; ma=86400';
-
     server_name jellyfin.DOMAIN.TLD;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
@@ -217,13 +210,6 @@ server {
     #listen 443 ssl;
     #listen [::]:443 ssl;
     #http2 on;
-
-    ## QUIC/HTTP3, requires Nginx 1.25+ w/http3 module
-    ## Can be used alongside http2 and http1.1
-    #listen 443 quic reuseport;
-    #listen [::]:443 quic reuseport;
-    ## required for browsers to direct them to quic port
-    #add_header Alt-Svc 'h3=":443"; ma=86400';
 
     server_name DOMAIN.TLD;
     # You can specify multiple domain names if you want

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -42,17 +42,17 @@ server {
     # Uncomment next line to Disable TLS 1.0 and 1.1 (Might break older devices)
     ssl_protocols TLSv1.3 TLSv1.2;
 
-    # use a variable to store the upstream proxy
-    # in this example we are using a hostname which is resolved via DNS
-    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
-    set $jellyfin jellyfin;
-    resolver 127.0.0.1 valid=30s;
-
     ssl_certificate /etc/letsencrypt/live/DOMAIN.TLD/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/DOMAIN.TLD/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN.TLD/chain.pem;
+
+    # use a variable to store the upstream proxy
+    # in this example we are using a hostname which is resolved via DNS
+    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
+    set $jellyfin jellyfin;
+    resolver 127.0.0.1 valid=30s;
 
     # Security / XSS Mitigation Headers
     # NOTE: X-Frame-Options may cause issues with the webOS app
@@ -202,15 +202,15 @@ server {
     # You can specify multiple domain names if you want
     #server_name jellyfin.local;
 
+    # Uncomment next line to disable TLS 1.0 and 1.1 (Might break older devices)
+    ssl_protocols TLSv1.3 TLSv1.2;
+
     ssl_certificate /etc/letsencrypt/live/DOMAIN.TLD/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/DOMAIN.TLD/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN.TLD/chain.pem;
     
-    # Uncomment next line to disable TLS 1.0 and 1.1 (Might break older devices)
-    ssl_protocols TLSv1.3 TLSv1.2;
-
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
     # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -7,7 +7,7 @@ title: Nginx
 
 "[Nginx](https://www.nginx.com/) (pronounced "engine X") is a web server which can also be used as a reverse proxy, load balancer, mail proxy and HTTP cache. The software was created by Igor Sysoev and first publicly released in 2004.[9] A company of the same name was founded in 2011 to provide support and Nginx plus paid software." - [Wikipedia](https://en.wikipedia.org/wiki/Nginx)
 
-## Nginx from a subdomain (jellyfin.example.org)
+## Nginx from a subdomain (jellyfin.DOMAIN.TLD)
 
 :::tip
 
@@ -181,7 +181,7 @@ server {
 
 </details>
 
-## Nginx with Subpath (example.org/jellyfin)
+## Nginx with Subpath (DOMAIN.TLD/jellyfin)
 
 When connecting to server from a client application, enter `http(s)://DOMAIN.TLD/jellyfin` in the address field.
 
@@ -483,4 +483,4 @@ In the "Advanced" tab, enter the following in "Custom Nginx Configuration".  Thi
     add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 ```
 
-In the "SSL" tab, use the jellyfin.example.org certificate that you created with Nginx Proxy Manager and enable "Force SSL", "HTTP/2 Support", "HSTS Enabled", "HSTS Subdomains".
+In the "SSL" tab, use the jellyfin.DOMAIN.TLD certificate that you created with Nginx Proxy Manager and enable "Force SSL", "HTTP/2 Support", "HSTS Enabled", "HSTS Subdomains".

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -107,6 +107,7 @@ server {
 ```
 
 ### HTTP Example
+
 <details>
   <summary>Expand HTTP Example</summary>
 ```config

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -7,13 +7,7 @@ title: Nginx
 
 "[Nginx](https://www.nginx.com/) (pronounced "engine X") is a web server which can also be used as a reverse proxy, load balancer, mail proxy and HTTP cache. The software was created by Igor Sysoev and first publicly released in 2004.[9] A company of the same name was founded in 2011 to provide support and Nginx plus paid software." - [Wikipedia](https://en.wikipedia.org/wiki/Nginx)
 
-## Nginx from a subdomain (jellyfin.DOMAIN.TLD)
-
-:::tip
-
-The default X-Frame-Options header may cause issues with the webOS app, causing it to remain stuck at a black screen. If enabled, the default Content Security Policy may also cause issues.
-
-:::
+## Nginx from a subdomain (jellyfin.example.org)
 
 Create the file `/etc/nginx/sites-available/jellyfin` which will forward requests to Jellyfin.  After you've finished, you will need to symlink this file to /etc/nginx/sites-enabled and then reload nginx.  This example assumes you've already acquired certifications as documented in our [Let's Encrypt](https://jellyfin.org/docs/general/networking/letsencrypt#nginx) guide.
 
@@ -25,7 +19,7 @@ Note that a server listening on http port 80 is required for the Certbot / Let's
 server {
     listen 80;
     listen [::]:80;
-    server_name jellyfin.DOMAIN.TLD;
+    server_name jellyfin.example.org;
 
     # Uncomment to redirect HTTP to HTTPS
     return 301 https://$host$request_uri;
@@ -41,7 +35,7 @@ server {
     #listen [::]:443 ssl;
     #http2 on;
 
-    server_name jellyfin.DOMAIN.TLD;
+    server_name jellyfin.example.org;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
@@ -49,11 +43,11 @@ server {
     # Uncomment next line to Disable TLS 1.0 and 1.1 (Might break older devices)
     ssl_protocols TLSv1.3 TLSv1.2;
 
-    ssl_certificate /etc/letsencrypt/live/DOMAIN.TLD/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/DOMAIN.TLD/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/example.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-    ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN.TLD/chain.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/example.org/chain.pem;
 
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
@@ -111,7 +105,7 @@ server {
 
 :::tip
 
-The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/). Using only HTTP will expose passwords and API keys.
+If you are planning on exposing your server over the Internet you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/). Using only HTTP will expose passwords and API keys.
 
 :::
 
@@ -122,7 +116,7 @@ The following configuration is provided for ease of use only. If you are plannin
 server {
     listen 80;
     listen [::]:80;
-    server_name jellyfin.DOMAIN.TLD;
+    server_name jellyfin.example.org;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
@@ -181,21 +175,21 @@ server {
 
 </details>
 
-## Nginx with Subpath (DOMAIN.TLD/jellyfin)
+## Nginx with Subpath (example.org/jellyfin)
 
-When connecting to server from a client application, enter `http(s)://DOMAIN.TLD/jellyfin` in the address field.
+When connecting to server from a client application, enter `http(s)://example.org/jellyfin` in the address field.
 
 Set the [base URL](/docs/general/networking#base-url) field in the Jellyfin server. This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the web client. Fill in this box with `/jellyfin` and click Save. The server will need to be restarted before this change takes effect.
 
 ### HTTPS subpath example
 
 ```conf
-# Jellyfin hosted on https://DOMAIN.TLD/jellyfin
+# Jellyfin hosted on https://example.org/jellyfin
 
 server {
     listen 80;
     listen [::]:80;
-    server_name DOMAIN.TLD;
+    server_name example.org;
 
     # Uncomment to redirect HTTP to HTTPS
     return 301 https://$host$request_uri;
@@ -211,18 +205,18 @@ server {
     #listen [::]:443 ssl;
     #http2 on;
 
-    server_name DOMAIN.TLD;
+    server_name example.org;
     # You can specify multiple domain names if you want
     #server_name jellyfin.local;
 
     # Uncomment next line to disable TLS 1.0 and 1.1 (Might break older devices)
     ssl_protocols TLSv1.3 TLSv1.2;
 
-    ssl_certificate /etc/letsencrypt/live/DOMAIN.TLD/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/DOMAIN.TLD/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/example.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-    ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN.TLD/chain.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/example.org/chain.pem;
     
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
@@ -291,13 +285,13 @@ server {
   <summary>Expand HTTP Example</summary>
 
 ```conf
-# Jellyfin hosted on http://DOMAIN.TLD/jellyfin
+# Jellyfin hosted on http://example.org/jellyfin
 
 server {
     listen 80;
     listen [::]:80;
 
-    server_name DOMAIN.TLD;
+    server_name example.org;
     # You can specify multiple domain names if you want
     #server_name jellyfin.local;
 
@@ -483,4 +477,4 @@ In the "Advanced" tab, enter the following in "Custom Nginx Configuration".  Thi
     add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 ```
 
-In the "SSL" tab, use the jellyfin.DOMAIN.TLD certificate that you created with Nginx Proxy Manager and enable "Force SSL", "HTTP/2 Support", "HSTS Enabled", "HSTS Subdomains".
+In the "SSL" tab, use the jellyfin.example.org certificate that you created with Nginx Proxy Manager and enable "Force SSL", "HTTP/2 Support", "HSTS Enabled", "HSTS Subdomains".

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -179,78 +179,6 @@ When connecting to server from a client application, enter `http(s)://DOMAIN_NAM
 
 Set the [base URL](/docs/general/networking#base-url) field in the Jellyfin server. This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the web client. Fill in this box with `/jellyfin` and click Save. The server will need to be restarted before this change takes effect.
 
-### HTTP config example
-
-:::caution
-
-HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS (see below for HTTPS configuration example). [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
-
-:::
-
-```conf
-# Jellyfin hosted on http://DOMAIN_NAME/jellyfin
-
-server {
-    listen 80;
-    listen [::]:80;
-
-    server_name DOMAIN_NAME;
-    # You can specify multiple domain names if you want
-    #server_name jellyfin.local;
-
-    # use a variable to store the upstream proxy
-    # in this example we are using a hostname which is resolved via DNS
-    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
-    set $jellyfin jellyfin;
-    resolver 127.0.0.1 valid=30s;
-
-    # Uncomment and create directory to also host static content
-    #root /srv/http/media;
-    index index.html;
-
-    location / {
-        try_files $uri $uri/ =404;
-    }
-
-    # Jellyfin
-    location /jellyfin {
-        return 302 $scheme://$host/jellyfin/;
-    }
-
-    # The / at the end is significant.
-    # https://www.acunetix.com/blog/articles/a-fresh-look-on-reverse-proxy-related-attacks/
-    location /jellyfin/ {
-        # Proxy main Jellyfin traffic
-        proxy_pass http://$jellyfin:8096;
-        proxy_pass_request_headers on;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
-
-        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
-        proxy_buffering off;
-    }
-
-    location /jellyfin/socket {
-        # Proxy Jellyfin Websockets traffic
-        proxy_pass http://$jellyfin:8096;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Protocol $scheme;
-        proxy_set_header X-Forwarded-Host $http_host;
-    }
-}
-```
-
 ### HTTPS config example
 
 ```conf
@@ -326,6 +254,83 @@ server {
     }
 }
 ```
+
+### HTTP config example
+
+:::caution
+
+HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS (see below for HTTPS configuration example). [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
+
+<details>
+  <summary>Expand HTTP Example</summary>
+
+:::
+
+```conf
+# Jellyfin hosted on http://DOMAIN_NAME/jellyfin
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name DOMAIN_NAME;
+    # You can specify multiple domain names if you want
+    #server_name jellyfin.local;
+
+    # use a variable to store the upstream proxy
+    # in this example we are using a hostname which is resolved via DNS
+    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
+    set $jellyfin jellyfin;
+    resolver 127.0.0.1 valid=30s;
+
+    # Uncomment and create directory to also host static content
+    #root /srv/http/media;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    # Jellyfin
+    location /jellyfin {
+        return 302 $scheme://$host/jellyfin/;
+    }
+
+    # The / at the end is significant.
+    # https://www.acunetix.com/blog/articles/a-fresh-look-on-reverse-proxy-related-attacks/
+    location /jellyfin/ {
+        # Proxy main Jellyfin traffic
+        proxy_pass http://$jellyfin:8096;
+        proxy_pass_request_headers on;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+
+        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        proxy_buffering off;
+    }
+
+    location /jellyfin/socket {
+        # Proxy Jellyfin Websockets traffic
+        proxy_pass http://$jellyfin:8096;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+    }
+}
+```
+
+</details>
 
 ## Extra Nginx Configurations
 

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -181,7 +181,7 @@ When connecting to server from a client application, enter `http(s)://DOMAIN_NAM
 
 Set the [base URL](/docs/general/networking#base-url) field in the Jellyfin server. This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the web client. Fill in this box with `/jellyfin` and click Save. The server will need to be restarted before this change takes effect.
 
-### HTTPS config example
+### HTTPS subpath example
 
 ```conf
 # Jellyfin hosted on https://DOMAIN_NAME/jellyfin
@@ -257,7 +257,7 @@ server {
 }
 ```
 
-### HTTP config example
+### HTTP subpath example
 
 :::caution
 

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -234,12 +234,24 @@ server {
         # Disable buffering when the nginx proxy gets very resource heavy upon streaming
         proxy_buffering off;
     }
+
+    location /jellyfin/socket {
+        # Proxy Jellyfin Websockets traffic
+        proxy_pass http://$jellyfin:8096;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+    }
 }
 ```
 
 ### HTTPS config example
-
-The following config is meant to work with Certbot / Let's Encrypt.  Note that a server listening on http port 80 is required for the Certbot / Let's Encrypt certification creation / renewal process.
 
 ```conf
 # Jellyfin hosted on https://DOMAIN_NAME/jellyfin
@@ -260,14 +272,13 @@ server {
     server_name DOMAIN_NAME;
     # You can specify multiple domain names if you want
     #server_name jellyfin.local;
+
     ssl_certificate /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-    add_header Strict-Transport-Security "max-age=31536000" always;
     ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN_NAME/chain.pem;
-    ssl_stapling on;
-    ssl_stapling_verify on;
+
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
     # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
@@ -275,7 +286,7 @@ server {
     resolver 127.0.0.1 valid=30s;
 
     # Uncomment next line to disable TLS 1.0 and 1.1 (Might break older devices)
-    # ssl_protocols TLSv1.3 TLSv1.2;
+    ssl_protocols TLSv1.3 TLSv1.2;
 
     # Jellyfin
     location /jellyfin {
@@ -286,18 +297,13 @@ server {
     # https://www.acunetix.com/blog/articles/a-fresh-look-on-reverse-proxy-related-attacks/
     location /jellyfin/ {
         # Proxy main Jellyfin traffic
-
         proxy_pass http://$jellyfin:8096;
-
         proxy_pass_request_headers on;
-
         proxy_set_header Host $host;
-
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
-
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
 
@@ -305,6 +311,19 @@ server {
         proxy_buffering off;
     }
 
+    location /jellyfin/socket {
+        # Proxy Jellyfin Websockets traffic
+        proxy_pass http://$jellyfin:8096;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+    }
 }
 ```
 

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -116,7 +116,7 @@ server {
     listen [::]:80;
     server_name DOMAIN_NAME;
 
-    ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
+    # The default client_max_body_size is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
 
     # use a variable to store the upstream proxy

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -21,29 +21,30 @@ The default X-Frame-Options header may cause issues with the webOS app, causing 
 
 :::
 
-Create the file `/etc/nginx/sites-available/jellyfin` which will forward requests to Jellyfin.  After you've finished, you will need to symlink this file to /etc/nginx/sites-enabled and then reload nginx.
+Create the file `/etc/nginx/sites-available/jellyfin` which will forward requests to Jellyfin.  After you've finished, you will need to symlink this file to /etc/nginx/sites-enabled and then reload nginx.  This example assumes you've already acquired certifications as documented in our [Let's Encrypt](https://jellyfin.org/docs/general/networking/letsencrypt#nginx) guide.
+
+Note that a server listening on http port 80 is required for the Certbot / Let's Encrypt certificate renewal process.
 
 ```config
-# Uncomment the commented sections after you have acquired a SSL Certificate
 server {
     listen 80;
     listen [::]:80;
-    # server_name DOMAIN_NAME;
+    server_name DOMAIN_NAME;
 
     # Uncomment to redirect HTTP to HTTPS
-    # return 301 https://$host$request_uri;
-#}
+    return 301 https://$host$request_uri;
+}
 
-#server {
-    # listen 443 ssl http2;
-    # listen [::]:443 ssl http2;
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name DOMAIN_NAME;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
 
     # Uncomment next line to Disable TLS 1.0 and 1.1 (Might break older devices)
-    # ssl_protocols TLSv1.3 TLSv1.2;
+    ssl_protocols TLSv1.3 TLSv1.2;
 
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
@@ -51,14 +52,11 @@ server {
     set $jellyfin jellyfin;
     resolver 127.0.0.1 valid=30s;
 
-    #ssl_certificate /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem;
-    #ssl_certificate_key /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem;
-    #include /etc/letsencrypt/options-ssl-nginx.conf;
-    #ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-    #add_header Strict-Transport-Security "max-age=31536000" always;
-    #ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN_NAME/chain.pem;
-    #ssl_stapling on;
-    #ssl_stapling_verify on;
+    ssl_certificate /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN_NAME/chain.pem;
 
     # Security / XSS Mitigation Headers
     # NOTE: X-Frame-Options may cause issues with the webOS app
@@ -108,6 +106,72 @@ server {
 
 ```
 
+### HTTP Example
+<details>
+  <summary>Expand HTTP Example</summary>
+```config
+server {
+    listen 80;
+    listen [::]:80;
+    server_name DOMAIN_NAME
+
+    ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
+    client_max_body_size 20M;
+
+    # use a variable to store the upstream proxy
+    # in this example we are using a hostname which is resolved via DNS
+    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
+    set $jellyfin jellyfin;
+    resolver 127.0.0.1 valid=30s;
+
+    # Security / XSS Mitigation Headers
+    # NOTE: X-Frame-Options may cause issues with the webOS app
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
+    add_header X-Content-Type-Options "nosniff";
+
+    # Permissions policy. May cause issues on some clients
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
+
+    # Content Security Policy
+    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+    # Enforces https content and restricts JS/CSS to origin
+    # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
+    # NOTE: The default CSP headers may cause issues with the webOS app
+    #add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+
+    location / {
+        # Proxy main Jellyfin traffic
+        proxy_pass http://$jellyfin:8096;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+
+        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        proxy_buffering off;
+    }
+
+    location /socket {
+        # Proxy Jellyfin Websockets traffic
+        proxy_pass http://$jellyfin:8096;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+    }
+}
+
+```
+</details>
+
 ## Nginx with Subpath (example.org/jellyfin)
 
 When connecting to server from a client application, enter `http(s)://DOMAIN_NAME/jellyfin` in the address field.
@@ -156,18 +220,13 @@ server {
     # https://www.acunetix.com/blog/articles/a-fresh-look-on-reverse-proxy-related-attacks/
     location /jellyfin/ {
         # Proxy main Jellyfin traffic
-
         proxy_pass http://$jellyfin:8096;
-
         proxy_pass_request_headers on;
-
         proxy_set_header Host $host;
-
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
-
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
 

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -21,7 +21,7 @@ The default X-Frame-Options header may cause issues with the webOS app, causing 
 
 :::
 
-Create the file `/etc/nginx/conf.d/jellyfin.conf` which will forward requests to Jellyfin.
+Create the file `/etc/nginx/sites-available/jellyfin` which will forward requests to Jellyfin.  After you've finished, you will need to symlink this file to /etc/nginx/sites-enabled and then reload nginx.
 
 ```config
 # Uncomment the commented sections after you have acquired a SSL Certificate
@@ -66,11 +66,6 @@ server {
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-Content-Type-Options "nosniff";
 
-    # COOP/COEP. Disable if you use external plugins/images/assets
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Embedder-Policy "require-corp" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-
     # Permissions policy. May cause issues on some clients
     add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
 
@@ -81,11 +76,6 @@ server {
     # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
     # NOTE: The default CSP headers may cause issues with the webOS app
     #add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
-
-    location = / {
-        return 302 http://$host/web/;
-        #return 302 https://$host/web/;
-    }
 
     location / {
         # Proxy main Jellyfin traffic

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -264,8 +264,6 @@ HTTP is insecure. The following configuration is provided for ease of use only. 
 <details>
   <summary>Expand HTTP Example</summary>
 
-:::
-
 ```conf
 # Jellyfin hosted on http://DOMAIN_NAME/jellyfin
 

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -103,20 +103,20 @@ server {
         proxy_set_header X-Forwarded-Host $http_host;
     }
 }
-
 ```
 
 ### HTTP Example
 
 <details>
   <summary>Expand HTTP Example</summary>
+
 ```config
 server {
     listen 80;
     listen [::]:80;
     server_name DOMAIN_NAME;
 
-    # The default client_max_body_size is 1M, this might not be enough for some posters, etc.
+    ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
 
     # use a variable to store the upstream proxy
@@ -169,8 +169,8 @@ server {
         proxy_set_header X-Forwarded-Host $http_host;
     }
 }
-
 ```
+
 </details>
 
 ## Nginx with Subpath (example.org/jellyfin)
@@ -417,7 +417,6 @@ In the "Advanced" tab, enter the following in "Custom Nginx Configuration".  Thi
     # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
     # NOTE: The default CSP headers may cause issues with the webOS app
     #add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js https://www.gstatic.com/eureka/clank/95/cast_sender.js https://www.gstatic.com/eureka/clank/96/cast_sender.js https://www.gstatic.com/eureka/clank/97/cast_sender.js https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
-
 ```
 
 In the "SSL" tab, use the jellyfin.example.org certificate that you created with Nginx Proxy Manager and enable "Force SSL", "HTTP/2 Support", "HSTS Enabled", "HSTS Subdomains".

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -114,7 +114,7 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name DOMAIN_NAME
+    server_name DOMAIN_NAME;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -9,12 +9,6 @@ title: Nginx
 
 ## Nginx from a subdomain (jellyfin.example.org)
 
-:::caution
-
-HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/). Using only HTTP will expose passwords and API keys.
-
-:::
-
 :::tip
 
 The default X-Frame-Options header may cause issues with the webOS app, causing it to remain stuck at a black screen. If enabled, the default Content Security Policy may also cause issues.
@@ -31,7 +25,7 @@ Note that a server listening on http port 80 is required for the Certbot / Let's
 server {
     listen 80;
     listen [::]:80;
-    server_name DOMAIN_NAME;
+    server_name jellyfin.DOMAIN.TLD;
 
     # Uncomment to redirect HTTP to HTTPS
     return 301 https://$host$request_uri;
@@ -40,7 +34,7 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name DOMAIN_NAME;
+    server_name jellyfin.DOMAIN.TLD;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
@@ -54,11 +48,11 @@ server {
     set $jellyfin jellyfin;
     resolver 127.0.0.1 valid=30s;
 
-    ssl_certificate /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/DOMAIN.TLD/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/DOMAIN.TLD/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-    ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN_NAME/chain.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN.TLD/chain.pem;
 
     # Security / XSS Mitigation Headers
     # NOTE: X-Frame-Options may cause issues with the webOS app
@@ -69,13 +63,12 @@ server {
     # Permissions policy. May cause issues on some clients
     add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
 
-
     # Content Security Policy
     # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
     # Enforces https content and restricts JS/CSS to origin
     # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
     # NOTE: The default CSP headers may cause issues with the webOS app
-    #add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+    add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 
     location / {
         # Proxy main Jellyfin traffic
@@ -109,6 +102,12 @@ server {
 
 ### HTTP config example
 
+:::tip
+
+The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/). Using only HTTP will expose passwords and API keys.
+
+:::
+
 <details>
   <summary>Expand HTTP Example</summary>
 
@@ -116,7 +115,7 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name DOMAIN_NAME;
+    server_name jellyfin.DOMAIN.TLD;
 
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
@@ -141,7 +140,7 @@ server {
     # Enforces https content and restricts JS/CSS to origin
     # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
     # NOTE: The default CSP headers may cause issues with the webOS app
-    #add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+    add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 
     location / {
         # Proxy main Jellyfin traffic
@@ -177,19 +176,19 @@ server {
 
 ## Nginx with Subpath (example.org/jellyfin)
 
-When connecting to server from a client application, enter `http(s)://DOMAIN_NAME/jellyfin` in the address field.
+When connecting to server from a client application, enter `http(s)://DOMAIN.TLD/jellyfin` in the address field.
 
 Set the [base URL](/docs/general/networking#base-url) field in the Jellyfin server. This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the web client. Fill in this box with `/jellyfin` and click Save. The server will need to be restarted before this change takes effect.
 
 ### HTTPS subpath example
 
 ```conf
-# Jellyfin hosted on https://DOMAIN_NAME/jellyfin
+# Jellyfin hosted on https://DOMAIN.TLD/jellyfin
 
 server {
     listen 80;
     listen [::]:80;
-    server_name DOMAIN_NAME;
+    server_name DOMAIN.TLD;
 
     # Uncomment to redirect HTTP to HTTPS
     return 301 https://$host$request_uri;
@@ -199,15 +198,18 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name DOMAIN_NAME;
+    server_name DOMAIN.TLD;
     # You can specify multiple domain names if you want
     #server_name jellyfin.local;
 
-    ssl_certificate /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/DOMAIN.TLD/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/DOMAIN.TLD/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-    ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN_NAME/chain.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN.TLD/chain.pem;
+    
+    # Uncomment next line to disable TLS 1.0 and 1.1 (Might break older devices)
+    ssl_protocols TLSv1.3 TLSv1.2;
 
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
@@ -215,8 +217,21 @@ server {
     set $jellyfin jellyfin;
     resolver 127.0.0.1 valid=30s;
 
-    # Uncomment next line to disable TLS 1.0 and 1.1 (Might break older devices)
-    ssl_protocols TLSv1.3 TLSv1.2;
+    # Security / XSS Mitigation Headers
+    # NOTE: X-Frame-Options may cause issues with the webOS app 
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
+    add_header X-Content-Type-Options "nosniff";
+
+    # Permissions policy. May cause issues on some clients
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
+
+    # Content Security Policy
+    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+    # Enforces https content and restricts JS/CSS to origin
+    # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
+    # NOTE: The default CSP headers may cause issues with the webOS app
+    add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 
     # Jellyfin
     location /jellyfin {
@@ -259,23 +274,17 @@ server {
 
 ### HTTP subpath example
 
-:::caution
-
-HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS (see below for HTTPS configuration example). [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
-
-:::
-
 <details>
   <summary>Expand HTTP Example</summary>
 
 ```conf
-# Jellyfin hosted on http://DOMAIN_NAME/jellyfin
+# Jellyfin hosted on http://DOMAIN.TLD/jellyfin
 
 server {
     listen 80;
     listen [::]:80;
 
-    server_name DOMAIN_NAME;
+    server_name DOMAIN.TLD;
     # You can specify multiple domain names if you want
     #server_name jellyfin.local;
 
@@ -284,6 +293,22 @@ server {
     # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
     set $jellyfin jellyfin;
     resolver 127.0.0.1 valid=30s;
+
+    # Security / XSS Mitigation Headers
+    # NOTE: X-Frame-Options may cause issues with the webOS app 
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
+    add_header X-Content-Type-Options "nosniff";
+
+    # Permissions policy. May cause issues on some clients
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=(), serial=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
+
+    # Content Security Policy
+    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+    # Enforces https content and restricts JS/CSS to origin
+    # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
+    # NOTE: The default CSP headers may cause issues with the webOS app
+    add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 
     # Uncomment and create directory to also host static content
     #root /srv/http/media;
@@ -442,7 +467,7 @@ In the "Advanced" tab, enter the following in "Custom Nginx Configuration".  Thi
     # Enforces https content and restricts JS/CSS to origin
     # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
     # NOTE: The default CSP headers may cause issues with the webOS app
-    #add_header Content-Security-Policy "default-src https: data: blob: http://image.tmdb.org; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js https://www.gstatic.com/eureka/clank/95/cast_sender.js https://www.gstatic.com/eureka/clank/96/cast_sender.js https://www.gstatic.com/eureka/clank/97/cast_sender.js https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+    add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 ```
 
 In the "SSL" tab, use the jellyfin.example.org certificate that you created with Nginx Proxy Manager and enable "Force SSL", "HTTP/2 Support", "HSTS Enabled", "HSTS Subdomains".


### PR DESCRIPTION
Correcting and adjusting Nginx docs.  Jellyfin site config should not be in conf.d.  Also making adjustments to config to address common problems.  Particularly with the COOP/COEP headers causing image searching to not show images.