### PR TITLE
Add proxy setup to fail2ban guide

### DIFF
--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -199,7 +199,22 @@ Replace `<upstream-server-ip>` with the actual IP address of your upstream serve
 
    After making chaneges, save and close the file.
 
-### Step three: Restart Fail2Ban and Test the Setup
+### Step three: Add proxy IPs to Jellyfin
+1. **Get Proxy IPs**
+
+   Since you're using a proxy server, we need Jellyfin to output the correct IPs in logs for fail2ban to read.
+   
+   Depending on your hosting setup, these IP ranges could be from internal Docker IPs, haproxy, or some other service.
+
+   Jellyfin accepts IPs with subnet masks such as `172.18.0.1/24`. You'll need a comma-separated list of these.
+   
+3. **Add Proxies to Jellyfin**
+   
+   Open your Jellyfin server's dashboard, go to `Advanced` -> `Networking`, and then scroll down to `Known proxies`.
+
+   Enter your comma-seperated list of proxy IP ranges. You'll need to reboot the Jellyfin server as indicated.
+
+### Step four: Restart Fail2Ban and Test the Setup
 
 1. **Restart Fail2Ban**:
 


### PR DESCRIPTION
Currently, the advanced portion of the `fail2ban` guide is lacking the proper setup of the 'Known proxies' in the Adv/Network tab that's required to not get internal/private IPs in a lot of proxy setups (or even if you're just routing connections via internal docker means).