### PR TITLE
docs: fix audiobooks folder structure example for book

### DIFF
--- a/docs/general/server/media/books.md
+++ b/docs/general/server/media/books.md
@@ -10,12 +10,12 @@ The most common organization scheme for books is separation by Audiobook then by
 ```txt
 Books
 ├── Audiobooks
-│   ├── Author
-│   │   ├── Book1.flac
-│   │   └── Book2.flac
-│   └── Book
-│       ├── Chapter1.flac
-│       └── Chapter2.flac
+│   └── Author
+│       ├── Book1.flac
+│       ├── Book2.flac
+│       └── Book
+│           ├── Chapter1.flac
+│           └── Chapter2.flac
 └── Books
     └── Author
         ├── Book1.epub


### PR DESCRIPTION
A book should be under an Author, even for Audiobooks.

---
error in Server guide > Media > Books graph - Audiobooks "Books" folder should be under "Author" not "Audiobooks" parent

In https://jellyfin.org/docs/general/server/media/books, I believe
```
Books
├── Audiobooks
│   ├── Author
│   │   ├── Book1.flac
│   │   └── Book2.flac
│   └── Book
│       ├── Chapter1.flac
│       └── Chapter2.flac
└── Books
    └── Author
        ├── Book1.epub
        ├── Book2.epub
        ├── Book
        │   ├── Book1.epub
        │   ├── cover.ext
        │   └── metadata.opf
        └── Book3.mp3
```
should be
```
Books
├── Audiobooks
│   └── Author
│       ├── Book1.flac
│       ├── Book2.flac
│       └── Book
│           ├── Chapter1.flac
│           └── Chapter2.flac
└── Books
    └── Author
        ├── Book1.epub
        ├── Book2.epub
        ├── Book
        │   ├── Book1.epub
        │   ├── cover.ext
        │   └── metadata.opf
        └── Book3.mp3
``

That is in "Server guide > Media > Books" under Audiobooks, the "Books" folder should be under "Author" not "Audiobooks" parent folder.