### PR TITLE
remove hotio counter

### DIFF
--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -14,7 +14,7 @@ This image is also published on the GitHub Container Registry: `ghcr.io/jellyfin
 
 LinuxServer.io image: `linuxserver/jellyfin` [![linuxserver jellyfin Docker Pull Count](https://img.shields.io/docker/pulls/linuxserver/jellyfin.svg)](https://hub.docker.com/r/linuxserver/jellyfin).
 
-hotio image: `hotio/jellyfin` [![hotio jellyfin Docker Pull Count](https://img.shields.io/docker/pulls/hotio/jellyfin.svg)](https://hub.docker.com/r/hotio/jellyfin).
+hotio image: `ghcr.io/hotio/jellyfin`.
 
 Jellyfin distributes official container images on [Docker Hub](https://hub.docker.com/r/jellyfin/jellyfin/) and the [GitHub Container Registry](https://ghcr.io/jellyfin/jellyfin) for multiple architectures.
 These images are based on Debian and [built directly from the Jellyfin source code](https://github.com/jellyfin/jellyfin-packaging/blob/master/docker/Dockerfile).


### PR DESCRIPTION
Since the `hotio` image is not/ no longer(?) present on docker-hub, the Pull stats do not work anymore.
ghcr.io does not support accessing the pull count via API, therefore we will have to remove the pull counter for this image as well.

I previously suggested using "ghcr.io: pull count unavailable" banners that link to the repo, however we did not do that.
Therefore the only approach here is to remove this banner entirely.