### PR TITLE
Add Finer into clients

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -882,7 +882,7 @@ export const Clients: Array<Client> = [
     clientType: ClientType.ThirdParty,
     deviceTypes: [DeviceType.Mobile],
     licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android, Platform.IOS, Platform.iPadOS],
+    platforms: [Platform.Android, Platform.IOS, Platform.IpadOS],
     primaryLinks: [
       {
         id: 'app-store',
@@ -932,27 +932,27 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: "fladder",
-    name: "Fladder",
-    description: "A simple, cross-platform Jellyfin frontend built on top of Flutter.",
+    id: 'fladder',
+    name: 'Fladder',
+    description: 'A simple, cross-platform Jellyfin frontend built on top of Flutter.',
     clientType: ClientType.ThirdParty,
     deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
     licenseType: LicenseType.OpenSource,
     platforms: [Platform.Linux, Platform.Windows, Platform.MacOS, Platform.Android, Platform.Browser],
     primaryLinks: [
       {
-        id: "play-store",
-        name: "Play Store",
-        url: "https://play.google.com/store/apps/details?id=nl.jknaapen.fladder",
-      },
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=nl.jknaapen.fladder'
+      }
     ],
     secondaryLinks: [
       {
-        id: "github",
-        name: "GitHub",
-        url: "https://github.com/DonutWare/Fladder",
-      },
-    ],
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/DonutWare/Fladder'
+      }
+    ]
   },
   {
     id: 'symfonium',
@@ -975,6 +975,29 @@ export const Clients: Array<Client> = [
         id: 'website',
         name: 'Website',
         url: 'https://symfonium.app/'
+      }
+    ]
+  },
+  {
+    id: 'finer',
+    name: 'Finer',
+    description: 'Jellyfin Music Player for macOS/iPadOS/iOS, built with native technologies.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.MacOS, Platform.IpadOS, Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/finer-player/id6738301953'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://monk-studio.com/finer'
       }
     ]
   }

--- a/src/data/platform.ts
+++ b/src/data/platform.ts
@@ -7,6 +7,7 @@ enum Platform {
   Discord = 'Discord',
   FireOS = 'Fire TV',
   IOS = 'iOS',
+  IpadOS = 'iPadOS',
   Kodi = 'Kodi',
   Roku = 'Roku',
   SailfishOS = 'Sailfish OS',


### PR DESCRIPTION
Hi team, thanks for the work on Jellyfin community.  

I've recently built a new music client for Jellyfin, the app was originally built for macOS, and expanded to iPadOS/iOS as requested by users, and it's free. 

The player is built with performance and minimum resource usage in mind, and has some very unique features like 3rd party lyrics syncing, lyrics translation and push notification integration.  

Check out https://monk-studio.com/finer. 

<img width="1619" alt="Screenshot 2025-03-04 at 23 32 30" src="https://github.com/user-attachments/assets/68a19d09-c0dd-4b1d-b607-4af069076c11" />


------------------

This MR added Finer to client list, also fixed type-missing of IpadOS, and prettier violation of the ts file. 




