### PR TITLE
Update the linux.md for generic amd64 installation with details for Arch-based issues

### DIFF
--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -364,6 +364,16 @@ sudo mkdir data cache config log
 ### `FFmpeg` Installation
 
 If you are not running a Debian derivative, install `ffmpeg` through your OS's package manager, and skip this section.
+In case you run into trascoding and playback issues and you are running an Arch derivative, one which has `jellyfin-ffmpeg` bundled in its package manager, you can try installing `jellyfin-ffmpeg` to fix the issue. If still not working, also consider moving the `jellyfin-ffmpeg` installation folder from its default location at `/usr/lib/jellyfin-ffmpeg` to the one directory looked for by Jellyfin at run *i.e.:* `/usr/share/jellyfin-ffmpeg/`.
+```sh
+sudo pacman -S jellyfin-ffmpeg
+sudo cp -a /usr/lib/jellyfin-ffmpeg /usr/share/jellyfin-ffmpeg/
+```
+A further step into troubleshooting is to manually set the transcoding app path into the config file `encoding.xml` adding two new lines
+```sh
+<EncoderAppPath>/usr/share/jellyfin-ffmpeg/</EncoderAppPath>
+<EncoderAppPathDisplay>/usr/share/jellyfin-ffmpeg/ffmpeg</EncoderAppPathDisplay>
+```
 
 :::caution
 


### PR DESCRIPTION
Added a paragraph for Arch-based distro running into the fatal playback error when ffmpeg is not found and jellyfin-ffmpeg is installed in a different directory in the system tree than the one looked by default by Jellyfin.

Hope this is the right place, otherwise please move it to the relevant troubleshoot/FAQ section, as I couldn't find a dedicated one and had a lot of trouble finding a solution via various forums and issues.
Thanks