### PR TITLE
Add metadata images section

### DIFF
--- a/docs/general/server/media/_external-images.md
+++ b/docs/general/server/media/_external-images.md
@@ -1,5 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-
-## External Images
-
-Please refer to the [external images section of the music docs](/docs/general/server/media/music#external-images) while we work on a comprehensive page for external images

--- a/docs/general/server/media/_metadata-images.md
+++ b/docs/general/server/media/_metadata-images.md
@@ -1,0 +1,66 @@
+<!-- markdownlint-disable MD041 -->
+
+## Metadata Images
+
+Images can be provided as external files within the media folders, or embedded in the media files for music. When external imaged are provided, they should be placed alongside the media files. When they are provided, they will take precedence over other sources.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value='music' label='Music'>
+    ```txt
+    Album
+    ├── cover.jpg
+    ├── backdrop.webp
+    ├── logo.png
+    ├── Track 1.m4a
+    └── Track 2.m4a
+    ```
+    When no images are provided for music, Jellyfin will take the cover image from the first track that has an embedded cover image.
+  </TabItem>
+  <TabItem value='movies' label='Movies'>
+    ```txt
+    Movie (2035)
+    ├── cover.jpg
+    ├── backdrop.webp
+    ├── logo.png
+    └── Movie (2035).mp4
+    ```
+  </TabItem>
+  <TabItem value='shows' label='Shows'>
+    ```txt
+    Series Name B (2018)
+    ├── cover.jpg
+    ├── thumbnail.jpg
+    └── Season 01
+        ├── backdrop.webp
+        ├── cover.jpg
+        ├── logo.png
+        ├── Series Name B S01E01.mkv
+        └── Series Name B S01E02.mkv
+    ```
+  </TabItem>
+</Tabs>
+
+| Type       | Description                        | Allowed Names                                  |
+| ---------- | ---------------------------------- | ---------------------------------------------- |
+| Primary    | The primary cover image            | folder, poster, cover, default                 |
+| Art        | Unused                             | art                                            |
+| Backdrop   | Background image in media page     | backdrop, fanart, background, art, extrafanart |
+| Banner     | Unused                             | banner                                         |
+| Logo       | Logo displayed on the top          | logo                                           |
+| Thumb      | Thumbnail for homepage, video only | thumb                                          |
+| Disc       | Unused                             | disc                                           |
+| Box        | Unused                             | box                                            |
+| Screenshot | Deprecated                         | screenshot                                     |
+| Menu       | Unused                             | menu                                           |
+| Chapter    | Unused                             | chapter                                        |
+| BoxRear    | Unused                             | boxrear                                        |
+| Profile    | Unused                             | profile                                        |
+
+Multiple backdrop images can be used to cycle through several over time. Simply append a number to the end of the filename directly after or after a hyphen, e.g. `backdrop-1.jpg`, `backdrop2.jpg`.
+
+Below is a screenshot showing the 3 main types of images in Jellyfin
+
+![Album Image View](/images/docs/server/media/music/album-images.png)

--- a/docs/general/server/media/movies.md
+++ b/docs/general/server/media/movies.md
@@ -77,6 +77,6 @@ import ExternalExtras from './\_video-external-extras.md';
 
 <ExternalExtras />
 
-import ExternalImages from './\_external-images.md';
+import MetadataImages from './\_metadata-images.md';
 
-<ExternalImages />
+<MetadataImages />

--- a/docs/general/server/media/music-videos.md
+++ b/docs/general/server/media/music-videos.md
@@ -59,6 +59,6 @@ import ExternalExtras from './\_video-external-extras.md';
 
 <ExternalExtras />
 
-import ExternalImages from './\_external-images.md';
+import MetadataImages from './\_metadata-images.md';
 
-<ExternalImages />
+<MetadataImages />

--- a/docs/general/server/media/music.md
+++ b/docs/general/server/media/music.md
@@ -97,35 +97,9 @@ Line 5
 (...)
 ```
 
-## Images
+import MetadataImages from './\_metadata-images.md';
 
-Images can come from a few different sources. For music, there are 3 image types, as shown in this image.
-
-![Album View](/images/docs/server/media/music/album-images.png)
-
-### External images
-
-Images can be provided as external files within the media folders. When provided, they should be placed alongside the media files. In case they are provided, they will take precedence over other sources.
-
-If a cover image is not provided, Jellyfin will fallback to the first track with an embedded album image. If no backdrop or logo types are available, Jellyfin will fallback to these images of the album artist instead.
-
-```txt
-Album
-├── cover.jpg
-├── backdrop.webp
-├── logo.png
-├── Track 1.wav
-├── Track 2.wav
-└── Track 3.wav
-```
-
-| Type     | Allowed Names                                  |
-| -------- | ---------------------------------------------- |
-| Primary  | folder, poster, cover, default                 |
-| Backdrop | backdrop, fanart, background, art, extrafanart |
-| Logo     | logo                                           |
-
-Multiple backdrop images can be used to cycle through several over time. Simply append a number to the end of the filename directly after or after a hyphen.
+<MetadataImages />
 
 ## File Extensions / Containers
 

--- a/docs/general/server/media/shows.md
+++ b/docs/general/server/media/shows.md
@@ -97,6 +97,6 @@ import Multipart from './\_video-multipart.md';
 
 <Multipart />
 
-import ExternalImages from './\_external-images.md';
+import ExternalImages from './\_metadata-images.md';
 
 <ExternalImages />


### PR DESCRIPTION
Add a section to document images in metadata

Missing:
- Where the images are from if not provided at all
- Where the images are from when extracted from video
- maybe some alternative file names?