### PR TITLE
Update branding guide to include logo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@ blog/                                  @jellyfin/core
 src/data/                              @jellyfin/core
 docs/general/about.md                  @jellyfin/core
 docs/general/community-standards.md    @joshuaboniface
+docs/general/contributing/             @jellyfin/core

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,8 @@
 .env.test.local
 .env.production.local
 
+CODEOWNERS
+
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/docs/general/contributing/branding.md
+++ b/docs/general/contributing/branding.md
@@ -14,6 +14,15 @@ You are free to use the Jellyfin name to promote your project, with some restric
 - Do not use the Jellyfin name in any context that promotes, allows or encourages piracy.
 - Do not wrongfully claim to be part of the Jellyfin team.
 
+It is also preferred for projects outside of the Jellyfin organization use unique names that are not based on a "jelly" prefix or "fin" suffix.
+
+## Usage of the Jellyfin logo
+
+- Do not use the Jellyfin logo as the logo or app icon for your project. This includes:
+  - recolored variations of the logo
+  - rotating the logo
+  - any other minor changes to the official logo
+
 ## Writing Style
 
 As a general rule, Jellyfin should always be capitalized, but language, file, or system conventions trump Jellyfin naming conventions.


### PR DESCRIPTION
* Updates the branding guide to specify that usage of the Jellyfin logo as a project logo or app icon is not permitted.
* Updates the branding guide to specify that unique project names that do not include "jelly" as a prefix or "fin" as a suffix are preferred.