### PR TITLE
Add symfonium music client

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -921,13 +921,37 @@ export const Clients: Array<Client> = [
         id: 'app-store',
         name: 'App Store',
         url: 'https://apps.apple.com/us/app/manet-music/id6470928235'
-      },
+      }
     ],
     secondaryLinks: [
       {
         id: 'website',
         name: 'Website',
         url: 'https://tilo.dev/manet/'
+      }
+    ]
+  },
+  {
+    id: 'symfonium',
+    name: 'Symfonium',
+    description:
+      'An offline-first third-party music player that enhances your Jellyfin experience with streaming, syncing, and full personalization',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.Android],
+    primaryLinks: [
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=com.fredrikburmester.streamyfin'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://symfonium.app/'
       }
     ]
   }


### PR DESCRIPTION
This pull request adds the [symfonium app](https://symfonium.app/) as a client for music.
It will look like this:
![image](https://github.com/user-attachments/assets/82f33360-ec44-41c1-a8d9-e9a3eb1ed87b)

How does a third-party client gets as "recommended" approved?
