### PR TITLE
Clarify bash script setup process

### DIFF
--- a/docs/general/installation/advanced/manual.md
+++ b/docs/general/installation/advanced/manual.md
@@ -162,13 +162,19 @@ sudo apt install -f
 
 ### Running Jellyfin
 
-Due to the number of command line options that must be passed on to the Jellyfin binary, it is easiest to create a small script to run Jellyfin.
+Due to the number of [command line options](https://jellyfin.org/docs/general/administration/configuration/#command-line-options) that must be passed on to the Jellyfin binary, it is easiest to create a small script to run Jellyfin.
 
 ```sh
 sudoedit jellyfin.sh
 ```
 
-Then paste the following commands and modify as needed.
+Then paste the following commands.
+
+:::note
+
+Optionally, to make changes to the directories used or specify extra [command line options](https://jellyfin.org/docs/general/administration/configuration/#command-line-options), add or modify the script below as needed.
+
+:::
 
 ```sh
 #!/bin/bash

--- a/docs/general/installation/advanced/manual.md
+++ b/docs/general/installation/advanced/manual.md
@@ -168,13 +168,7 @@ Due to the number of [command line options](https://jellyfin.org/docs/general/ad
 sudoedit jellyfin.sh
 ```
 
-Then paste the following commands.
-
-:::note
-
-Optionally, to make changes to the directories used or specify extra [command line options](https://jellyfin.org/docs/general/administration/configuration/#command-line-options), add or modify the script below as needed.
-
-:::
+Then paste the following commands, optionally changing paths and options as needed.
 
 ```sh
 #!/bin/bash

--- a/docs/general/installation/advanced/manual.md
+++ b/docs/general/installation/advanced/manual.md
@@ -193,7 +193,9 @@ Assuming you desire Jellyfin to run as a non-root user, `chmod` all files and di
 Also make the startup script above executable.
 
 ```sh
-sudo chown -R user:group *
+USER=$(id --name --user)
+GROUP=$(id --name --group)
+sudo chown -R $USER:$GROUP *
 sudo chmod u+x jellyfin.sh
 ```
 

--- a/docs/general/installation/advanced/manual.md
+++ b/docs/general/installation/advanced/manual.md
@@ -168,7 +168,7 @@ Due to the number of [command line options](https://jellyfin.org/docs/general/ad
 sudoedit jellyfin.sh
 ```
 
-Then paste the following commands, optionally changing paths and options as needed.
+Then paste the following commands, optionally changing arguments as needed for custom deployments.
 
 ```sh
 #!/bin/bash


### PR DESCRIPTION
this should make it more clear that the given bash script will work out of box without modification, and also supplies the user and group name for the chown command. 

the $USER variable should already exist, but in trying to figure out a clear way to have the id command just spit out the username I found someone complaining that their distro doesn't set the env variable, so I figure it's best to just set it anyway.