### PR TITLE
Update fail2ban.md

### DIFF
--- a/docs/general/networking/fail2ban.md
+++ b/docs/general/networking/fail2ban.md
@@ -64,7 +64,7 @@ Paste:
 
 ```bash
 [Definition]
-failregex = ^.*Authentication request for .* has been denied \(IP: <ADDR>\)\.
+failregex = ^.*Authentication request for .* has been denied \(IP: "<ADDR>"\)\.
 ```
 
 Save and exit, then reload Fail2ban:


### PR DESCRIPTION
I had to add the quotes ("") near the <ADDR> field in the regex because on my jellyfin (up-to-date), the log format is :  Authentication request for "a" has been denied (IP: "192.168.10.8").

and not : 
Authentication request for "a" has been denied (IP: 192.168.10.8).

So the regex of fail2ban did not match with the tutorial.

Regards