### PR TITLE
update kitsu url

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -99,7 +99,7 @@ Supports several different metadata providers and options for organizing your co
 [![Contributors](https://img.shields.io/github/contributors/jellyfin/jellyfin-plugin-kitsu.svg)](https://github.com/jellyfin/jellyfin-plugin-kitsu)
 [![License](https://img.shields.io/github/license/jellyfin/jellyfin-plugin-kitsu.svg)](https://github.com/jellyfin/jellyfin-plugin-kitsu)
 
-Provides metadata support from [Kitsu](https://kitsu.io/).
+Provides metadata support from [Kitsu](https://kitsu.app/).
 
 - [Github](https://github.com/jellyfin/jellyfin-plugin-kitsu)
 


### PR DESCRIPTION
Kitsu has changed their URL. This PR updates it

This banner will show when visiting from https://kitsu.io
<img width="1511" alt="截圖 2025-02-18 下午6 32 48" src="https://github.com/user-attachments/assets/dc04ee8e-72a6-478f-91cf-8472433052cd" />
