### PR TITLE
Fix anchors

### DIFF
--- a/docs/general/clients/jellyfin-vue.md
+++ b/docs/general/clients/jellyfin-vue.md
@@ -2,6 +2,7 @@
 uid: jellyfin-vue
 title: Jellyfin Vue
 ---
+import Link from '@docusaurus/Link';
 
 # Jellyfin Vue
 
@@ -66,7 +67,7 @@ services:
     restart: on-failure
 ```
 
-<span id="why-updates-needed"></span>
+<Link id="why-updates-needed"/>
 
 :::success
 Getting things up and running is as easy as doing `docker compose up -d` with your terminal


### PR DESCRIPTION
There is still a missing anchor in [Codec support table](https://jellyfin.org/docs/general/clients/codec-support#video-compatibility) (there is no page for desktop client, which I guess was Jellyfin Media Player?) Either way, since that fix is larger in scope, I left it out for another PR.