### PR TITLE
Update nginx.md

### DIFF
--- a/docs/general/post-install/networking/8_reverse-proxy/nginx.md
+++ b/docs/general/post-install/networking/8_reverse-proxy/nginx.md
@@ -90,6 +90,11 @@ server {
 }
 ```
 
+## WebOS Jellyfin App Error -27
+
+For the Jellyfin app on WebOS (running on LG TVs) the `Content-Security-Policy` header needs to be modified slightly: Remove `frame-ancestors 'self';`.
+Not removing this part may lead to the app displaying "Error -27" upon trying to log in.
+
 ## Extra Nginx Configurations
 
 ### Censor sensitive information in logs


### PR DESCRIPTION
Add note for WebOS app users experiencing error -27

I was hunting this error for hours before coming across https://github.com/jellyfin/jellyfin-webos/issues/258 where I found the solution: get rid of `frame-ancestors 'self';` in the CSP header.