### PR TITLE
Add server policy and homepage link

### DIFF
--- a/docs/general/community-standards/commercial-support.md
+++ b/docs/general/community-standards/commercial-support.md
@@ -18,3 +18,5 @@ Because of this policy, many within the project have mixed feelings about suppor
 Thus, while Jellyfin is a GNU GPL-licensed project which does not prevent or preclude commercial uses, please be aware that some members of our community do not look kindly on this and, as is their choice under our volunteer-only policy, may not be willing to provide support for commercial implementations. Not everyone feels this way, and such discussions are allowed here (subject to all other rules), but we want to ensure this is explicitly stated to avoid any misunderstandings or misaligned expectations.
 
 In short, if you are expecting support for the commercialization of Jellyfin, please do so respectfully and with the mutual understanding that this is not something everyone might wish to endorse, and no member of the team nor forum community is under any obligation to assist if they do not want to.
+
+Note that this policy is strictly in regards to **legitimate** business uses of Jellyfin. [Running pirate media instances is covered by our Server Policy.](/docs/general/community-standards/servers).

--- a/docs/general/community-standards/commercial-support.md
+++ b/docs/general/community-standards/commercial-support.md
@@ -19,4 +19,4 @@ Thus, while Jellyfin is a GNU GPL-licensed project which does not prevent or pre
 
 In short, if you are expecting support for the commercialization of Jellyfin, please do so respectfully and with the mutual understanding that this is not something everyone might wish to endorse, and no member of the team nor forum community is under any obligation to assist if they do not want to.
 
-Note that this policy is strictly in regards to **legitimate** business uses of Jellyfin. [Running pirate media instances is covered by our Server Policy.](/docs/general/community-standards/servers).
+Note that this policy is strictly in regards to **legitimate** business uses of Jellyfin. [Running pirate media instances is covered by our Server Policy.](/docs/general/community-standards/servers)

--- a/docs/general/community-standards/servers.md
+++ b/docs/general/community-standards/servers.md
@@ -13,7 +13,7 @@ The Jellyfin Project itself, and members of the Jellyfin team, **do not provide 
 
 * **It is not us. We do not run that server.** Do not contact us, privately or publicly, for help with connecting, resetting your password, etc. We cannot help you because we do not run the server. Contact whoever you are paying. If you do not know who that is, we cannot help you.
 
-* **This is almost unequivocally piracy of some sort.** Do not discuss it with us [as per our community standards guidelines](/docs/general/community-standards).
+* **This is almost unequivocally piracy of some sort.** Do not discuss it with us [as per our community standards](/docs/general/community-standards).
 
 Requests for support/help with other people's servers will be ignored.
 
@@ -21,6 +21,6 @@ Requests for support/help with other people's servers will be ignored.
 
 If you run a Jellyfin server instance for other people, ensure that your users are aware that **you** are their contact for help and support, not us. We are not your server's "customer support" team. **You are not "Jellyfin"**. Do not use our name. Do not insinuate to your users that your server is run by us or that we are the same people.
 
-We will link your users to this page if they contact us for help with your server. If you are charging people for pirate access to a Jellyfin server and violate these guidelines, and we become aware, we reserve the right to report you to your hosting provider for piracy and ban you and your users from our support channels. This is [a violation of our community standards guidelines](/docs/general/community-standards) and will not be tolerated.
+We will link your users to this page if they contact us for help with your server. If you are charging people for pirate access to a Jellyfin server and violate these guidelines, and we become aware, we reserve the right to report you to your hosting provider for piracy and ban you and your users from our support channels. This is [a violation of our community standards](/docs/general/community-standards) and will not be tolerated.
 
 You have been warned.

--- a/docs/general/community-standards/servers.md
+++ b/docs/general/community-standards/servers.md
@@ -16,3 +16,7 @@ The Jellyfin Project itself, and members of the Jellyfin team, **do not provide 
 * **This is almost unequivocably piracy of some sort.** Do not discuss it with us [as per our community standards guidelines](/docs/general/community-standards). **We are in no way affiliated with "Mobilvids" or any similar pirate services**.
 
 Requests for support/help with other people's servers will be ignored.
+
+## Running a Third Party Server
+
+If you are running such a third party server, **you are not "Jellyfin"**. Do not use our name. Do not insinuate to your users that we are the same people. Do not send them to us for "support". We will link your users to this page if they contact us. If you insist on continuing, and we become aware, we reserve the right to report you to your hosting provider for piracy.

--- a/docs/general/community-standards/servers.md
+++ b/docs/general/community-standards/servers.md
@@ -1,0 +1,18 @@
+---
+uid: community-standards-servers
+title: Server Policy
+---
+
+# Server Policy
+
+Jellyfin is a free and open source project that provides the **tools to run your own server** for hosting your media, and clients to connect to one of those servers.
+
+The Jellyfin Project itself, and members of the Jellyfin team, **do not provide servers for you to use**, with the sole exception of [our demo server for evaluation and testing](https://demo.jellyfin.org/stable).
+
+**If you are using or paying someone for "Jellyfin" i.e. access to a specific server:**
+
+* **It is not us. We do not run that server.** Do not contact us, privately or publicly, for help with connecting, resetting your password, etc. We cannot help you because we do not run the server. Contact whoever you are paying. If you do not know who that is, we cannot help you.
+
+* **This is almost unequivocably piracy of some sort.** Do not discuss it with us [as per our community standards guidelines](/docs/general/community-standards). **We are in no way affiliated with "Mobilvids" or any similar pirate services**.
+
+Requests for support/help with other people's servers will be ignored.

--- a/docs/general/community-standards/servers.md
+++ b/docs/general/community-standards/servers.md
@@ -21,6 +21,6 @@ Requests for support/help with other people's servers will be ignored.
 
 If you run a Jellyfin server instance for other people, ensure that your users are aware that **you** are their contact for help and support, not us. We are not your server's "customer support" team. **You are not "Jellyfin"**. Do not use our name. Do not insinuate to your users that your server is run by us or that we are the same people.
 
-We will link your users to this page if they contact us for help with your server. If you are charging people for pirate access to a Jellyfin server and violate these guidelines, and we become aware, we reserve the right to report you to your hosting provider for piracy and ban your users from our support channels. This is [a violation of our community standards guidelines](/docs/general/community-standards) and will not be tolerated.
+We will link your users to this page if they contact us for help with your server. If you are charging people for pirate access to a Jellyfin server and violate these guidelines, and we become aware, we reserve the right to report you to your hosting provider for piracy and ban you and your users from our support channels. This is [a violation of our community standards guidelines](/docs/general/community-standards) and will not be tolerated.
 
 You have been warned.

--- a/docs/general/community-standards/servers.md
+++ b/docs/general/community-standards/servers.md
@@ -19,7 +19,7 @@ Requests for support/help with other people's servers will be ignored.
 
 ## If You Run A Jellyfin Server
 
-If you run a Jellyfin server instance, ensure that your users are aware that **you** are their contact for help and support, not us. We are not your server's "customer support" team. **You are not "Jellyfin"**. Do not use our name. Do not insinuate to your users that your server is run by us or that we are the same people.
+If you run a Jellyfin server instance for other people, ensure that your users are aware that **you** are their contact for help and support, not us. We are not your server's "customer support" team. **You are not "Jellyfin"**. Do not use our name. Do not insinuate to your users that your server is run by us or that we are the same people.
 
 We will link your users to this page if they contact us for help with your server. If you are charging people for pirate access to a Jellyfin server and violate these guidelines, and we become aware, we reserve the right to report you to your hosting provider for piracy and ban your users from our support channels. This is [a violation of our community standards guidelines](/docs/general/community-standards) and will not be tolerated.
 

--- a/docs/general/community-standards/servers.md
+++ b/docs/general/community-standards/servers.md
@@ -13,7 +13,7 @@ The Jellyfin Project itself, and members of the Jellyfin team, **do not provide 
 
 * **It is not us. We do not run that server.** Do not contact us, privately or publicly, for help with connecting, resetting your password, etc. We cannot help you because we do not run the server. Contact whoever you are paying. If you do not know who that is, we cannot help you.
 
-* **This is almost unequivocally piracy of some sort.** Do not discuss it with us [as per our community standards guidelines](/docs/general/community-standards). **We are in no way affiliated with "Mobilvids" or any similar pirate services**.
+* **This is almost unequivocally piracy of some sort.** Do not discuss it with us [as per our community standards guidelines](/docs/general/community-standards).
 
 Requests for support/help with other people's servers will be ignored.
 

--- a/docs/general/community-standards/servers.md
+++ b/docs/general/community-standards/servers.md
@@ -13,10 +13,14 @@ The Jellyfin Project itself, and members of the Jellyfin team, **do not provide 
 
 * **It is not us. We do not run that server.** Do not contact us, privately or publicly, for help with connecting, resetting your password, etc. We cannot help you because we do not run the server. Contact whoever you are paying. If you do not know who that is, we cannot help you.
 
-* **This is almost unequivocably piracy of some sort.** Do not discuss it with us [as per our community standards guidelines](/docs/general/community-standards). **We are in no way affiliated with "Mobilvids" or any similar pirate services**.
+* **This is almost unequivocally piracy of some sort.** Do not discuss it with us [as per our community standards guidelines](/docs/general/community-standards). **We are in no way affiliated with "Mobilvids" or any similar pirate services**.
 
 Requests for support/help with other people's servers will be ignored.
 
-## Running a Third Party Server
+## If You Run A Jellyfin Server
 
-If you are running such a third party server, **you are not "Jellyfin"**. Do not use our name. Do not insinuate to your users that we are the same people. Do not send them to us for "support". We will link your users to this page if they contact us. If you insist on continuing, and we become aware, we reserve the right to report you to your hosting provider for piracy.
+If you run a Jellyfin server instance, ensure that your users are aware that **you** are their contact for help and support, not us. We are not your server's "customer support" team. **You are not "Jellyfin"**. Do not use our name. Do not insinuate to your users that your server is run by us or that we are the same people.
+
+We will link your users to this page if they contact us for help with your server. If you are charging people for pirate access to a Jellyfin server and violate these guidelines, and we become aware, we reserve the right to report you to your hosting provider for piracy and ban your users from our support channels. This is [a violation of our community standards guidelines](/docs/general/community-standards) and will not be tolerated.
+
+You have been warned.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,7 +28,7 @@ export default function Home() {
             Download Now
           </Link>
         </div>
-        <p><a href="/docs/community-standards/servers">Note: We do not run servers for users.</a></p>
+        <p><a href="/docs/general/community-standards/servers">Note: We do not run servers for users.</a></p>
       </Hero>
       <main>
         <HomepageFeatures />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,7 +28,7 @@ export default function Home() {
             Download Now
           </Link>
         </div>
-        <p><a href="/docs/community-standards/server-policy">Note: We do not run servers for users.</a></p>
+        <p><a href="/docs/community-standards/servers">Note: We do not run servers for users.</a></p>
       </Hero>
       <main>
         <HomepageFeatures />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,6 +28,7 @@ export default function Home() {
             Download Now
           </Link>
         </div>
+        <p><a href="/docs/community-standards/server-policy">Note: We do not run servers for users.</a></p>
       </Hero>
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
With a recent uptick in people asking for help with "Jellyfin" i.e. some third party server we do not support, add this as an explicit policy and add a link on the homepage to it.