### PR TITLE
Part°2 - fix some typography

### DIFF
--- a/docs/general/contributing/development.md
+++ b/docs/general/contributing/development.md
@@ -15,7 +15,7 @@ Summarized here are the two biggest ones, one for backend devs and another for f
 - [Jellyfin Server](https://github.com/jellyfin/jellyfin): The server portion, built using .NET 8 and C#.
 - [Jellyfin Web](https://github.com/jellyfin/jellyfin-web): The main client application built for browsers, but also used in some of our other clients that are just wrappers.
 
-Note that each of the repositories also has its own documentation on how to get started with that project, generally found in the repository README. You can also view the organization [source tree](/docs/general/contributing/source-tree) to see how some of the bigger projects are structured.
+Note that each of the repositories also has its own documentation on how to get started with that project, generally found in the repository as README. You can also view the organization [source tree](/docs/general/contributing/source-tree) to see how some of the bigger projects are structured.
 
 The best way to get going on some actual development is to look through the [issues list](https://github.com/jellyfin/jellyfin/issues) of the associated repository, find an issue you would like to work on, and start hacking! Issues are triaged regularly by the administrative team, and labels assigned that should help you find issues within your skill-set. Once you start working on an issue, please comment on it stating your intent to work on the issue, to avoid unnecessary duplication of work.
 
@@ -25,7 +25,7 @@ A list of issue types can be found on the [issue guidelines](/docs/general/contr
 
 ### What if there isn't an issue?
 
-If there isn't already an issue dealing with the changes you want to make, please [create an issue](/docs/general/contributing/issues) to track it first, then ensure your PR(s) reference the issue in question. This is especially useful for bugs that are found and then fixed by the author, so both the original issue and the fix can be documented and tracked in detail.
+If there isn't already an issue dealing with the changes you want to make, please [create an issue](/docs/general/contributing/issues) to track it first, then ensure your PR(s) reference to the issue in question. This is especially useful for bugs that are found and then fixed by the author, so both the original issue and the fix can be documented and tracked in detail.
 
 ## How should you make changes?
 
@@ -58,7 +58,7 @@ The first step is to set up a copy of the Git repository of the project you want
 
 5. Build the Jellyfin Web project with NPM, and copy the location of the resulting `dist` folder.
 
-6. In your `Jellyfin.Server` project add an environment variable named `JELLYFIN_WEB_DIR` with the value set to the full path of your `dist` folder.
+6. In your `Jellyfin.Server` project adds an environment variable named `JELLYFIN_WEB_DIR` with the value set to the full path of your `dist` folder.
 
 You will now be ready to begin building or modifying the project.
 
@@ -116,7 +116,7 @@ If it's your first time contributing code to a particular repository, please add
 
 From time to time, major projects may come up that require multiple PRs and contributions from multiple people. For these tasks, feature branches specific to the feature should be created, based off of `master`. This helps allow the work to progress without breaking `master` for long periods and allowing those interested in that particular project the ability to work at their own pace instead of racing to fix a broken feature before the next release. To create a feature branch, please communicate with a Core team member and that can be arranged.
 
-Once the feature a feature branch was created for is ready, it can be merged in one shot into `master` and the feature branch removed. Alternatively, for very-long-lived features, certain "stable" snapshots can be merged into `master` as required.
+Once the feature, a feature branch was created for is ready, it can be merged in one shot into `master` and the feature branch removed. Alternatively, for very-long-lived features, certain "stable" snapshots can be merged into `master` as required.
 
 ### The Master Branch
 
@@ -157,7 +157,7 @@ When submitting a new PR, please ensure you do the following things. If you have
 
 - Before submitting a PR, squash "junk" commits together to keep the overall history clean. A single commit should cover a single significant change: avoid squashing all your changes together, especially for large PRs that touch many files, but also don't leave "fixed this", "whoops typo" commits in your branch history as this is needless clutter in the final history of the project.
 
-- Write a good title that quickly describes what has been changed. For example, "Add LDAP support to Jellyfin". As mentioned in [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/), always use the imperative mood, and keep the title short but descriptive. The title will eventually be a changelog entry, so please try to use proper capitalization but no punctuation; note that the Core team may alter titles to better conform to this standard before merging.
+- Write a good title that quickly describes what has been changed. For example, "Add LDAP support to Jellyfin". As mentioned in [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/), always use the imperative mood, and keep the title short but descriptive. The title will eventually be a changelog entry, so please try to use proper capitalization but no punctuation; Note that the Core team may alter titles to better conform to this standard before merging.
 
 - For anything but the most trivial changes that can be described fully in the (short) title, follow the PR template and write a PR body to describe, in as much detail as possible:
 
@@ -165,7 +165,7 @@ When submitting a new PR, please ensure you do the following things. If you have
 
   2. How you approached the issue (if applicable) and briefly describe the changes, especially for large PRs.
 
-- If your pull request is not finished yet, please mark it as a "draft" when you open it. While this tag is in place, the pull request will not be merged, and reviews should remain as comments only. Once you are happy with the final state of your PR, please remove this tag; forgetting to do so might result in your PR being unintentionally ignored as still under active development! Inactive WIPs may occasionally elicit pings from the team inquiring on the status and closed if there is no response.
+- If your pull request is not finished yet, please mark it as a "draft" when you open it. While this tag is in place, the pull request will not be merged, and reviews should remain as comments only. Once you are happy with the final state of your PR, please remove this tag; Forgetting to do so might result in your PR being unintentionally ignored as still under active development! Inactive WIPs may occasionally elicit pings from the team inquiring on the status and closed if there is no response.
 
 - Avoid rebasing and force-pushing to large or complex pull requests if at all possible, and especially after reviews. It forces unnecessary reviews to verify the changes are still okay and build properly.
 

--- a/docs/general/contributing/issues.md
+++ b/docs/general/contributing/issues.md
@@ -41,9 +41,9 @@ When writing a bug issue, please ensure you capture as much relevant detail as p
 
 - Any non-standard configurations you use
 
-Bugs should be tagged with `[bug]` at the beginning of their title. This will later be removed by the Jellyfin team when assigning labels. To assist in triaging, if you know which other [label(s)](/docs/general/contributing/issues#issue-labels) should be applied to your issue, please add them after the `[bug]` label.
+Bugs should be tagged with `[bug]` at the beginning of their title. This will later be removed from the Jellyfin team when assigning labels. To assist in triaging, if you know which other [label(s)](/docs/general/contributing/issues#issue-labels) should be applied to your issue, please add them after the `[bug]` label.
 
-Bugs should be reproduceable. That is, you should be able to have determined through troubleshooting how to replicate the issue. While one-time bugs should not be ignored, if they're difficult or impossible to reproduce, it's likely very hard to fix them. Please attempt to reproduce the bug before filing the issue and include the smallest test case you can to demonstrate it.
+Bugs should be reproducible. That is, you should be able to have determined through troubleshooting how to replicate the issue. While one-time bugs should not be ignored, if they're difficult or impossible to reproduce, it's likely very hard to fix them. Please attempt to reproduce the bug before filing the issue and include the smallest test case you can to demonstrate it.
 
 If you ever need assistance for troubleshooting or opening an issue, please [contact the community](/docs/general/getting-help) and we'll try to help you out!
 

--- a/docs/general/contributing/release-procedure.md
+++ b/docs/general/contributing/release-procedure.md
@@ -80,7 +80,7 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
 ### Hotfix Release Procedure
 
-1. During normal work on the `master` branch, select PRs suitable for backporting by tagging them with the `stable-backport` label during the PR lifecycle. All PRs will target `master` and thus bugfixes for the stable release must include this label to be included.
+1. During normal work on the `master` branch, select PRs suitable for backporting by tagging them with the `stable-backport` label during the PR lifecycle. All PRs will target `master` and thus bug fixes for the stable release must include this label to be included.
 
 1. Collect the list of merged `stable-backport` PRs from all relevant repositories.
 
@@ -126,4 +126,4 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
 1. Wait for builds to complete.
 
-1. Announce the new release in the [jellyfin-announce](https://matrix.to/#/#jellyfin-announce:matrix.org) channel and anywhere else as required.
+1. Announce the new release in the [jellyfin-announce](https://matrix.to/#/#jellyfin-announce:matrix.org) channel, and anywhere else as required.

--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -57,7 +57,7 @@ However [`rpmfusion`](https://rpmfusion.org/) provides both `jellyfin-server` an
 
    :::note
 
-   You do not need to manually install `ffmpeg`; it will be installed by the Jellyfin server package as a dependency.
+   You do not need to manually install `ffmpeg`; It will be installed by the Jellyfin server package as a dependency.
 
    :::
 
@@ -89,10 +89,10 @@ However [`rpmfusion`](https://rpmfusion.org/) provides both `jellyfin-server` an
 
    This will open the following ports:
 
-   * `8096 TCP`, used by default for HTTP traffic; you can change this in the dashboard
-   * `8920 TCP`, used by default for HTTPS traffic; you can change this in the dashboard
-   * `1900 UDP`, used for service auto-discovery; this is not configurable
-   * `7359 UDP`, used for auto-discovery; this is not configurable
+   * `8096 TCP`, used by default for HTTP traffic; You can change this in the dashboard
+   * `8920 TCP`, used by default for HTTPS traffic; You can change this in the dashboard
+   * `1900 UDP`, used for service auto-discovery; This is not configurable
+   * `7359 UDP`, used for auto-discovery; This is not configurable
 
    :::
 
@@ -155,7 +155,7 @@ The script tries to handle as many common derivatives as possible, including, at
 
 ### Repository (Using extrepo)
 
-extrepo is only supported on Debian currently. The advantage of extrepo is that it is packaged in Debian. So you don’t have to execute the `curl | sudo bash` combo from the previous Automatic section. The risk with that command is that it relies on the security of the webserver. extrepo avoids this by having the Jellyfin repo information including the GPG key in its [extrepo-data](https://salsa.debian.org/extrepo-team/extrepo-data/-/blob/master/repos/debian/jellyfin.yaml?ref_type=heads). extrepo-data is verified with GPG by the extrepo tool. So there is a chain of trust from Debian all the way to the Jellyfin repo information.
+extrepo is only supported on Debian currently. The advantage of extrepo is that it is packaged in Debian. So you don’t have to execute the `curl | sudo bash` combo from the previous Automatic section. The risk with that command is that it relies on the security of the web server. extrepo avoids this by having the Jellyfin repo information including the GPG key in its [extrepo-data](https://salsa.debian.org/extrepo-team/extrepo-data/-/blob/master/repos/debian/jellyfin.yaml?ref_type=heads). extrepo-data is verified with GPG by the extrepo tool. So there is a chain of trust from Debian all the way to the Jellyfin repo information.
 
 ```sh
 sudo apt install extrepo
@@ -182,7 +182,7 @@ If you would prefer to install everything manually, the full steps are as follow
 
    :::note
 
-   If the above command fails you will need to install the following package `software-properties-common`.
+   If the above command fails, you will need to install the following package `software-properties-common`.
    This can be achieved with the following command `sudo apt-get install software-properties-common`
 
    :::
@@ -216,7 +216,7 @@ If you would prefer to install everything manually, the full steps are as follow
 
    The supported values for the above variables are:
 
-   * `${VERSION_OS}`: One of `debian` or `ubuntu`; if it is not, use the closest one for your distribution.
+   * `${VERSION_OS}`: One of `debian` or `ubuntu`; If it is not, use the closest one for your distribution.
    * `${VERSION_CODENAME}`: One of our supported [Debian](https://github.com/jellyfin/jellyfin-repo-helper-scripts/blob/master/install-debuntu.sh#L7) or [Ubuntu](https://github.com/jellyfin/jellyfin-repo-helper-scripts/blob/master/install-debuntu.sh#L8) release codenames. These can change as new releases come out and old releases are dropped, so check the script to be sure yours is supported.
    * `${DPKG_ARCHITECTURE}`: One of our [supported architectures](https://github.com/jellyfin/jellyfin-repo-helper-scripts/blob/master/install-debuntu.sh#L6). Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is **not** supported on the `i386` architecture.
 
@@ -255,7 +255,7 @@ If you would prefer to install everything manually, the full steps are as follow
 
 ### `.deb` Packages (Very Manual)
 
-Raw `.deb` packages, including old versions, source packages, and `dpkg` meta files, are available [in the main download repository](https://repo.jellyfin.org/?path=/server/).
+Raw `.deb` packages, including older versions, source packages, and `dpkg` meta files, are available [in the main download repository](https://repo.jellyfin.org/?path=/server/).
 
 :::note
 
@@ -271,7 +271,7 @@ The repository is the preferred way to obtain Jellyfin on Debian and Ubuntu syst
 
    :::note
 
-   If the above command fails you will need to install the following package `software-properties-common`.
+   If the above command fails, you will need to install the following package `software-properties-common`.
    This can be achieved with the following command `sudo apt-get install software-properties-common`
 
    :::
@@ -288,7 +288,7 @@ The repository is the preferred way to obtain Jellyfin on Debian and Ubuntu syst
 
    :::note
 
-   This step may throw errors; continue to the next step to resolve them.
+   This step may throw errors; Continue to the next step to resolve them.
 
    :::
 
@@ -367,7 +367,7 @@ If you are not running a Debian derivative, install `ffmpeg` through your OS's p
 
 :::caution
 
-Not being able to use `jellyfin-ffmpeg` will most likely break hardware acceleration and tonemapping.
+Not being able to use `jellyfin-ffmpeg` will most likely break hardware acceleration and tone mapping.
 
 :::
 
@@ -403,14 +403,14 @@ $JELLYFINDIR/jellyfin/jellyfin \
 ```
 
 Assuming you desire Jellyfin to run as a non-root user, `chmod` all files and directories to your normal login user and group.
-Also make the startup script above executable.
+Also, make the startup script above executable.
 
 ```sh
 sudo chown -R user:group *
 sudo chmod u+x jellyfin.sh
 ```
 
-Finally you can run it.
+Finally, you can run it.
 You will see lots of log information when run, this is normal.
 Setup is as usual in the web browser.
 

--- a/docs/general/installation/macos.md
+++ b/docs/general/installation/macos.md
@@ -33,11 +33,11 @@ Jellyfin 10.9 or newer is required for Apple Silicon native support.
 ### Uninstall
 
 1. Stop the currently running server either via the dashboard or using the application icon.
-2. Move the `.app` package to the trash.
+2. Move the `.app` package in the trash.
 
 ### Deleting Configuration
 
-This will delete all settings and user information. This applies for the .app package and the portable version.
+This will delete all settings and user information. This applies to the .app package and the portable version.
 
 1. Delete the folder `~/.config/jellyfin/`
 2. Delete the folder `~/.local/share/jellyfin/`
@@ -84,14 +84,14 @@ Closing the terminal window will end Jellyfin. Running Jellyfin in screen or tmu
 
 The portable version doesn't come with FFmpeg by default. There are a few options for installing FFmpeg:
 
-- download jellyfin-ffmpeg from the [Jellyfin repo](https://repo.jellyfin.org/?path=/ffmpeg/macos) (recommended)
-- use the package manager homebrew by typing `brew install ffmpeg` into your Terminal ([here's how to install homebrew if you don't have it already](https://treehouse.github.io/installation-guides/mac/homebrew)
-- download the most recent static build from [this link](https://evermeet.cx/ffmpeg/get/zip) (compiled by a third party see [this page](https://evermeet.cx/ffmpeg/) for options and information) (Apple Silicon builds are not available from this source)
-- compile from source available from the official [website](https://ffmpeg.org/download.html)
+- Download jellyfin-ffmpeg from the [Jellyfin repo](https://repo.jellyfin.org/?path=/ffmpeg/macos) (recommended)
+- Use the package manager homebrew by typing `brew install ffmpeg` into your Terminal ([here's how to install homebrew if you don't have it already](https://treehouse.github.io/installation-guides/mac/homebrew)
+- Download the most recent static build from [this link](https://evermeet.cx/ffmpeg/get/zip) (compiled by a third party see [this page](https://evermeet.cx/ffmpeg/) for options and information) (Apple Silicon builds are not available from this source)
+- Compile from source available from the official [website](https://ffmpeg.org/download.html)
 
 Once downloaded, remove the quarantine flag for the `ffmpeg` and `ffprobe`.
 
-Ensure that both `ffmpeg` and `ffprobe` are located at the same path, then execute the following command:
+Ensure that both `ffmpeg` and `ffprobe` are located in the same path, then execute the following command:
 
 ```shell
 cd /path/to/ffmpeg/folder

--- a/docs/general/installation/source.md
+++ b/docs/general/installation/source.md
@@ -34,13 +34,13 @@ All package builds begin with these two steps:
    docker build -t $USERNAME/jellyfin --file docker/Dockerfile .
    ```
 
-   or
+   Or
 
    ```sh
    podman build -t $USERNAME/jellyfin --file docker/Dockerfile .
    ```
 
-   or use provided Python build script:
+   Or use provided Python build script:
 
    ```sh
    ./build.py auto docker
@@ -54,7 +54,7 @@ All package builds begin with these two steps:
    docker run -d -p 8096:8096 $USERNAME/jellyfin
    ```
 
-   or
+   Or
 
    ```sh
    podman run -d -p 8096:8096 $USERNAME/jellyfin
@@ -101,13 +101,13 @@ This will very likely be split out into a separate repository at some point in t
    windows\build-jellyfin.ps1 -verbose
    ```
 
-   - The `-WindowsVersion` and `-Architecture` flags can optimize the build for your current environment; the default is generic Windows x64.
+   - The `-WindowsVersion` and `-Architecture` flags can optimize the build for your current environment; The default is a generic Windows x64.
 
-   - The `-InstallLocation` flag lets you select where the compiled binaries go; the default is `$Env:AppData\Jellyfin-Server\`.
+   - The `-InstallLocation` flag lets you select where the compiled binaries go; The default is `$Env:AppData\Jellyfin-Server\`.
 
-   - The `-InstallFFMPEG` flag will automatically pull the stable `ffmpeg` binaries appropriate to your architecture (x86/x64 only for now) from [BtbN](https://github.com/BtbN/FFmpeg-Builds/releases) and place them in your Jellyfin directory.
+   - The `-InstallFFMPEG` flag will automatically pull the appropriate stable `ffmpeg` binaries for your architecture (x86/x64 only for now) from [BtbN](https://github.com/BtbN/FFmpeg-Builds/releases) and place them in your Jellyfin directory.
 
-   - The `-InstallNSSM` flag will automatically pull the stable `nssm` binary appropriate to your architecture (x86/x64 only for now) from [NSSM's Website](https://nssm.cc/) and place it in your Jellyfin directory.
+   - The `-InstallNSSM` flag will automatically pull the appropriate stable `nssm` binary for your architecture (x86/x64 only for now) from [NSSM's Website](https://nssm.cc/) and place it in your Jellyfin directory.
 
 7. (Optional) Use [NSSM](https://nssm.cc) to configure Jellyfin to run as a service.
 

--- a/docs/general/installation/windows.md
+++ b/docs/general/installation/windows.md
@@ -11,8 +11,8 @@ Windows installers and builds in ZIP archive format are available [here](/downlo
 
 :::caution
 
-If you installed a version prior to 10.4.0 using a PowerShell script, you will need to manually remove the service using the command `nssm remove Jellyfin` and uninstall the server by remove all the files manually.
-Also one might need to move the data files to the correct location, or point the installer at the old location.
+If you installed a version prior to 10.4.0 using a PowerShell script, you will need to manually remove the service using the command `nssm remove Jellyfin` and uninstall the server by removing all the files manually.
+Also, one might need to move the data files to the correct location, or point the installer at the old location.
 
 :::
 
@@ -23,7 +23,7 @@ Using the Advanced/Service mode may experience FFmpeg hardware acceleration issu
 
 :::
 
-## Install using installer
+## Install using the installer
 
 **Install**
 
@@ -42,7 +42,7 @@ Using the Advanced/Service mode may experience FFmpeg hardware acceleration issu
 
 **Uninstall**
 
-1. Go to `Add or remove programs` in Windows.
+1. Go to `Add or remove programs` on Windows.
 2. Search for Jellyfin.
 3. Click Uninstall.
 

--- a/docs/general/networking/apache.md
+++ b/docs/general/networking/apache.md
@@ -18,7 +18,7 @@ title: Apache
     CustomLog /var/log/apache2/DOMAIN_NAME-access.log combined
 </VirtualHost>
 
-# If you are not using a SSL certificate, replace the 'redirect'
+# If you are not using an SSL certificate, replace the 'redirect'
 # line above with all lines below starting with 'Proxy'
 <IfModule mod_ssl.c>
 <VirtualHost *:443>
@@ -60,7 +60,7 @@ title: Apache
 </IfModule>
 ```
 
-If you encouter errors, you may have to enable `mod_proxy`, `mod_ssl`, `proxy_wstunnel`, `http2`, `headers` and `remoteip` support manually.
+If you encounter errors, you may have to enable `mod_proxy`, `mod_ssl`, `proxy_wstunnel`, `http2`, `headers` and `remoteip` support manually.
 
 ```bash
 sudo a2enmod proxy proxy_http ssl proxy_wstunnel remoteip http2 headers
@@ -68,13 +68,13 @@ sudo a2enmod proxy proxy_http ssl proxy_wstunnel remoteip http2 headers
 
 ## Apache with Subpath (example.org/jellyfin)
 
-When connecting to server from a client application, enter `http(s)://DOMAIN_NAME/jellyfin` in the address field.
+When connecting to the server from a client application, enter `http(s)://DOMAIN_NAME/jellyfin` in the address field.
 
 Set the [base URL](/docs/general/networking#base-url) field in the Jellyfin server. This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the web client. Fill in this box with `/jellyfin` and click Save. The server will need to be restarted before this change takes effect.
 
 :::caution
 
-HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
+HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet, you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
 
 :::
 

--- a/docs/general/networking/caddy.md
+++ b/docs/general/networking/caddy.md
@@ -14,7 +14,7 @@ You can reverse proxy to Jellyfin either with or without a config file, and eith
 If you aren't familiar with Caddy yet, check out its [Getting Started](https://caddyserver.com/docs/getting-started) guide.
 
 :::caution
-There are a some guides that have a Caddyfile which includes a `tls` section with the DNS provider's API key as shown in the following example.
+There is some guides that have a Caddyfile which includes a `tls` section with the DNS provider's API key as shown in the following example.
 
 ```Caddyfile
 example.com {
@@ -49,16 +49,16 @@ That is a simple but production-ready plaintext HTTP reverse proxy.
 
 If you have:
 
-- permission to bind to low ports, and
-- a public domain name's DNS records pointed at your machine,
+- Permission to bind to low ports, and
+- A public domain name's DNS records pointed at your machine,
 
-then you can serve over HTTPS just as easily:
+Then you can serve over HTTPS just as easily:
 
 ```bash
 caddy reverse-proxy --from example.com --to 127.0.0.1:8096
 ```
 
-You will see Caddy provision a TLS certificate for your site and if it succeeds, you can then access your Jellyfin server over HTTPS with your domain name.
+You will see Caddy provision of a TLS certificate for your site and if it succeeds, you can then access your Jellyfin server over HTTPS with your domain name.
 
 ## Caddyfile
 

--- a/docs/general/networking/dlna.md
+++ b/docs/general/networking/dlna.md
@@ -5,10 +5,10 @@ title: DLNA
 
 ## DLNA
 
-DLNA is based on uPnP.
+DLNA is based on UPnP.
 DLNA will send a broadcast signal from Jellyfin.
 This broadcast is limited to Jellyfin's current subnet.
-If you are using docker, the network should use Host Mode, otherwise the broadcast signal will only be sent in the bridged network inside of docker.
+If you are using docker, the network should use Host Mode, otherwise the broadcast signal will only be sent on the bridged network inside of docker.
 
 If DLNA fails to bind properly, the message `[ERR] Failed to bind to port 1900: "Address already in use". DLNA will be unavailable` should appear in the logs.
 

--- a/docs/general/networking/haproxy.md
+++ b/docs/general/networking/haproxy.md
@@ -12,7 +12,7 @@ frontend jellyfin_proxy
     bind *:80
 
 # Note that haproxy requires you to concatenate the certificate and key into a single file
-# Uncomment the appropriate lines after you have acquired a SSL Certificate
+# Uncomment the appropriate lines after you have acquired an SSL Certificate
 #
 #  HAProxy <1.7
 #    bind *:443 ssl crt /etc/ssl/DOMAIN_NAME.pem

--- a/docs/general/networking/iis.md
+++ b/docs/general/networking/iis.md
@@ -119,4 +119,4 @@ Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.
 
 ## SSL
 
-[CertifytheWeb](https://certifytheweb.com/); a very easy to use UI for getting certificates
+[CertifytheWeb](https://certifytheweb.com/); A very easy to use UI for getting certificates

--- a/docs/general/networking/index.md
+++ b/docs/general/networking/index.md
@@ -9,23 +9,23 @@ This section describes how to get basic connectivity to a Jellyfin server, and a
 
 ## Connectivity
 
-Many clients will automatically discover servers running on the same LAN and display them on login. If you are outside the network when you connect you can type in the complete IP address or domain name in the server field with the correct port to continue to the login page. You can find the default ports below to access the web frontend.
+Many clients will automatically discover servers running on the same LAN and display them on login. If you are outside the network when you connect, you can type in the complete IP address or domain name in the server field with the correct port to continue to the login page. You can find the default ports below to access the web frontend.
 
 HTTP and HTTPS are the primary means of connecting to the server. If using a self-signed certificate for HTTPS, some clients may not work such as Chromecast or Roku.
 
 :::caution
 
 In order for Chromecast to work on your local LAN, the easiest solution is to use IPv6 instead of IPv4.
-For IPv4, you need to use NAT reflection to redirect to your local LAN IPv4 or add a override rules to your local DNS server to point to your local LAN IPv4 (for example 192.168.1.10) of Jellyfin.  
+For IPv4, you need to use NAT reflection to redirect to your local LAN IPv4 or add an override rules to your local DNS server to point to your local LAN IPv4 (for example 192.168.1.10) of Jellyfin.  
 Because Chromecasts have hardcoded Google DNS servers, you need to block Chromecast from reaching these servers (8.8.8.8) so it makes use of your local DNS server instead.  
-For a public routable IPv6 (not a link-local or ULA) there is no difference between public or local. Such IPv6 address is simultaneously publicly routable and accessible from the local LAN.  
+For a public routable IPv6 (not a link-local or ULA), there is no difference between public or local. Such IPv6 address is simultaneously publicly routable and accessible from the local LAN.  
 Because of that, there is no blocking, redirecting or DNS override needed.
 
 :::
 
 ### Port Bindings
 
-This document aims to provide an administrator with knowledge on what ports Jellyfin binds to and what purpose they serve.
+This document aims to provide an administrator with the knowledge of what ports Jellyfin binds to and what purpose they serve.
 
 #### Static Ports
 
@@ -72,7 +72,7 @@ Omit `-nodes` to set a password interactively.
 
 Remove `-days 365` to make it 'permanent'.
 
-Add `-subj '/CN=localhost'` to make it not ask interactive questions about content of certificate.
+Add `-subj '/CN=localhost'` to make it not ask interactive questions about the content of the certificate.
 
 The above command creates `./privkey.pem` which will require one more step before use in Jellyfin.
 
@@ -84,7 +84,7 @@ openssl pkcs12 -export -out jellyfin.pfx -inkey privkey.pem -in /usr/local/etc/l
 
 It's possible to run Jellyfin behind another server acting as a reverse proxy. With a reverse proxy setup, this server handles all network traffic and proxies it back to Jellyfin. This provides the benefits of using DNS names and not having to remember port numbers, as well as easier integration and management of SSL certificates.
 
-In cases when you would like to not use host networking with docker, you may use the gateway ip as a known proxy to fix ip resolution for clients logging in.
+In cases when you would like to not use host networking with docker, you may use the gateway IP as a known proxy to fix IP resolution for clients logging in.
 
 :::caution
 
@@ -95,9 +95,9 @@ These examples assume you want to run Jellyfin under a sub-domain (e.g. jellyfin
 
 :::caution
 
-Be careful when logging requests with your reverse proxy. Jellyfin sometimes sends authentication information as part of the URL (e.g `api_key` parameter), so logging the full request path can expose secrets to your logfile.
-We recommend that you either protect your logfiles or do not log full request URLs or censor sensitive data from the logfile.
-The nginx documentation below includes an example how to censor sensitive information from a logfile.
+Be careful when logging requests with your reverse proxy. Jellyfin sometimes sends authentication information as part of the URL (e.g. `api_key` parameter), so logging the full request path can expose the secrets to your log files.
+We recommend that you either protect your log files or do not log full request URLs or censor sensitive data from it.
+The nginx documentation below includes an example how to censor sensitive information from a log file.
 
 :::
 
@@ -153,4 +153,4 @@ There are three main caveats to this setting.
 
 ### Final Steps
 
-It's strongly recommend that you check your SSL strength and server security at [SSLLabs](https://www.ssllabs.com/ssltest/analyze.html) if you are exposing these services to the internet.
+It's strongly recommended that you check your SSL strength and server security at [SSLLabs](https://www.ssllabs.com/ssltest/analyze.html) if you are exposing these services to the internet.

--- a/docs/general/networking/letsencrypt.md
+++ b/docs/general/networking/letsencrypt.md
@@ -129,19 +129,19 @@ First, you need to determine a few things.
 1. **MAKE SURE YOU HAVE A CNAME FOR JELLYFIN WITH YOUR DNS PROVIDER BEFORE PROCEEDING**
 2. Where you wish to store information regarding Let's Encrypt (docker calls these "volumes")
 3. What subdomain or subfolder you wish to use with Let's Encrypt (ex. jellyfin.example.com)
-4. What timezone you wish to use
+4. What Timezone you wish to use
 5. If you'll be using either HTTP-01 or DNS-01 for challenges.
 6. What network you'll be running on (I'd recommend the default macvlan network called "br0")
 7. What IP you want your container running on
 8. What ports you'll be using (ex. 180 for port 80, and 1443 for 443)
 9. Make sure ports 80 (if using http validation) and 443 are forwarded to the docker container from your router (instructions vary upon manufacturer)
-10. What user will the container be running as (you can determine the PUID and PGID by running `id` (replacing "user" with the username of the user the container will be running as)
+10. What user will the container be run as (you can determine the PUID and PGID by running `id` (replacing "user" with the username of the user the container will be running as)
 
 List of DNS Plugins [here](https://certbot.eff.org/docs/using.html#dns-plugins) if using DNS-01 challenge.
 
 Then, depending on what those settings are, you'll need to adjust the values below as needed.
 
-For example, the docker create command from the LinuxServer team for the Swag Docker container:
+For example, the docker creates a command from the LinuxServer team for the Swag Docker container:
 
 ```sh
 docker create \
@@ -223,7 +223,7 @@ server {
 }
 ```
 
-The lines we're interested in is `set $upstream_app jellyfin`. Now, assuming Jellyfin and Let's Encrypt are on the same network within Docker, it _should_ see it and start handling reverse proxy without much issue. If it doesn't however, you'll just need to change `jellyfin` in that line to whatever the IP of your Jellyfin server is. We'll also look at the line `location ~ (/jellyfin)?/socket` and add a slash after socket, so the line should look like this `location ~ (/jellyfin)?/socket/`.
+The lines we're interested in is `set $upstream_app jellyfin`. Now, assuming Jellyfin and Let's Encrypt are on the same network within Docker, it _should_ see it and start handling reverse proxy without much issue. If it doesn't, however, you'll just need to change `jellyfin` in that line to whatever the IP of your Jellyfin server is. We'll also look at the line `location ~ (/jellyfin)?/socket` and add a slash after socket, so the line should look like this `location ~ (/jellyfin)?/socket/`.
 
 Then, within Jellyfin settings (Dashboard -> Networking), scroll down to "Public HTTP port number" and "Public HTTPS port number", and make sure HTTP Port number is 8096, while HTTPS port number is 8920.
 

--- a/docs/general/networking/monitoring.md
+++ b/docs/general/networking/monitoring.md
@@ -9,7 +9,7 @@ Jellyfin has two monitoring and metrics endpoints built-in: a basic health check
 
 ### Health check endpoint
 
-Jellyfin exposes the `/health` endpoint designated for checking the status of the underlying service. Currently this will verify HTTP and database connectivity and return a `200 OK` response if successful. You can see this for yourself by using `curl`:
+Jellyfin exposes the `/health` endpoint designated for checking the status of the underlying service. Currently, this will verify HTTP and database connectivity and return a `200 OK` response if successful. You can see this for yourself by using `curl`:
 
 ```sh
 curl -i http://myserver:8096/health

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -51,7 +51,7 @@ server {
 
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
-    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
+    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address, e.g. `set $jellyfin 127.0.0.1`)
     set $jellyfin jellyfin;
     resolver 127.0.0.1 valid=30s;
 
@@ -80,7 +80,7 @@ server {
         proxy_set_header X-Forwarded-Protocol $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
 
-        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        # Disable buffering, when the nginx proxy gets very resource heavy upon streaming
         proxy_buffering off;
     }
 
@@ -122,7 +122,7 @@ server {
 
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
-    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
+    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address, e.g. `set $jellyfin 127.0.0.1`)
     set $jellyfin jellyfin;
     resolver 127.0.0.1 valid=30s;
 
@@ -152,7 +152,7 @@ server {
         proxy_set_header X-Forwarded-Protocol $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
 
-        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        # Disable buffering, when the nginx proxy gets very resource heavy upon streaming
         proxy_buffering off;
     }
 
@@ -176,7 +176,7 @@ server {
 
 ## Nginx with Subpath (example.org/jellyfin)
 
-When connecting to server from a client application, enter `http(s)://example.org/jellyfin` in the address field.
+When connecting to the server from a client application, enter `http(s)://example.org/jellyfin` in the address field.
 
 Set the [base URL](/docs/general/networking#base-url) field in the Jellyfin server. This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the web client. Fill in this box with `/jellyfin` and click Save. The server will need to be restarted before this change takes effect.
 
@@ -219,7 +219,7 @@ server {
     
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
-    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
+    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address, e.g. `set $jellyfin 127.0.0.1`)
     set $jellyfin jellyfin;
     resolver 127.0.0.1 valid=30s;
 
@@ -258,7 +258,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
 
-        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        # Disable buffering, when the nginx proxy gets very resource heavy upon streaming
         proxy_buffering off;
     }
 
@@ -296,7 +296,7 @@ server {
 
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
-    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
+    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address, e.g. `set $jellyfin 127.0.0.1`)
     set $jellyfin jellyfin;
     resolver 127.0.0.1 valid=30s;
 
@@ -343,7 +343,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
 
-        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        # Disable buffering, when the nginx proxy gets very resource heavy upon streaming
         proxy_buffering off;
     }
 
@@ -369,7 +369,7 @@ server {
 
 ### Censor sensitive information in logs
 
-This censors any <code>api_key</code> URL parameter from the logfile.
+This censors any <code>api_key</code> URL parameter from the log file.
 
 ```conf
 #Must be in HTTP block
@@ -384,14 +384,14 @@ map $request $secretfilter {
 }
 
 #Must be inside server block
-#Insert into all servers where you want filtering (e.g HTTP + HTTPS block)
+#Insert into all servers where you want filtering (e.g. HTTP + HTTPS block)
 access_log /var/log/nginx/access.log stripsecrets;
 ```
 
 ### Cache Images
 
 ```conf
-# Add this outside of you server block (i.e. http block)
+# Add this outside of your server block (i.e. http block)
 proxy_cache_path /var/cache/nginx/jellyfin levels=1:2 keys_zone=jellyfin:100m max_size=15g inactive=30d use_temp_path=off;
 
 # Cache images (inside server block)
@@ -416,7 +416,7 @@ Ensure that the directory /var/cache/nginx/jellyfin exists and the nginx user ha
 ### Rate Limit Downloads
 
 ```conf
-# Add this outside of you server block (i.e. http block)
+# Add this outside of your server block (i.e. http block)
 limit_conn_zone $binary_remote_addr zone=addr:10m;
 
 # Downloads limit (inside server block)
@@ -432,7 +432,7 @@ location ~ /Items/(.*)/Download$ {
    limit_rate 1700k; # Speed limit (here is on kb/s)
    limit_conn addr 3; # Number of simultaneous downloads per IP
    limit_conn_status 460; # Custom error handling
-   # proxy_buffering on; # Be sure buffering is on (it is by default on nginx), otherwise limits won't work
+   # proxy_buffering on; # Be sure buffering is on (it is by default on nginx). Otherwise, limits won't work
 }
 
 # Error page
@@ -447,12 +447,12 @@ error_page 460 http://your-page-telling-your-limit/;
 
 Create a proxy host and point it to your Jellyfin server's IP address and http port (usually 8096)
 
-Enable "Block Common Exploits", and "Websockets Support". Configure the access list if you intend to use them. Otherwise leave it on "publicly accessible".
+Enable "Block Common Exploits", and "Websockets Support". Configure the access list if you intend to use them. Otherwise, leave it on "publicly accessible".
 
 In the "Advanced" tab, enter the following in "Custom Nginx Configuration".  This is optional, but recommended if you intend to make Jellyfin accessible outside of your home.
 
 ```config
-    # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+    # Disable buffering, when the nginx proxy gets very resource heavy upon streaming
     proxy_buffering off;
 
     # Proxy main Jellyfin traffic

--- a/docs/general/networking/traefik.md
+++ b/docs/general/networking/traefik.md
@@ -11,7 +11,7 @@ Create docker-compose.yml, traefik.toml and acme.json in the **same** directory 
 
 :::note
 
-Ensure you enable Basic Auth protection for Traefik or disable its Dashboard. Otherwise your Dashboard will be accessible from the internet.
+Ensure you enable Basic Auth protection for Traefik or disable its Dashboard. Otherwise, your Dashboard will be accessible from the internet.
 
 :::
 
@@ -173,7 +173,7 @@ chmod 600 acme.json
 
 :::caution
 
-Change example.com to your domain name and update the acme.json file with your email address. Let's Encrypt does not require a valid email but example.com will be flagged as fake.
+Change example.com to your domain name and update the acme.json file with your email address. Let's Encrypt does not require a valid email, but example.com will be flagged as fake.
 
 :::
 

--- a/docs/general/networking/traefik2.md
+++ b/docs/general/networking/traefik2.md
@@ -17,11 +17,11 @@ Ensure you enable some basic firewall or auth protection for Traefik or disable 
 
 :::note
 
-Traefik has many options for the configuration of LetsEncrypt using your choice of challenges. If your server is accessible from the Internet via port 80 or 443, you can use the HTTP-01 or TLS-ALPN-01 challenges. If so, the certificatesresolvers.leresolver.acme.httpchallenge.entrypoint must be reachable by Let's Encrypt through port 80/443. You can also use a DNS-01 challenge via one of the available [providers](https://docs.traefik.io/https/acme/#providers). Configuration is beyond the scope of this guide. This guide can use both HTTP-01 and DNS-01 by commenting or uncommenting the various blocks. You are most likely to use HTTP-01 unless you have full access to your DNS configuration. The configuration below uses RFC2136 (as set by certificatesresolvers.leresolver.acme.dnsChallenge of `traefik.toml`) and the variables for that provider are shown in the `.env` file as a formatting guide. See provider documentation and comments about configuration of your ACME provider of choice, or change the configuration to HTTP-01 in `traefik.toml`'s comments.
+Traefik has many options for the configuration of LetsEncrypt using your choice of challenges. If your server is accessible from the Internet via port 80 or 443, you can use the HTTP-01 or TLS-ALPN-01 challenges. If so, the certificatesresolvers.leresolver.acme.httpchallenge.entrypoint must be reachable by Let's Encrypt through port 80/443. You can also use a DNS-01 challenge via one of the available [providers](https://docs.traefik.io/https/acme/#providers). Configuration is beyond the scope of this guide. This guide can use both HTTP-01 and DNS-01 by commenting or uncommenting the various blocks. You are most likely to use HTTP-01 unless you have full access to your DNS configuration. The configuration below uses RFC2136 (as set by certificatesresolvers.leresolver.acme.dnsChallenge of `traefik.toml`), and the variables for that provider are shown in the `.env` file as a formatting guide. See provider documentation and comments about configuration of your ACME provider of choice, or change the configuration to HTTP-01 in `traefik.toml`'s comments.
 
 :::
 
-The configuration below creates a Traefik v2.x installation with access at entryPoint ports 80 (labelled 'http'), 443 (labeled 'https'), and 9999 (labeled 'secure'). Unrelated to this Jellyfin configuration, it redirects all traffic from http (port 80) to https (port 443) to ensure all data is encrypted. As for Jellyfin, it makes the service accessible without a path on the secure entry point. This configuration is intended to be used as a starting point and some adaptation is likely required for your configuration. If you want Jellyfin to be accessible without using a port (using the default https port), simply change 'secure' to 'https' in `docker-compose.yml` where indicated and remove the ':9999' from the SSLHost parameter. If you want Jellyfin to be accessible with a path, simply add the PathPrefix (i.e. '/jellyfin') and see the note near the end of this document about configuring Jellyfin.
+The configuration below creates a Traefik v2.x installation with access at entryPoint ports 80 (labelled 'http'), 443 (labeled 'https'), and 9999 (labeled 'secure'). Unrelated to this Jellyfin configuration, it redirects all traffic from http (port 80) to https (port 443) to ensure all data is encrypted. As for Jellyfin, it makes the service accessible without a path on the secure entry point. This configuration is intended to be used as a starting point and some adaptation is likely required for your configuration. If you want Jellyfin to be accessed without using a port (using the default https port), simply change 'secure' to 'https' in `docker-compose.yml` where indicated and remove the ':9999' from the SSLHost parameter. If you want Jellyfin to be accessible with a path, simply add the PathPrefix (i.e. '/jellyfin') and see the note near the end of this document about configuring Jellyfin.
 
 ### docker-compose.yml
 
@@ -218,13 +218,13 @@ TOML files can't support environment variables, so all values must be hard coded
     provider = "rfc2136"
     delayBeforeCheck = 0
     # A DNS server used to check whether the DNS is set up correctly before
-    # making the ACME request. Ideally a DNS server that isn't going to cache an old entry.
+    # making the ACME request. Ideally, a DNS server that isn't going to cache an old entry.
     resolvers = ["8.8.8.8:53"]
 
 [retry]
 ```
 
-Due to a [quirk](https://github.com/containous/traefik/issues/5559) in Traefik, you cannot dynamically route to containers when network_mode=host. We have created a static route to the docker host (192.168.1.xx:8096) in `traefik-provider.toml`. The use of host networking (as in this doc) or macvlan are required to use DLNA or an HdHomeRun so it can utilize the multicast network. `traefik-provider.toml` defines the jellyfin-svc@file service which we are pointing the router to in the `docker-compose.yml` file. You can not set a URL in `docker-compose.yml` which is why we set up this service externally. Be sure to update the IP address below to the IP address of the host on the local network (in this case, 192.168.1.xx).
+Due to a [quirk](https://github.com/containous/traefik/issues/5559) in Traefik, you cannot dynamically route to containers when network_mode=host. We have created a static route to the docker host (192.168.1.xx:8096) in `traefik-provider.toml`. The use of host networking (as in this doc) or macvlan are required to use DLNA or an HdHomeRun so it can utilize the multicast network. `traefik-provider.toml` defines the jellyfin-svc@file service which we are pointing the router to in the `docker-compose.yml` file. You cannot set a URL in `docker-compose.yml` which is why we set up this service externally. Be sure to update the IP address below to the IP address of the host on the local network (in this case, 192.168.1.xx).
 
 ### traefik-provider.toml
 
@@ -279,7 +279,7 @@ chmod 600 acme.json traefik.log
 
 :::caution
 
-These configurations use DOMAIN_NAME (i.e.: example.com) and HOST_NAME (i.e.: servername) throughout it. You should replace these with your server's name. HOST_NAME.DOMAIN_NAME refers to the machine itself (ie: servername.example.com). Don't forget to update `traefik.toml`'s YOU@DOMAIN_NAME with your email address. Let's Encrypt does not require a valid email but invalid e-mails may be flagged as fake.
+These configurations use DOMAIN_NAME (i.e.: example.com) and HOST_NAME (i.e.: servername) throughout it. You should replace these with your server's name. HOST_NAME.DOMAIN_NAME refers to the machine itself (ie: servername.example.com). Don't forget to update `traefik.toml`'s YOU@DOMAIN_NAME with your email address. Let's Encrypt does not require a valid email, but invalid e-mails may be flagged as fake.
 
 :::
 


### PR DESCRIPTION
## Summary

Fix typographical errors across multiple documentation files to improve readability and accuracy.

Bug Fixes:
- Correct various typographical errors across multiple documentation files, including punctuation, capitalization, and grammar issues.

Documentation:
- Update documentation to fix typographical errors, ensuring clarity and consistency in language usage.

Wait for https://github.com/jellyfin/jellyfin.org/pull/1181 to be merged