### PR TITLE
Add check to avoid publishing to cloudflare when already publishing to github pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   publish:
-    if: github.repository == 'jellyfin/jellyfin.org'
+    if: github.event_name != 'push' && github.repository == 'jellyfin/jellyfin.org'
     name: Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
Adds a condition to avoid publishing to cloudflare on push to master

Fixes #1253
