### PR TITLE
Fix broken intel hwa link

### DIFF
--- a/redirects.ts
+++ b/redirects.ts
@@ -64,6 +64,10 @@ const redirects: ClientRedirects.Options['redirects'] = [
     to: '/docs/general/post-install/transcoding/hardware-acceleration/'
   },
   {
+    from: '/docs/general/administration/hardware-acceleration/intel',
+    to: '/docs/general/post-install/transcoding/hardware-acceleration/intel'
+  },
+  {
     from: '/docs/general/server/transcoding',
     to: '/docs/general/post-install/transcoding/'
   },

--- a/scripts/data/jellyfin-web-urls.json
+++ b/scripts/data/jellyfin-web-urls.json
@@ -1,5 +1,6 @@
 [
   "/docs/general/administration/hardware-acceleration.html",
+  "/docs/general/administration/hardware-acceleration/intel",
   "/docs/general/contributing/index.html",
   "/docs/general/networking/dlna.html",
   "/docs/general/networking/index.html",


### PR DESCRIPTION
Adds a redirect for a broken link used in web

Related to https://github.com/jellyfin/jellyfin-web/pull/6847