### PR TITLE
Update Manet to include the MacOS platform

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -911,11 +911,11 @@ export const Clients: Array<Client> = [
   {
     id: 'manet',
     name: 'Manet',
-    description: 'A third-party music client for iOS',
+    description: 'A third-party music client for iOS and macOS',
     clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile],
+    deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
     licenseType: LicenseType.Proprietary,
-    platforms: [Platform.IOS],
+    platforms: [Platform.IOS, Platform.MacOS],
     primaryLinks: [
       {
         id: 'app-store',
@@ -927,7 +927,7 @@ export const Clients: Array<Client> = [
       {
         id: 'website',
         name: 'Website',
-        url: 'https://tilo.dev/manet/'
+        url: 'https://tilosoftware.io/manet/'
       }
     ]
   },


### PR DESCRIPTION
This adds the recently added macOS support for the music player Manet on the clients page.

The macOS client requires the in-app subscription, so not sure if you still want to have it on the website? I'll mention it here so we can discuss it at least so you don't get surprised by it 😊 