### PR TITLE
docs: remove zap2xml recommendation

### DIFF
--- a/docs/general/server/live-tv/setup-guide.md
+++ b/docs/general/server/live-tv/setup-guide.md
@@ -89,8 +89,6 @@ Schedules Direct is a paid service that provides U.S., Canadian, and other guide
 
 This option allows for downloading of guide data in the [XMLTV](http://wiki.xmltv.org/index.php/XMLTVFormat) format.
 
-To create an XML file with guide data, there are several different methods. A reliable way to do this is to use [shuaiscott's zap2xml Docker container](https://github.com/shuaiscott/zap2xml).
-
 ## Mapping Channels
 
 Guide data from the 'TV Guide Data Providers' will need to be mapped to the physical channel from the tuner. Click the '...' next to the guide provider you set up and select 'Map Channels'


### PR DESCRIPTION
The README for `shuaiscott/zap2xml` was updated to mark it as deprecated on November 19, 2024 [1]. Additionally, `zap2xml` supported `tvguide` and `zap2it`. The former service has not existed for a few years, and the latter recently ceased to exist, so there's no reason to recommend this script any longer.

It was good while it lasted, R.I.P.

1. https://github.com/shuaiscott/zap2xml/commit/2c500bd14a655ebb7eaee1b9a3e7f4ceb3c46d1d