### PR TITLE
Adjusting docs for notification config location

### DIFF
--- a/docs/general/server/notifications.md
+++ b/docs/general/server/notifications.md
@@ -13,4 +13,4 @@ Notifications can be sent using different services depending on what kind of int
 
 ## Configuration
 
-You can properly configure this feature on the **Notifications** page in the settings. All notification types will be shown in a list as well as their current status. They can be enabled individually and can be set to only monitor specific users. Any installed notification services will show up in a list in this section.
+After installing the **Webhook** plugin, you will navigate to "My Plugins" in the dashboard and then select the Webhook plugin to configure notifications. All notification types will be shown in a list as well as their current status. They can be enabled individually and can be set to only monitor specific users. Any installed notification services will show up in a list in this section.

--- a/docs/general/server/notifications.md
+++ b/docs/general/server/notifications.md
@@ -1,16 +1,14 @@
 ---
 uid: server-notifications
-title: Notifications
+title: Webhook Plugin for Notifications
 ---
-
-# Notifications
-
-You can use notifications to get alerts when certain events happen on your server. Some common notifications include plugin installations and different user events.
 
 ## Services
 
-Notifications can be sent using different services depending on what kind of integration you want. Jellyfin will show notifications on the dashboard by default, but you can install alternative services on the **Plugins** page. Most services will require additional configuration but can be extremely useful for those who want instant updates for activity on their server.
+Notifications via the Webhook Plugin can be sent using different services depending on what kind of integration you want. Jellyfin will show notifications on the dashboard by default, but you can send notifications via the Webhook Plugin to additional messaging services. Most services will require additional configuration but can be extremely useful for those who want instant updates for activity on their server.
 
 ## Configuration
 
 After installing the **Webhook** plugin, you will navigate to "My Plugins" in the dashboard and then select the Webhook plugin to configure notifications. All notification types will be shown in a list as well as their current status. They can be enabled individually and can be set to only monitor specific users. Any installed notification services will show up in a list in this section.
+
+Templates for popular messaging services are available on the webhook plugin's [github page](https://github.com/jellyfin/jellyfin-plugin-webhook/tree/master/Jellyfin.Plugin.Webhook/Templates).


### PR DESCRIPTION
Adjusting docs for notification config location.  Currently the docs still state that there is a notification tab in the Dashboard menu root.  Clarifying that notifications are configured in the webhook plugin's page now.