### PR TITLE
Update index.mdx to add AudioMuse-AI to the 3rd party plugin list

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -321,6 +321,12 @@ A plugin to integrate your TubeArchivist library with Jellyfin, providing metada
 
 - [GitHub](https://github.com/tubearchivist/tubearchivist-jf-plugin)
 
+#### AudioMuse-AI
+
+Enhance Jellyfin with sonic analysis and smart song clustering, replacing InstantMix with sonically similar music suggestions.**Links:**
+
+- [GitHub](https://github.com/NeptuneHub/audiomuse-ai-plugin)
+
 ## Repositories
 
 import { OfficialPluginRepositories, ThirdPartyRepositories } from '../../../../src/data/pluginRepositories';

--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -255,71 +255,7 @@ Ani-Sync lets you synchronize/scrobble your Jellyfin Anime watch progress to pop
 
 **Links:**
 
-- [GitHub](https://github.com/vosmiic/jellyfin-ani-sync)
-
-#### Kinopoisk metadata plugin
-
-Fetches metadata from [https://kinopoisk.ru](https://kinopoisk.ru). This site is popular in the Russian-speaking community and contains almost no English-language information. Can provide movies and series rating, description, actors and staff, trailers and so on.
-
-**Links:**
-
-- [GitHub](https://github.com/LinFor/jellyfin-plugin-kinopoisk)
-
-#### Last.FM
-
-Enables audio scrobbling to Last.FM as well as a metadata fetcher source.
-
-**Links:**
-
-- [GitHub](https://github.com/jesseward/jellyfin-plugin-lastfm)
-
-#### Merge Versions
-
-Automatically group every repeated movie.
-
-**Links:**
-
-- [GitHub](https://github.com/danieladov/jellyfin-plugin-mergeversions)
-
-#### Shokofin
-
-A plugin to integrate your Shoko database with the Jellyfin media server.
-
-**Links:**
-
-- [GitHub](https://github.com/ShokoAnime/Shokofin)
-
-#### Skin Manager
-
-Download and manage the most popular skins.
-
-**Links:**
-
-- [GitHub](https://github.com/danieladov/jellyfin-plugin-skin-manager)
-
-#### Themerr
-
-Plugin for Jellyfin that adds theme songs to movies and tv shows using ThemerrDB.
-
-**Links:**
-
-- [GitHub](https://github.com/LizardByte/themerr-jellyfin)
-
-#### YouTube Metadata
-
-Downloads metadata of YouTube videos with a YouTube API key.
-
-**Links:**
-
-- [GitHub](https://github.com/ankenyr/jellyfin-youtube-metadata-plugin)
-
-#### TubeArchivistMetadata
-
-A plugin to integrate your TubeArchivist library with Jellyfin, providing metadata and organizing media.
-
-**Links:**
-
-- [GitHub](https://github.com/tubearchivist/tubearchivist-jf-plugin)
+* [GitHub](https://github.com/vosmiic/jellyfin-ani-sync)
 
 #### AudioMuse-AI
 
@@ -327,7 +263,76 @@ Enhance Jellyfin with sonic analysis and smart song clustering, replacing Instan
 
 **Links:**
 
-- [GitHub](https://github.com/NeptuneHub/audiomuse-ai-plugin)
+* [GitHub](https://github.com/NeptuneHub/audiomuse-ai-plugin)
+
+#### Kinopoisk metadata plugin
+
+Fetches metadata from [https://kinopoisk.ru](https://kinopoisk.ru). This site is popular in the Russian-speaking community and contains almost no English-language information. Can provide movies and series rating, description, actors and staff, trailers and so on.
+
+**Links:**
+
+* [GitHub](https://github.com/LinFor/jellyfin-plugin-kinopoisk)
+
+#### Last.FM
+
+Enables audio scrobbling to Last.FM as well as a metadata fetcher source.
+
+**Links:**
+
+* [GitHub](https://github.com/jesseward/jellyfin-plugin-lastfm)
+
+#### Merge Versions
+
+Automatically group every repeated movie.
+
+**Links:**
+
+* [GitHub](https://github.com/danieladov/jellyfin-plugin-mergeversions)
+
+#### Shokofin
+
+A plugin to integrate your Shoko database with the Jellyfin media server.
+
+**Links:**
+
+* [GitHub](https://github.com/ShokoAnime/Shokofin)
+
+#### Skin Manager
+
+Download and manage the most popular skins.
+
+**Links:**
+
+* [GitHub](https://github.com/danieladov/jellyfin-plugin-skin-manager)
+
+#### Themerr
+
+Plugin for Jellyfin that adds theme songs to movies and tv shows using ThemerrDB.
+
+**Links:**
+
+* [GitHub](https://github.com/LizardByte/themerr-jellyfin)
+
+#### TubeArchivistMetadata
+
+A plugin to integrate your TubeArchivist library with Jellyfin, providing metadata and organizing media.
+
+**Links:**
+
+* [GitHub](https://github.com/tubearchivist/tubearchivist-jf-plugin)
+
+#### YouTube Metadata
+
+Downloads metadata of YouTube videos with a YouTube API key.
+
+**Links:**
+
+* [GitHub](https://github.com/ankenyr/jellyfin-youtube-metadata-plugin)
+
+---
+
+Let me know if you'd like it sorted by GitHub repo name or description instead.
+
 
 ## Repositories
 

--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -323,7 +323,9 @@ A plugin to integrate your TubeArchivist library with Jellyfin, providing metada
 
 #### AudioMuse-AI
 
-Enhance Jellyfin with sonic analysis and smart song clustering, replacing InstantMix with sonically similar music suggestions.**Links:**
+Enhance Jellyfin with sonic analysis and smart song clustering, replacing InstantMix with sonically similar music suggestions.
+
+**Links:**
 
 - [GitHub](https://github.com/NeptuneHub/audiomuse-ai-plugin)
 

--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -329,11 +329,6 @@ Downloads metadata of YouTube videos with a YouTube API key.
 
 - [GitHub](https://github.com/ankenyr/jellyfin-youtube-metadata-plugin)
 
----
-
-Let me know if you'd like it sorted by GitHub repo name or description instead.
-
-
 ## Repositories
 
 import { OfficialPluginRepositories, ThirdPartyRepositories } from '../../../../src/data/pluginRepositories';

--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -255,7 +255,7 @@ Ani-Sync lets you synchronize/scrobble your Jellyfin Anime watch progress to pop
 
 **Links:**
 
-* [GitHub](https://github.com/vosmiic/jellyfin-ani-sync)
+- [GitHub](https://github.com/vosmiic/jellyfin-ani-sync)
 
 #### AudioMuse-AI
 
@@ -263,7 +263,7 @@ Enhance Jellyfin with sonic analysis and smart song clustering, replacing Instan
 
 **Links:**
 
-* [GitHub](https://github.com/NeptuneHub/audiomuse-ai-plugin)
+- [GitHub](https://github.com/NeptuneHub/audiomuse-ai-plugin)
 
 #### Kinopoisk metadata plugin
 
@@ -271,7 +271,7 @@ Fetches metadata from [https://kinopoisk.ru](https://kinopoisk.ru). This site is
 
 **Links:**
 
-* [GitHub](https://github.com/LinFor/jellyfin-plugin-kinopoisk)
+- [GitHub](https://github.com/LinFor/jellyfin-plugin-kinopoisk)
 
 #### Last.FM
 
@@ -279,7 +279,7 @@ Enables audio scrobbling to Last.FM as well as a metadata fetcher source.
 
 **Links:**
 
-* [GitHub](https://github.com/jesseward/jellyfin-plugin-lastfm)
+- [GitHub](https://github.com/jesseward/jellyfin-plugin-lastfm)
 
 #### Merge Versions
 
@@ -287,7 +287,7 @@ Automatically group every repeated movie.
 
 **Links:**
 
-* [GitHub](https://github.com/danieladov/jellyfin-plugin-mergeversions)
+- [GitHub](https://github.com/danieladov/jellyfin-plugin-mergeversions)
 
 #### Shokofin
 
@@ -295,7 +295,7 @@ A plugin to integrate your Shoko database with the Jellyfin media server.
 
 **Links:**
 
-* [GitHub](https://github.com/ShokoAnime/Shokofin)
+- [GitHub](https://github.com/ShokoAnime/Shokofin)
 
 #### Skin Manager
 
@@ -303,7 +303,7 @@ Download and manage the most popular skins.
 
 **Links:**
 
-* [GitHub](https://github.com/danieladov/jellyfin-plugin-skin-manager)
+- [GitHub](https://github.com/danieladov/jellyfin-plugin-skin-manager)
 
 #### Themerr
 
@@ -311,7 +311,7 @@ Plugin for Jellyfin that adds theme songs to movies and tv shows using ThemerrDB
 
 **Links:**
 
-* [GitHub](https://github.com/LizardByte/themerr-jellyfin)
+- [GitHub](https://github.com/LizardByte/themerr-jellyfin)
 
 #### TubeArchivistMetadata
 
@@ -319,7 +319,7 @@ A plugin to integrate your TubeArchivist library with Jellyfin, providing metada
 
 **Links:**
 
-* [GitHub](https://github.com/tubearchivist/tubearchivist-jf-plugin)
+- [GitHub](https://github.com/tubearchivist/tubearchivist-jf-plugin)
 
 #### YouTube Metadata
 
@@ -327,7 +327,7 @@ Downloads metadata of YouTube videos with a YouTube API key.
 
 **Links:**
 
-* [GitHub](https://github.com/ankenyr/jellyfin-youtube-metadata-plugin)
+- [GitHub](https://github.com/ankenyr/jellyfin-youtube-metadata-plugin)
 
 ---
 

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -48,6 +48,14 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     }
   },
   {
+    id: 'gh:neptunehub/audiomuse-ai-plugin',
+    name: "AudioMuse-AI Repo",
+    url: 'https://raw.githubusercontent.com/neptunehub/audiomuse-ai-plugin/master/manifest.json',
+    includes: {
+      'AudioMuse-AI': 'https://github.com/neptunehub/audiomuse-ai-plugin'
+    }
+  },
+  {
     id: 'gh:danieladov/JellyfinPluginManifest',
     name: "danieladov's Repo",
     url: 'https://raw.githubusercontent.com/danieladov/JellyfinPluginManifest/master/manifest.json',


### PR DESCRIPTION
As suggested on Discord, I'm submitting this PR to add the **AudioMuse AI** plugin to the list of 3rd-party Jellyfin plugins:

 [https://github.com/NeptuneHub/audiomuse-ai-plugin](https://github.com/NeptuneHub/audiomuse-ai-plugin)

I've added it to the end of the list (since the current order isn't alphabetical) and followed the existing formatting style.

Let me know if it's ok or any change is needed.

Thanks.
