### PR TITLE
remove  X-XSS-Protection

### DIFF
--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -58,7 +58,6 @@ server {
     # Security / XSS Mitigation Headers
     # NOTE: X-Frame-Options may cause issues with the webOS app
     add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-XSS-Protection "0"; # Do NOT enable. This is obsolete/dangerous
     add_header X-Content-Type-Options "nosniff";
 
     # Permissions policy. May cause issues with some clients


### PR DESCRIPTION
why is this line not removed, when it is dangerous and obsolete?

According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection, we should remove it.