### PR TITLE
fix failregex in fail2ban.md

### DIFF
--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -64,7 +64,7 @@ Paste:
 
 ```bash
 [Definition]
-failregex = ^.*Authentication request for .* has been denied \(IP: <ADDR>\)\.
+failregex = ^.*Authentication request for .* has been denied \(IP: "<ADDR>"\)\.
 ```
 
 Save and exit, then reload Fail2ban:


### PR DESCRIPTION
I found that the regex as posted in the Definition section on the site does not work. I do not know if this is due to recent changes in how Jellyfin server logs failed IP addresses, but the current failregex does not work out of the box.

The difference is the addition of a " before and after the ADDR portion, because the IP address is enclosed in quotation marks in the log, so the " will match those characters. Without it, I was getting no matches.