### PR TITLE
Revert "update movie version sorting"

### DIFF
--- a/docs/general/server/media/movies.md
+++ b/docs/general/server/media/movies.md
@@ -74,7 +74,7 @@ If labels are not added to the end of filenames, as shown above, each file will 
 
 ### Order of Versions
 
-Movie versions are sorted by the width of the resolution in a descending order. The resolution from the media info is used. Multiple items with the same resolution will be sorted alphabetically.
+Movie versions are presented in an alphabetically sorted list. An exception applies to resolution names, which are sorted in descending order from highest to lowest resolution. A version name qualifies as a resolution name when ending with either a `p` or an `i`.
 
 :::note
 


### PR DESCRIPTION
Reverts #1096

The documentation for multiple version sorting was updated to address sorting [issues](https://github.com/jellyfin/jellyfin/issues/12129) in version 10.9. However, these issues were resolved by #[12626](https://github.com/jellyfin/jellyfin/pull/12626), which was released in server version 10.10. Multiple version sorting now behave as they did prior to 10.9.
