### PR TITLE
Update Gentoo package name

### DIFF
--- a/docs/general/installation/advanced/community.md
+++ b/docs/general/installation/advanced/community.md
@@ -112,8 +112,10 @@ Builds in RPM package format are provided by RPM Fusion. Official packages are n
 The Gentoo ebuild repository includes the Jellyfin package which can be installed like other software:
 
 ```sh
-emerge www-apps/jellyfin
+emerge --ask www-apps/jellyfin-bin
 ```
+
+For more information, refer to the [Gentoo wiki](https://wiki.gentoo.org/wiki/Jellyfin).
 
 ## NixOS
 

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -352,7 +352,7 @@ makepkg -si`}
         details: (
           <>
             <pre>
-              <code>emerge www-apps/jellyfin</code>
+              <code>emerge --ask www-apps/jellyfin-bin</code>
             </pre>
             <p className='margin-bottom--none'>
               Once installed, Jellyfin will be running as a service. Manage it with{' '}


### PR DESCRIPTION
The name of the Jellyfin package in the Gentoo installation instructions no longer match the names in the Gentoo repositories and wiki.

`www-apps/jellyfin` -> `www-apps/jellyfin-bin`

I've also added a link to the official wiki on the documentation.