### PR TITLE
Change sudo nano to sudoedit

### DIFF
--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -384,7 +384,7 @@ sudo apt install -f
 Due to the number of command line options that must be passed on to the Jellyfin binary, it is easiest to create a small script to run Jellyfin.
 
 ```sh
-SUDO_EDITOR=nano sudoedit jellyfin.sh
+sudoedit jellyfin.sh
 ```
 
 Then paste the following commands and modify as needed.

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -384,7 +384,7 @@ sudo apt install -f
 Due to the number of command line options that must be passed on to the Jellyfin binary, it is easiest to create a small script to run Jellyfin.
 
 ```sh
-sudo nano jellyfin.sh
+SUDO_EDITOR=nano sudoedit jellyfin.sh
 ```
 
 Then paste the following commands and modify as needed.

--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -21,7 +21,7 @@ Jellyfin produces logs that can be monitored by Fail2ban to prevent brute-force 
 You need to create a jail for Fail2ban. If you're on Ubuntu and use nano as editor, run:
 
 ```bash
-sudo nano /etc/fail2ban/jail.d/jellyfin.local
+SUDO_EDITOR=nano sudoedit /etc/fail2ban/jail.d/jellyfin.local
 ```
 
 Add this to the new file, replacing `/path_to_logs` with the path to the log files above, e.g. `/var/log/jellyfin/`:

--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -21,7 +21,7 @@ Jellyfin produces logs that can be monitored by Fail2ban to prevent brute-force 
 You need to create a jail for Fail2ban. If you're on Ubuntu and use nano as editor, run:
 
 ```bash
-SUDO_EDITOR=nano sudoedit /etc/fail2ban/jail.d/jellyfin.local
+sudoedit /etc/fail2ban/jail.d/jellyfin.local
 ```
 
 Add this to the new file, replacing `/path_to_logs` with the path to the log files above, e.g. `/var/log/jellyfin/`:

--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -57,7 +57,7 @@ Note:
 The filter contains a set of rules which Fail2ban will use to identify a failed authentication attempt. Create the filter by running:
 
 ```bash
-sudo nano /etc/fail2ban/filter.d/jellyfin.conf
+SUDO_EDITOR=nano sudoedit /etc/fail2ban/filter.d/jellyfin.conf
 ```
 
 Paste:

--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -57,7 +57,7 @@ Note:
 The filter contains a set of rules which Fail2ban will use to identify a failed authentication attempt. Create the filter by running:
 
 ```bash
-SUDO_EDITOR=nano sudoedit /etc/fail2ban/filter.d/jellyfin.conf
+sudoedit /etc/fail2ban/filter.d/jellyfin.conf
 ```
 
 Paste:


### PR DESCRIPTION
`sudoedit` is safer than running `nano` with `sudo`. I changed the 3 entries I could find that had `sudo nano` to `SUDO_EDITOR=nano sudoedit`