### PR TITLE
fix broken title for post-install guide

### DIFF
--- a/docs/general/post-install/_category_.yml
+++ b/docs/general/post-install/_category_.yml
@@ -1,1 +1,2 @@
 position: 3
+label: 'Post Install Setup'


### PR DESCRIPTION
when the index of the post install guide was removed from the PR the title also got removed

replacement of #1384 