### PR TITLE
Warn about a .nfo genre tag and Albums/Artists

### DIFF
--- a/docs/general/server/metadata/nfo.md
+++ b/docs/general/server/metadata/nfo.md
@@ -37,10 +37,6 @@ It's currently not possible to disable .nfo metadata. Local metadata will always
 User data importing is only possible for a single user. This user can be set in the .nfo settings.
 :::
 
-:::note
-Music Albums and Music Artists are currently not compatible with the genre tag, that will just be ignored.
-:::
-
 | Tag           | Note                                                                                                                  |
 | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | name          |                                                                                                                       |
@@ -82,7 +78,7 @@ Music Albums and Music Artists are currently not compatible with the genre tag, 
 | premiered     |                                                                                                                       |
 | releasedate   |                                                                                                                       |
 | enddate       |                                                                                                                       |
-| genre         | multiple tags allowed                                                                                                 |
+| genre         | multiple tags allowed. These tags will be ignored for music albums and music artists.                                 |
 | tag           | multiple tags allowed                                                                                                 |
 | style         | multiple tags allowed                                                                                                 |
 | fileinfo      |                                                                                                                       |

--- a/docs/general/server/metadata/nfo.md
+++ b/docs/general/server/metadata/nfo.md
@@ -37,6 +37,10 @@ It's currently not possible to disable .nfo metadata. Local metadata will always
 User data importing is only possible for a single user. This user can be set in the .nfo settings.
 :::
 
+:::note
+Music Albums and Music Artists are currently not compatible with the genre tag, that will just be ignored.
+:::
+
 | Tag           | Note                                                                                                                  |
 | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | name          |                                                                                                                       |


### PR DESCRIPTION
Add a note mentioning that album.nfo and artist.nfo are not compatible with the genre tag, as mentioned in jellyfin/jellyfin#13350.