### PR TITLE
use url of 10.10.z branch in web-config.md

### DIFF
--- a/docs/general/clients/web-config.md
+++ b/docs/general/clients/web-config.md
@@ -9,7 +9,7 @@ title: Jellyfin Web Configuration
 
 The Jellyfin Web default interface can be configured using the `config.json` file in the webroot. Where this is and how to edit it depends on the installation method.
 
-We recommend obtaining the [stable](https://github.com/jellyfin/jellyfin-web/blob/release-10.8.z/src/config.json) or the [unstable](https://github.com/jellyfin/jellyfin-web/blob/master/src/config.json) default version of the file to pre-populate your configuration directory before starting Jellyfin for the first time; unlike most other components of this directory, it will not be created automatically.
+We recommend obtaining the [stable](https://github.com/jellyfin/jellyfin-web/blob/release-10.10.z/src/config.json) or the [unstable](https://github.com/jellyfin/jellyfin-web/blob/master/src/config.json) default version of the file to pre-populate your configuration directory before starting Jellyfin for the first time; unlike most other components of this directory, it will not be created automatically.
 
 ### Debian/Ubuntu/Fedora/CentOS Packages
 


### PR DESCRIPTION
The link to the stable default web config file is probably meant to point to the latest release, correct?

If this was otherwise intentionally left at 10.8.z, please disregard this PR