### PR TITLE
Fix fail2ban regex

### DIFF
--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -64,7 +64,7 @@ Paste:
 
 ```bash
 [Definition]
-failregex = ^.*Authentication request for .* has been denied \(IP: "<ADDR>"\)\.
+failregex = ^.*Authentication request for .* has been denied \(IP: <ADDR>\)\.
 ```
 
 Save and exit, then reload Fail2ban:


### PR DESCRIPTION
Existing fail2ban regex doesn't match failed login attempts because the IP address is [not quoted](https://github.com/jellyfin/jellyfin/blob/317d7a9f4f76dbd964e2649ed4b7d03d3e68ca9d/Jellyfin.Server.Implementations/Users/UserManager.cs#L488) in the log messages.