### PR TITLE
Fix dead link to Upgrade and Downgrade documentation

### DIFF
--- a/docs/general/testing/server/index.md
+++ b/docs/general/testing/server/index.md
@@ -19,7 +19,7 @@ To install them, navigate to our [downloads page](/downloads/server) and choose 
 
 ![Downloads Page](/images/docs/testing/server/weekly-1.png)
 
-Follow the steps in the [Upgrade & Downgrade documentation](/docs/general/testing/upgrades-and-downgrades) for more detailed instructions.
+Follow the steps in the [Upgrade & Downgrade documentation](/docs/general/testing/upgrades) for more detailed instructions.
 
 ## Testing from Master Branch
 


### PR DESCRIPTION
Found a dead link on the site [Testing Jellyfin Server](https://jellyfin.org/docs/general/testing/server/) for the Upgrade & Downgrade documentation.

I've fixed this issue in this commit.