### PR TITLE
Updated Swiftfin codec support docs

### DIFF
--- a/docs/general/clients/codec-support.md
+++ b/docs/general/clients/codec-support.md
@@ -21,8 +21,8 @@ The goal is to Direct Play all media. This means the container, video, audio and
 | [H.264 10Bit](https://caniuse.com/#feat=mpeg4 'H264 Browser Support Reference')                                    | ✅             | ✅             | ❌      | 🔶<sup>12</sup>| ✅             | ✅             | ❌             | ✅             | ❌                                                                              | ✅   | ✅                                                           |
 | [H.265 8Bit](https://caniuse.com/#feat=hevc 'HEVC Browser Support Reference')                                      | 🔶<sup>8</sup> | ✅<sup>7</sup> | ❌      | 🔶<sup>1</sup> | 🔶<sup>2</sup> | ✅<sup>5</sup> | 🔶<sup>1</sup> | ✅<sup>6</sup> | 🔶<sup>9</sup>                                                                              | ✅   | ✅                                                           |
 | [H.265 10Bit](https://caniuse.com/#feat=hevc 'HEVC Browser Support Reference')                                     | 🔶<sup>8</sup> | ✅<sup>7</sup> | ❌      | 🔶<sup>1</sup> | 🔶<sup>2</sup> | 🔶<sup>5</sup> | 🔶<sup>1</sup> | ✅<sup>6</sup> | 🔶<sup>9</sup>                                                                              | ✅   | ✅                                                           |
-| [VP9](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#VP9 'V9 Browser Support Reference')  | ✅             | ✅             | ✅      | ✅<sup>10</sup>| ✅<sup>3</sup> | 🔶<sup>3</sup> | ❌             | ❌             | ✅                                                                              | ✅   | ✅                                                           |
-| [AV1](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#AV1 'AV1 Browser Support Reference') | ✅             | ✅             | ✅      | 🔶<sup>11</sup>| ✅             | 🔶<sup>4</sup> | ❌             | ❌  | ✅                                                                              | ✅   | ✅                                                           |
+| [VP9](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#VP9 'V9 Browser Support Reference')  | ✅             | ✅             | ✅      | ✅<sup>10</sup>| ✅<sup>3</sup> | 🔶<sup>3</sup> | ❌             | ✅<sup>13</sup>| ✅                                                                              | ✅   | ✅                                                           |
+| [AV1](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#AV1 'AV1 Browser Support Reference') | ✅             | ✅             | ✅      | 🔶<sup>11</sup>| ✅             | 🔶<sup>4</sup> | ❌             | 🔶<sup>14</sup>| ✅                                                                              | ✅   | ✅                                                           |
 
 <sup>1</sup>HEVC is only supported in MP4, M4V, and MOV containers.
 <br />
@@ -47,6 +47,11 @@ The goal is to Direct Play all media. This means the container, video, audio and
 <sup>11</sup>AV1 decoding is only available on devices with A17 or M3 series chips or newer and requires at least Safari 17.
 <br />
 <sup>12</sup>Need to be manually enabled in Settings > Playback > Enable H.264 High 10 Profile. Playback on Apple Silicon Macs with macOS version < 14 and Intel Macs with all macOS versions may result in blank frames if this is enabled.
+<br />
+<sup>13</sup>VP9 is only availble with Swiftfin (VLCKit) player.
+<br />
+<sup>14</sup>AV1 is enabled by default for Swiftfin (VLCKit). AV1 is disabled by default but can be enabled for Native (AVKit) using Custom Device Profiles. Enabling AV1 may result in a poor experience for SOCs prior to A17.
+<br />
 
 [Format Cheatsheet:](https://en.wikipedia.org/wiki/MPEG-4#MPEG-4_Parts)
 


### PR DESCRIPTION
Updated documentation to show that Swiftfin supports AV1 and VP9, as found in my own testing and in Swiftfin's [documentation](https://github.com/jellyfin/Swiftfin/blob/main/Documentation/players.md).