### PR TITLE
refactor: remove deprecated docker compose v1 mentions

### DIFF
--- a/docs/general/administration/hardware-acceleration/amd.md
+++ b/docs/general/administration/hardware-acceleration/amd.md
@@ -409,7 +409,7 @@ Root permission is required.
    getent group video | cut -d: -f3
    ```
 
-2. Use Docker command line **or** docker-compose:
+2. Use Docker command line **or** docker compose:
 
    - Example command line:
 
@@ -427,10 +427,9 @@ Root permission is required.
       jellyfin/jellyfin
      ```
 
-   - Example docker-compose (version 3) configuration file written in YAML:
+   - Example docker-compose configuration file written in YAML:
 
      ```yaml
-     version: '3'
      services:
        jellyfin:
          image: jellyfin/jellyfin

--- a/docs/general/administration/hardware-acceleration/intel.md
+++ b/docs/general/administration/hardware-acceleration/intel.md
@@ -501,7 +501,7 @@ What you need to do is pass the host's `render` group id to Docker and modify th
    getent group render | cut -d: -f3
    ```
 
-2. Use docker command line **or** docker-compose:
+2. Use docker command line **or** docker compose:
 
    - Example command line:
 
@@ -519,10 +519,9 @@ What you need to do is pass the host's `render` group id to Docker and modify th
       jellyfin/jellyfin
      ```
 
-   - Example docker-compose (version 3) configuration file written in YAML:
+   - Example docker-compose configuration file written in YAML:
 
      ```yaml
-     version: '3'
      services:
        jellyfin:
          image: jellyfin/jellyfin

--- a/docs/general/administration/hardware-acceleration/nvidia.md
+++ b/docs/general/administration/hardware-acceleration/nvidia.md
@@ -331,10 +331,9 @@ Root permission is required.
       jellyfin/jellyfin
      ```
 
-   - Example docker-compose (version 3) configuration file written in YAML:
+   - Example docker-compose configuration file written in YAML:
 
      ```yaml
-     version: '3'
      services:
        jellyfin:
          image: jellyfin/jellyfin

--- a/docs/general/administration/migrate.md
+++ b/docs/general/administration/migrate.md
@@ -72,7 +72,6 @@ docker run -d \
 ### Using docker-compose yaml
 
 ```yml
-version: '3'
 services:
   jellyfin:
     image: jellyfin/jellyfin

--- a/docs/general/networking/traefik.md
+++ b/docs/general/networking/traefik.md
@@ -31,7 +31,6 @@ sudo docker network create traefik
 ### docker-compose.yml
 
 ```yml
-version: '3.5'
 networks:
   traefik:
     name: traefik
@@ -181,7 +180,7 @@ Change example.com to your domain name and update the acme.json file with your e
 Launch the Traefik and Jellyfin services.
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Congratulations, your stack with Traefik and Jellyfin is running!

--- a/docs/general/networking/traefik2.md
+++ b/docs/general/networking/traefik2.md
@@ -26,7 +26,6 @@ The configuration below creates a Traefik v2.x installation with access at entry
 ### docker-compose.yml
 
 ```yml
-version: '2.4'
 services:
   traefik:
     container_name: traefik
@@ -287,7 +286,7 @@ These configurations use DOMAIN_NAME (i.e.: example.com) and HOST_NAME (i.e.: se
 Launch the Traefik and Jellyfin services.
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 If you set a PathPrefix (i.e. /jellyfin), you need to configure Jellyfin to expect it. After starting the service, access Jellyfin directly (via the host's IP at port 8096) and change the 'Base URL' in Dashboard / Advanced / Networking to match the '/jellyfin' path (if you used one in this configuration). Afterward, you may wish to create a firewall rule to prevent direct access to Jellyfin at port 8096 on the host, or simply ensure the port is not accessible via the Internet.


### PR DESCRIPTION
* [`version` key is deprecated](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete). It even issues a warning in docker compose post v1.
* `docker-compose` v1 has been totally deprecated one year ago already.