### PR TITLE
refactor(web-config): remove mention to stable config as config.json source

### DIFF
--- a/docs/general/clients/web-config.md
+++ b/docs/general/clients/web-config.md
@@ -9,7 +9,7 @@ title: Jellyfin Web Configuration
 
 The Jellyfin Web default interface can be configured using the `config.json` file in the webroot. Where this is and how to edit it depends on the installation method.
 
-We recommend obtaining the [stable](https://github.com/jellyfin/jellyfin-web/blob/release-10.8.z/src/config.json) or the [unstable](https://github.com/jellyfin/jellyfin-web/blob/master/src/config.json) default version of the file to pre-populate your configuration directory before starting Jellyfin for the first time; unlike most other components of this directory, it will not be created automatically.
+We recommend obtaining the [unstable](https://github.com/jellyfin/jellyfin-web/blob/master/src/config.json) default version of the file to pre-populate your configuration directory before starting Jellyfin for the first time; unlike most other components of this directory, it will not be created automatically.
 
 ### Debian/Ubuntu/Fedora/CentOS Packages
 


### PR DESCRIPTION
This is out of date already and with the faster cadence of releases we plan to have, this can easily become a burden to maintain.

@thornbill Does web break if the json file contains keys that it's not aware of (that's the only incompatibility I can see, some new setting introduced in an update)? Or it's able to just pick the ones that it expects correctly?

Marking as a draft until we have OK from Bill in that regard