### PR TITLE
Fix quick start guide link redirect for iOS app

### DIFF
--- a/redirects.ts
+++ b/redirects.ts
@@ -114,8 +114,13 @@ const redirects: ClientRedirects.Options['redirects'] = [
   },
   // quick start replaced with post install
   {
-    from: '/docs/general/quick-start',
-    to: '/docs/general/post-install/setup-wizard'
+    from: [
+      '/docs/general/quick-start',
+      // the .html url is linked from the iOS app
+      '/docs/general/quick-start.html'
+    ],
+    // TODO: create a better replacement page with similar content to the quick start guide
+    to: '/docs/'
   }
 ];
 export default redirects;


### PR DESCRIPTION
Fixes the 404 in https://github.com/jellyfin/jellyfin-expo/issues/658

We still need a better replacement with similar content to the original quick start guide, but at least this will resolve the 404 for now. The app will also need updated to directly link to this new page when it is available.