### PR TITLE
Update movie folder structure 

### DIFF
--- a/docs/general/server/media/movies.md
+++ b/docs/general/server/media/movies.md
@@ -5,7 +5,7 @@ title: Movies
 
 # Movies
 
-Movies should usually be in the library root directory or in a subfolder for the individual films. The subfolders allow for organization of metadata and images. Adding the year at the end in parentheses will yield the best results when scraping metadata.
+Movies must be in the library root directory or in a subfolder for the individual films. Not following this structure may lead to misidentification or missing media. Subfolders allow for organization of metadata and images. Adding the year at the end in parentheses will yield the best results when scraping metadata.
 
 :::tip
 


### PR DESCRIPTION
Clarify movies structure by explicitly stating that loose media or subdirectory structure as defined in this document is required for proper media identification.

Fixes #942