### PR TITLE
Fix obsolete official Dockerfile URL

### DIFF
--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -16,7 +16,7 @@ LinuxServer.io image: `linuxserver/jellyfin` <a href="https://hub.docker.com/r/l
 hotio image: `hotio/jellyfin` <a href="https://hub.docker.com/r/hotio/jellyfin"><img alt="Docker Pull Count" src="https://img.shields.io/docker/pulls/hotio/jellyfin.svg" /></a>.
 
 Jellyfin distributes [official container images on Docker Hub](https://hub.docker.com/r/jellyfin/jellyfin/) for multiple architectures.
-These images are based on Debian and [built directly from the Jellyfin source code](https://github.com/jellyfin/jellyfin/blob/master/Dockerfile).
+These images are based on Debian and [built directly from the Jellyfin source code](https://github.com/jellyfin/jellyfin-packaging/blob/master/docker/Dockerfile).
 
 Additionally, there are several third parties providing unofficial container images, including the [LinuxServer.io](https://www.linuxserver.io/) ([Dockerfile](https://github.com/linuxserver/docker-jellyfin/blob/master/Dockerfile)) project and [hotio](https://github.com/hotio) ([Dockerfile](https://github.com/hotio/jellyfin/blob/release/linux-amd64.Dockerfile)), which offer images based on Ubuntu and the official Jellyfin Ubuntu binary packages.
 


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin/pull/11162 (first in 10.9.0) moved the Dockerfile from the main repository to jellyfin-packaging.