### PR TITLE
Update social.png in meta tags to fix cache on some services

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,7 +19,7 @@ const config: Config = {
   organizationName: 'jellyfin',
   projectName: 'jellyfin.org',
   themeConfig: {
-    image: 'images/social.png',
+    image: 'images/social.png?v2',
     metadata: [
       { name: 'og:type', content: 'website' },
       { name: 'twitter:card', content: 'summary_large_image' },


### PR DESCRIPTION
Some services are still caching our old social.png with the old logo. Updating the URL with a cache buster should solve this.