### PR TITLE
Fixing font errors for NGINX HTTP reverse-proxy

### DIFF
--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -140,7 +140,7 @@ server {
     # Enforces https content and restricts JS/CSS to origin
     # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
     # NOTE: The default CSP headers may cause issues with the webOS app
-    add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+    add_header Content-Security-Policy "default-src https: data: blob: ; img-src 'self' https://* ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.youtube.com blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'; font-src 'self' data:";
 
     location / {
         # Proxy main Jellyfin traffic


### PR DESCRIPTION
The CSP config give for the NGINX HTTP reverse-proxy blocks loading of all fonts because of the default CSP rule. Added a font-src header to allow loading of fonts from the server.