### PR TITLE
Nginx Documentation Re-work

### DIFF
--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -94,16 +94,6 @@ server {
 }
 ```
 
-### HTTP config example
-
-:::tip
-
-If you are planning on exposing your server over the Internet, you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/). Using only HTTP will expose passwords and API keys.
-
-:::
-
-</details>
-
 ## Nginx with Subpath (example.org/jellyfin)
 
 When connecting to server from a client application, enter `http(s)://example.org/jellyfin` in the address field.

--- a/docs/general/networking/nginx.md
+++ b/docs/general/networking/nginx.md
@@ -300,9 +300,11 @@ In the "Advanced" tab, enter the following in "Custom Nginx Configuration".  Thi
 
 ### Nginx Proxy Manager Subpaths
 
+To use subpaths with Jellyfin you will need to add a custom location with the following location block.  Replace "SERVER_IP" with your Jellyfin server's actual IP.
+
 ```config
 location ^~ /jellyfin/ {
-    proxy_pass http://192.168.1.2:8096/;
+    proxy_pass http://SERVER_IP:8096/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
- Simplifying example to minimum "secure" config.
- Adding ```font-src``` to CSP to resolve https://github.com/jellyfin/jellyfin.org/issues/1275
- Removing http examples.  Not appreciably different that https.
- Adding Nginx Proxy Manager sub-path example as provided by forum user.  https://forum.jellyfin.org/t-nginx-proxy-manager-config?pid=42446#pid42446