### PR TITLE
ADD: Fail2ban guide for IP blocking on upstream server to Fail2ban guide (useful if jellyfin is hosted behind an upstream reverse proxy).

### DIFF
--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -227,7 +227,7 @@ Replace `<upstream-server-ip>` with the actual IP address of your upstream serve
 
 4. **Verify on Upstream Server**:
 
-   Check if the IP is banned in the corresponding jail's chain on the upstream server ('f2b-<jail-name>'):
+   Check if the IP is banned in the corresponding jail's chain on the upstream server ('f2b-jail-name'):
 
    ```bash
    ssh root@<upstream-server-ip> "iptables -L f2b-jellyfin"
@@ -243,7 +243,7 @@ Replace `<upstream-server-ip>` with the actual IP address of your upstream serve
 
 6. **Verify Unban**:
 
-    Verify that the IP is removed from the corresponding jail's chain ('f2b-<jail-name>'):
+    Verify that the IP is removed from the corresponding jail's chain ('f2b-jail-name'):
 
    ```bash
    ssh root@<upstream-server-ip> "iptables -L f2b-jellyfin"

--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -227,7 +227,7 @@ Replace `<upstream-server-ip>` with the actual IP address of your upstream serve
 
 4. **Verify on Upstream Server**:
 
-   Check if the IP is banned in the corresponding jail's chain on the upstream server (f2b-<jail-name>):
+   Check if the IP is banned in the corresponding jail's chain on the upstream server ('f2b-<jail-name>'):
 
    ```bash
    ssh root@<upstream-server-ip> "iptables -L f2b-jellyfin"
@@ -243,7 +243,7 @@ Replace `<upstream-server-ip>` with the actual IP address of your upstream serve
 
 6. **Verify Unban**:
 
-    Verify that the IP is removed from the corresponding jail's chain (f2b-<jail-name>):
+    Verify that the IP is removed from the corresponding jail's chain ('f2b-<jail-name>'):
 
    ```bash
    ssh root@<upstream-server-ip> "iptables -L f2b-jellyfin"

--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -86,3 +86,197 @@ Assuming you've at least one failed authentication attempt, you can test this ne
 ```bash
 sudo fail2ban-regex /path_to_logs/*.log /etc/fail2ban/filter.d/jellyfin.conf --print-all-matched
 ```
+
+---
+
+## Fail2Ban
+
+[Fail2ban](https://github.com/fail2ban/fail2ban) is an intrusion prevention software framework that protects computer servers from brute-force attacks.
+Fail2Ban operates by monitoring log files (e.g., `/var/log/auth.log`, `/var/log/apache/access.log`, etc.) for selected entries and running scripts based on their content.
+
+Jellyfin produces logs that can be monitored by Fail2Ban to prevent brute-force attacks on your machine.
+
+### Requirements
+
+- Jellyfin remotely accessible
+- Fail2Ban installed and running
+- Knowing where the logs for Jellyfin are stored: by default `/var/log/jellyfin/` for desktop and `/config/log/` for docker containers.
+
+---
+
+### Step One: Create the Jail
+
+You need to create a jail for Fail2Ban. If you're on Ubuntu and use nano as an editor, run:
+
+```bash
+sudoedit /etc/fail2ban/jail.d/jellyfin.local
+```
+
+Add this to the new file, replacing `/path_to_logs` with the path to the log files above, e.g., `/var/log/jellyfin/`:
+
+```ini
+[jellyfin]
+
+backend = auto
+enabled = true
+port = 80,443
+protocol = tcp
+filter = jellyfin
+maxretry = 3
+bantime = 86400
+findtime = 43200
+logpath = /path_to_logs/jellyfin*.log
+```
+
+Save and exit.
+
+**Note:**  
+If Jellyfin is running in a Docker container, add the following line to the `jellyfin.local` file to ensure compatibility with Docker's networking:
+
+```bash
+action = iptables-allports[name=jellyfin, chain=DOCKER-USER]
+```
+
+### Step Two: Create the Filter
+
+The filter contains a set of rules that Fail2Ban will use to identify failed authentication attempts. Create the filter by running:
+
+```bash
+sudoedit /etc/fail2ban/filter.d/jellyfin.conf
+```
+
+Add:
+
+```ini
+[Definition]
+failregex = ^.*Authentication request for .* has been denied \(IP: "<ADDR>"\)\.
+```
+
+Save and restart Fail2Ban:
+
+```bash
+sudo systemctl restart fail2ban
+```
+
+Verify Fail2Ban is running:
+
+```bash
+sudo systemctl status fail2ban
+```
+
+### Step Three: Test
+
+To test this setup with existing logs:
+
+```bash
+sudo fail2ban-regex /path_to_logs/*.log /etc/fail2ban/filter.d/jellyfin.conf --print-all-matched
+```
+
+---
+
+## Advanced Fail2Ban Setup: Managing Bans on an Upstream Proxy Server
+
+To enhance security, Fail2Ban can manage IP bans on an upstream reverse proxy server instead of directly on the Jellyfin server. This setup allows you to block malicious IPs closer to your network’s entry point, potentially benefiting other services using the same proxy.
+
+This guide offers two configurations for setting up Fail2Ban to manage IP bans on an upstream reverse proxy server:
+
+1. **Dynamic Chains**: Each Fail2Ban jail creates and manages its own `iptables` chain on the upstream server.
+2. **Communal Chain**: All Fail2Ban jails share a single `iptables` chain on the upstream server.
+
+### Prerequisites
+
+- **Fail2Ban** is installed on your local server (where services such as Jellyfin, Nginx, etc., are running).
+- **SSH key-based access** is set up from your Fail2Ban server to the upstream server.
+- **iptables** is configured on the upstream server.
+
+### Step 1: Set Up SSH Key-Based Authentication
+
+Establish SSH access from the Fail2Ban server to the upstream server for automated IP ban/unban actions.
+
+1. **Generate an SSH Key** (if not already created):
+
+   ```bash
+   ssh-keygen -t rsa -b 4096 -f /root/.ssh/id_rsa
+   ```
+
+2. **Copy the Key to the Upstream Server**:
+
+   ```bash
+   ssh-copy-id -i /root/.ssh/id_rsa.pub root@<upstream-server-ip>
+   ```
+
+3. **Verify Access**:
+
+   ```bash
+   ssh -i /root/.ssh/id_rsa root@<upstream-server-ip>
+   ```
+
+---
+
+### Option 1: Dynamic `iptables` Chains for Each Jail
+
+In this approach, each Fail2Ban jail dynamically manages its own `iptables` chain.
+
+#### Configure Fail2Ban for Dynamic Chains
+
+1. **Create the Action File**:
+
+   ```bash
+   sudo nano /etc/fail2ban/action.d/proxy-iptables-dynamic.conf
+   ```
+
+2. **Define the Action**:
+
+   ```ini
+   [Definition]
+   actionban = ssh root@<upstream-server-ip> "iptables -N f2b-<name> || true; iptables -I f2b-<name> -s <ip> -j DROP"
+   actionunban = ssh root@<upstream-server-ip> "iptables -D f2b-<name> -s <ip> -j DROP"
+   ```
+
+   Replace `<upstream-server-ip>` with the IP of your upstream server.
+
+#### Configure Jails for Dynamic Chains
+
+Update `/etc/fail2ban/jail.local`:
+
+```ini
+[jellyfin]
+action = proxy-iptables-dynamic
+```
+
+---
+
+### Option 2: Communal `iptables` Chain for All Jails
+
+In this approach, all jails share a single `iptables` chain.
+
+#### Configure Fail2Ban for Communal Chain
+
+1. **Create the Action File**:
+
+   ```bash
+   sudo nano /etc/fail2ban/action.d/proxy-iptables-communal.conf
+   ```
+
+2. **Define the Action**:
+
+   ```ini
+   [Definition]
+   actionban = ssh root@<upstream-server-ip> "iptables -I f2b-communal -s <ip> -j DROP"
+   actionunban = ssh root@<upstream-server-ip> "iptables -D f2b-communal -s <ip> -j DROP"
+   ```
+
+#### Configure Jails for Communal Chain
+
+Update `/etc/fail2ban/jail.local` for each jail:
+
+```ini
+[jellyfin]
+action = proxy-iptables-communal
+```
+
+---
+
+### Final Steps: Restart and Test
+
+After making changes, restart Fail2Ban and verify functionality as detailed above.

--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -100,7 +100,7 @@ This guide offers a configuration for setting up Fail2Ban to manage IP bans on a
 - **Fail2Ban** is installed on your local server (where Jellyfin is running).
 - **iptables** is configured on the upstream server.
 
-### Step 1: Set Up SSH Key-Based Authentication
+### Step one: Set Up SSH Key-Based Authentication
 
 Ensure the Fail2Ban server can SSH into the upstream server without needing a password. This is crucial for automating the IP ban/unban process.
 
@@ -126,7 +126,7 @@ Replace `<upstream-server-ip>` with the actual IP address of your upstream serve
    ssh -i /root/.ssh/id_rsa root@<upstream-server-ip>
    ```
 
-### Step 2: Configure Fail2Ban for Dynamic Chains
+### Step two: Configure Fail2Ban for Dynamic Chains
 
 1. **Create the Fail2Ban Action File**:
 
@@ -199,7 +199,7 @@ Replace `<upstream-server-ip>` with the actual IP address of your upstream serve
 
    After making chaneges, save and close the file.
 
-### Step 4: Restart Fail2Ban and Test the Setup
+### Step three: Restart Fail2Ban and Test the Setup
 
 1. **Restart Fail2Ban**:
 
@@ -249,7 +249,7 @@ Replace `<upstream-server-ip>` with the actual IP address of your upstream serve
    ssh root@<upstream-server-ip> "iptables -L f2b-jellyfin"
    ```
 
-### Step 5: Monitor Logs
+### Step four: Monitor Logs
 
 Monitor the Fail2Ban log to ensure that actions are being executed properly:
 

--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -95,7 +95,7 @@ To enhance security, Fail2Ban can manage IP bans on an upstream reverse proxy se
 
 This guide offers a configuration for setting up Fail2Ban to manage IP bans on an upstream reverse proxy server using **Dynamic Chains**, where each Fail2Ban jail creates and manages its own `iptables` chain on the upstream server.
 
-### Prerequisites
+### Assumptions
 
 - **Fail2Ban** is installed on your local server (where Jellyfin is running).
 - **iptables** is configured on the upstream server.


### PR DESCRIPTION
Hey Jellyfin team,

I wanted to suggest adding a setup guide to the Jellyfin documentation that covers using Fail2Ban for users who are running Jellyfin behind a reverse proxy on a separate upstream server. In my current setup, I have Jellyfin running in a Docker container on a local server, but it's accessible to the internet through an upstream reverse proxy server. 

In my experience, trying to block IPs with Fail2Ban on the Jellyfin host didn’t work effectively because Docker’s internal networking can bypass the host’s `iptables` rules, allowing banned IPs to still reach Jellyfin.

So I set up Fail2Ban on the Jellyfin host to automatically ban IP addresses on the upstream server using `iptables` whenever unauthorised login attempts are detected.

I’ve put together a basic guide that walks through the setup: [Fail2Ban Upstream Proxy Chain Setup Guide](https://github.com/famesjranko/server-scripts/blob/main/fail2ban_upstream_proxy_chain_setup_guide.md).

Here’s an overview of my setup:
```
internet -> upstream-proxy <- (ban/unban IP commands) <- Fail2Ban (monitors logs)
```
```
internet -> upstream-proxy -> (allowed traffic) -> host(docker[jellyfin])
```

### What I Did:
- **Fail2Ban Configuration:** Fail2Ban is installed on the Jellyfin host and monitors the Jellyfin logs for failed login attempts or other triggers.
- **Upstream Proxy Banning:** Instead of banning IPs directly on the Jellyfin host, Fail2Ban executes `iptables` commands via SSH on the upstream reverse proxy server. This ensures that banned IPs are blocked before they reach the Jellyfin host, adding an extra layer of protection.
- **Flexible Approach:** I implemented two options for managing IP bans:
  1. **Dynamic Chains:** Fail2Ban creates and manages individual `iptables` chains for each jail on the upstream server, allowing for more granular control of IP blocking by service.
  2. **Communal Chain:** All Fail2Ban jails share a single `iptables` chain on the upstream proxy, simplifying the management of banned IPs.

### Why This Is Useful:
- **Enhanced Security:** This setup can be especially helpful for users running Jellyfin behind a reverse proxy, as it blocks malicious traffic at the proxy level before it reaches the local network.
- **Scalable:** This method works well for users with multiple services running behind the same reverse proxy, not just Jellyfin, as Fail2Ban can be configured to manage bans for all services centrally.
- **Adaptable:** The guide includes dynamic chain management, allowing advanced users to customise their ban rules based on individual services, or use a communal approach for simplicity.

I believe this setup could be valuable for other Jellyfin users with similar reverse proxy configurations and would be a useful addition to the documentation.