### PR TITLE
Add Manet to the clients list

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -907,5 +907,28 @@ export const Clients: Array<Client> = [
         url: 'https://streamyfin.app'
       }
     ]
+  },
+  {
+    id: 'manet',
+    name: 'Manet',
+    description: 'A third-party music client for iOS',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/manet-music/id6470928235'
+      },
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://tilo.dev/manet/'
+      }
+    ]
   }
 ];


### PR DESCRIPTION
First of all - thank you all for your hard work on Jellyfin! It really is a great piece of software 🙌🏽 

I'm the developer of the [Manet](https://tilo.dev/manet/) music app for iOS and got sent a link to [this form post](https://forum.jellyfin.org/t-ios-carplay-client-for-music-manet?pid=22475#pid22475) that suggests that you might accept paid apps for the jellyfin.org website, so I thought I'd send this PR to open the discussion about being added.