### PR TITLE
Explain how to install subtitles in Docker

### DIFF
--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -113,7 +113,7 @@ Jellyfin uses fonts to render text in many places.
 
 ### Server Side System Fonts
 
-The system fonts installed on the server are used for burning in subtitles and rendering cover images. How to install them depends on the operating system.
+The system fonts installed on the server are used for burning in subtitles and rendering cover images. How to install them depends on the operating system or container being used.
 
 ### Client Side System Fonts
 
@@ -121,7 +121,7 @@ The system fonts installed on the client devices are used to display the text in
 
 ### Fallback Fonts
 
-The `Fallback Fonts` option is currently used by the web client to render subtitles only. This can be set to a folder containing fonts for this purpose. These fonts are limited to a total size of 20MB. Lightweight formats optimized for web like woff2 are recommended. A tool to convert normal TrueType (`.ttf`) and OpenType (`.otf`) fonts to woff2 can be found [in their repo](https://github.com/google/woff2).
+The `Fallback Fonts` option is currently used by the web client to render subtitles only. This can be set to a folder on the server containing fonts for this purpose, which will then be streamed to the client during playback, negating the need to manually install them to all clients locally. These fonts are limited to a total size of 20 MB. Lightweight formats optimized for web like woff2 are recommended. A tool to convert normal TrueType (`.ttf`) and OpenType (`.otf`) fonts to woff2 can be found [in their repo](https://github.com/google/woff2).
 
 ### Downloading Fonts
 

--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -113,7 +113,7 @@ Jellyfin uses fonts to render text in many places.
 
 ### Server Side System Fonts
 
-The system fonts installed on the server are used for burning in subtitles and rendering cover images. How to install them depends on the operating system or container being used.
+The system fonts installed on the server are used for burning in subtitles and rendering cover images. How to install them depends on the operating system or if a container is being used.
 
 ### Client Side System Fonts
 
@@ -121,7 +121,9 @@ The system fonts installed on the client devices are used to display the text in
 
 ### Fallback Fonts
 
-The `Fallback Fonts` option is currently used by the web client to render subtitles only. This can be set to a folder on the server containing fonts for this purpose, which will then be streamed to the client during playback, negating the need to manually install them to all clients locally. These fonts are limited to a total size of 20 MB. Lightweight formats optimized for web like woff2 are recommended. A tool to convert normal TrueType (`.ttf`) and OpenType (`.otf`) fonts to woff2 can be found [in their repo](https://github.com/google/woff2).
+The `Fallback Fonts` installed on the server are loaded up by the web client to render ASS subtitles. They will be used if no other existing fonts (such as MKV attachments or client-side fonts) can be used to render certain glyphs, such as CJK characters, instead of displaying an empty "tofu" block.
+
+This setting can be set to a folder on the server containing fonts for this purpose. These fonts are limited to a total size of 20 MB, since all of them will be always preloaded in the browser, regardless of whether they'll be needed or not. Lightweight formats optimized for web like woff2 are recommended. A tool to convert normal TrueType (`.ttf`) and OpenType (`.otf`) fonts to woff2 can be found [in their repo](https://github.com/google/woff2).
 
 ### Downloading Fonts
 

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -83,6 +83,12 @@ Multiple media libraries can be bind mounted if needed:
 ...etc
 ```
 
+Custom [server-side system fonts](/docs/general/administration/configuration/#server-side-system-fonts) directory can be optionally bind mounted in order to use these fonts during transcoding with subtitle burn-in:
+
+```sh
+--mount type=bind,source=/path/to/fonts,target=/usr/local/share/fonts/custom,readonly
+```
+
 ### Using Docker Compose
 
 Create a `docker-compose.yml` file with the following contents. Add in the UID and GID that you would like to run jellyfin as in the user line below, or remove the user line to use the default (root).
@@ -103,6 +109,11 @@ services:
       - type: bind
         source: /path/to/media2
         target: /media2
+        read_only: true
+      # Optional - extra fonts to be used during transcoding with subtitle burn-in
+      - type: bind
+        source: /path/to/fonts
+        target: /usr/local/share/fonts/custom
         read_only: true
     restart: 'unless-stopped'
     # Optional - alternative address used for autodiscovery

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -89,6 +89,12 @@ Custom [server-side system fonts](/docs/general/administration/configuration/#se
 --mount type=bind,source=/path/to/fonts,target=/usr/local/share/fonts/custom,readonly
 ```
 
+A directory of [fallback fonts](/docs/general/administration/configuration/#fallback-fonts) can be mounted as well. In this case, you will have to set the directory of fallback fonts to `/fallback_fonts` in Jellyfin server settings panel:
+
+```sh
+--mount type=bind,source=/path/to/fallback/fonts,target=/fallback_fonts,readonly
+```
+
 ### Using Docker Compose
 
 Create a `docker-compose.yml` file with the following contents. Add in the UID and GID that you would like to run jellyfin as in the user line below, or remove the user line to use the default (root).


### PR DESCRIPTION
Server-side fonts are used for subtitle burn-in, so it might be of interest to users to install custom fonts there.

Apparently it's enough to mount a custom font directory into for example `/usr/local/share/fonts/custom` (the `custom` part is arbitrary name, but the primary `/usr/local/share/fonts` folder shouldn't be mounted itself as it also has `.uuid` file there, so a subdir needs to be created.

And once that's done, the fontcache will apparently be automatically updated on container restart. So that just works out of the box with no changes to Jellyfin required at all.

Also did some changes to section where font types are explained.

> How to install them depends on the operating system **or container being used**.

This is meant to both suggest people to look into Docker docs if they use Docker container, and to also not have some newbie install fonts on host OS while using a container and be confused why that doesn't work, this slight addition will hopefully prevent that.

Also added some things to Fallback Fonts section to hopefully make it clear how that feature works and in which direction the fonts go there.