### PR TITLE
sort clients.ts

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -728,22 +728,6 @@ export const thirdPartyClients: Array<Client> = [
     ]
   },
   {
-    id: 'jellyfin-plugin-for-volumio',
-    name: 'Jellyfin Plugin for Volumio',
-    description: 'A Volumio plugin for playing audio from one or more Jellyfin servers.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [],
-    licenseType: LicenseType.OpenSource,
-    platforms: [],
-    primaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/patrickkfkan/volumio-jellyfin'
-      }
-    ]
-  },
-  {
     id: 'jftui',
     name: 'jftui',
     description: 'A terminal client for Jellyfin built as a REPL interface, that uses mpv for multimedia playback.',
@@ -973,6 +957,22 @@ export const thirdPartyClients: Array<Client> = [
         id: 'tauon',
         name: 'Website',
         url: 'https://tauonmusicbox.rocks'
+      }
+    ]
+  },
+  {
+    id: 'volumio',
+    name: 'Jellyfin Plugin for Volumio',
+    description: 'A Volumio plugin for playing audio from one or more Jellyfin servers.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [],
+    licenseType: LicenseType.OpenSource,
+    platforms: [],
+    primaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/patrickkfkan/volumio-jellyfin'
       }
     ]
   },

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -37,7 +37,7 @@ export type Client = {
   recommended?: boolean;
 };
 
-export const Clients: Array<Client> = [
+export const officialClients: Array<Client> = [
   {
     id: 'jellycon',
     name: 'JellyCon',
@@ -382,7 +382,10 @@ export const Clients: Array<Client> = [
         url: 'https://github.com/jellyfin/swiftfin'
       }
     ]
-  },
+  }
+]
+
+export const thirdPartyClients: Array<Client> = [
   {
     id: 'discord-music-manuel-rw',
     name: 'Discord Music Bot for Jellyfin by manuel-rw',
@@ -1024,4 +1027,9 @@ export const Clients: Array<Client> = [
       }
     ]
   }
+];
+
+export const Clients: Array<Client> = [
+  ...officialClients,
+  ...thirdPartyClients
 ];

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -783,11 +783,6 @@ export const thirdPartyClients: Array<Client> = [
     platforms: [Platform.Browser, Platform.Desktop],
     primaryLinks: [
       {
-        id: 'website',
-        name: 'Website',
-        url: 'https://preserveplayer.com/'
-      },
-      {
         id: 'gl-downloads',
         name: 'GitLab Downloads',
         url: 'https://gitlab.com/tonyfinn/preserve/-/releases'
@@ -798,6 +793,11 @@ export const thirdPartyClients: Array<Client> = [
         id: 'gitlab',
         name: 'GitLab',
         url: 'https://gitlab.com/tonyfinn/preserve'
+      },
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://preserveplayer.com/'
       }
     ]
   },

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -96,29 +96,6 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'jellyamp',
-    name: 'Jellyamp',
-    description: 'A desktop client for listening to music from a Jellyfin server.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Desktop],
-    primaryLinks: [
-      {
-        id: 'gh-downloads',
-        name: 'GitHub Downloads',
-        url: 'https://github.com/m0ngr31/jellyamp/releases'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/m0ngr31/jellyamp'
-      }
-    ]
-  },
-  {
     id: 'jellyfin-vue',
     name: 'Jellyfin Vue',
     description: 'A modern web client for Jellyfin based on Vue',
@@ -143,6 +120,290 @@ export const Clients: Array<Client> = [
         id: 'github',
         name: 'GitHub',
         url: 'https://github.com/jellyfin/jellyfin-vue'
+      }
+    ]
+  },
+  {
+    id: 'jellycon',
+    name: 'JellyCon',
+    description:
+      'A lightweight Kodi add-on that lets you browse and play media files directly from your Jellyfin server within the Kodi interface.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Kodi],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: 'https://github.com/jellyfin/jellycon#installation'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellycon'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-kodi',
+    name: 'Jellyfin for Kodi',
+    description: 'A Kodi add-on that syncs metadata from selected Jellyfin libraries into the local Kodi database.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Kodi],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: '/docs/general/clients/kodi'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-kodi'
+      }
+    ]
+  },
+  {
+    id: 'jellyfin-android',
+    name: 'Jellyfin for Android',
+    description: 'The official Jellyfin app for Android devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Android],
+    primaryLinks: [
+      {
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/en/packages/org.jellyfin.mobile/'
+      },
+      {
+        id: 'amazon-store',
+        name: 'Amazon Appstore',
+        url: 'https://www.amazon.com/gp/aw/d/B081RFTTQ9'
+      },
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.mobile'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-android'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-expo',
+    name: 'Jellyfin Mobile for iOS',
+    description: 'The official Jellyfin app for iOS and iPadOS devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/jellyfin-mobile/id1480192618?mt=8'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-expo'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'swiftfin',
+    name: 'Swiftfin',
+    description:
+      'Swiftfin is a modern video client for Jellyfin. Redesigned in Swift to maximize direct play with the power of VLC and look native on all classes of Apple devices.',
+    clientType: ClientType.OfficialBeta,
+    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.IOS, Platform.TVOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/swiftfin'
+      }
+    ]
+  },
+  {
+    id: 'jellyfin-androidtv',
+    name: 'Jellyfin for Android TV',
+    description: 'The official Jellyfin app for Android TV and Fire TV devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.AndroidTV, Platform.FireOS],
+    primaryLinks: [
+      {
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/en/packages/org.jellyfin.androidtv/'
+      },
+      {
+        id: 'amazon-store',
+        name: 'Amazon Appstore',
+        url: 'https://www.amazon.com/gp/aw/d/B07TX7Z725'
+      },
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.androidtv'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-androidtv'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-roku',
+    name: 'Jellyfin for Roku',
+    description: 'The official Jellyfin app for Roku devices.',
+    smallDescription:
+      'Due to a technical limitation of the Roku store, the Jellyfin app for Roku may state that a cable or satellite subscription is required. However, no subscription of any form is required to use the Jellyfin server or any official client.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Roku],
+    primaryLinks: [
+      {
+        id: 'roku-store',
+        name: 'Channel Store',
+        url: 'https://channelstore.roku.com/details/592369/jellyfin'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-roku'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-webos',
+    name: 'Jellyfin for WebOS',
+    description: 'The official Jellyfin app for WebOS devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.WebOS],
+    primaryLinks: [
+      {
+        id: 'lg-store',
+        name: 'Content Store',
+        url: 'https://us.lgappstv.com/main/tvapp/detail?appId=1030579'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-webos'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'mopidy',
+    name: 'Mopidy-Jellyfin',
+    description: 'An official plugin for Mopidy that uses Jellyfin as a backend.',
+    clientType: ClientType.Official,
+    deviceTypes: [],
+    licenseType: LicenseType.OpenSource,
+    platforms: [],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: '/docs/general/clients/mopidy'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/mopidy-jellyfin'
+      }
+    ]
+  },
+  {
+    id: 'infuse',
+    name: 'Infuse',
+    description: 'A third-party client for iOS, iPadOS, and tvOS devices.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.IOS, Platform.TVOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/app/id1136220934?mt=8'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://firecore.com/infuse'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyamp',
+    name: 'Jellyamp',
+    description: 'A desktop client for listening to music from a Jellyfin server.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Desktop],
+    primaryLinks: [
+      {
+        id: 'gh-downloads',
+        name: 'GitHub Downloads',
+        url: 'https://github.com/m0ngr31/jellyamp/releases'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/m0ngr31/jellyamp'
       }
     ]
   },
@@ -282,136 +543,6 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'jellycon',
-    name: 'JellyCon',
-    description:
-      'A lightweight Kodi add-on that lets you browse and play media files directly from your Jellyfin server within the Kodi interface.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Kodi],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/jellyfin/jellycon#installation'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellycon'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-kodi',
-    name: 'Jellyfin for Kodi',
-    description: 'A Kodi add-on that syncs metadata from selected Jellyfin libraries into the local Kodi database.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Kodi],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: '/docs/general/clients/kodi'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-kodi'
-      }
-    ]
-  },
-  {
-    id: 'jellyfin-android',
-    name: 'Jellyfin for Android',
-    description: 'The official Jellyfin app for Android devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android],
-    primaryLinks: [
-      {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/en/packages/org.jellyfin.mobile/'
-      },
-      {
-        id: 'amazon-store',
-        name: 'Amazon Appstore',
-        url: 'https://www.amazon.com/gp/aw/d/B081RFTTQ9'
-      },
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.mobile'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-android'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-expo',
-    name: 'Jellyfin Mobile for iOS',
-    description: 'The official Jellyfin app for iOS and iPadOS devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.IOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/us/app/jellyfin-mobile/id1480192618?mt=8'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-expo'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'swiftfin',
-    name: 'Swiftfin',
-    description:
-      'Swiftfin is a modern video client for Jellyfin. Redesigned in Swift to maximize direct play with the power of VLC and look native on all classes of Apple devices.',
-    clientType: ClientType.OfficialBeta,
-    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.IOS, Platform.TVOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/swiftfin'
-      }
-    ]
-  },
-  {
     id: 'findroid',
     name: 'Findroid',
     description:
@@ -545,137 +676,6 @@ export const Clients: Array<Client> = [
         id: 'yatse',
         name: 'Website',
         url: 'https://yatse.tv/'
-      }
-    ]
-  },
-  {
-    id: 'jellyfin-androidtv',
-    name: 'Jellyfin for Android TV',
-    description: 'The official Jellyfin app for Android TV and Fire TV devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.AndroidTV, Platform.FireOS],
-    primaryLinks: [
-      {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/en/packages/org.jellyfin.androidtv/'
-      },
-      {
-        id: 'amazon-store',
-        name: 'Amazon Appstore',
-        url: 'https://www.amazon.com/gp/aw/d/B07TX7Z725'
-      },
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.androidtv'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-androidtv'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-roku',
-    name: 'Jellyfin for Roku',
-    description: 'The official Jellyfin app for Roku devices.',
-    smallDescription:
-      'Due to a technical limitation of the Roku store, the Jellyfin app for Roku may state that a cable or satellite subscription is required. However, no subscription of any form is required to use the Jellyfin server or any official client.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Roku],
-    primaryLinks: [
-      {
-        id: 'roku-store',
-        name: 'Channel Store',
-        url: 'https://channelstore.roku.com/details/592369/jellyfin'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-roku'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-webos',
-    name: 'Jellyfin for WebOS',
-    description: 'The official Jellyfin app for WebOS devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.WebOS],
-    primaryLinks: [
-      {
-        id: 'lg-store',
-        name: 'Content Store',
-        url: 'https://us.lgappstv.com/main/tvapp/detail?appId=1030579'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-webos'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'infuse',
-    name: 'Infuse',
-    description: 'A third-party client for iOS, iPadOS, and tvOS devices.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.Proprietary,
-    platforms: [Platform.IOS, Platform.TVOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/app/id1136220934?mt=8'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'website',
-        name: 'Website',
-        url: 'https://firecore.com/infuse'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'mopidy',
-    name: 'Mopidy-Jellyfin',
-    description: 'An official plugin for Mopidy that uses Jellyfin as a backend.',
-    clientType: ClientType.Official,
-    deviceTypes: [],
-    licenseType: LicenseType.OpenSource,
-    platforms: [],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: '/docs/general/clients/mopidy'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/mopidy-jellyfin'
       }
     ]
   },
@@ -882,7 +882,7 @@ export const Clients: Array<Client> = [
     clientType: ClientType.ThirdParty,
     deviceTypes: [DeviceType.Mobile],
     licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android, Platform.IOS, Platform.iPadOS],
+    platforms: [Platform.Android, Platform.IOS],
     primaryLinks: [
       {
         id: 'app-store',

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -39,31 +39,6 @@ export type Client = {
 
 export const officialClients: Array<Client> = [
   {
-    id: 'jellycon',
-    name: 'JellyCon',
-    description:
-      'A lightweight Kodi add-on that lets you browse and play media files directly from your Jellyfin server within the Kodi interface.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Kodi],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/jellyfin/jellycon#installation'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellycon'
-      }
-    ],
-    recommended: true
-  },
-  {
     id: 'jellyfin-android',
     name: 'Jellyfin for Android',
     description: 'The official Jellyfin app for Android devices.',
@@ -132,6 +107,55 @@ export const officialClients: Array<Client> = [
     recommended: true
   },
   {
+    id: 'jellyfin-ios',
+    name: 'Jellyfin for iOS',
+    description: 'The official Jellyfin app for iOS and iPadOS devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/jellyfin-mobile/id1480192618?mt=8'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-expo'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellycon',
+    name: 'JellyCon',
+    description:
+      'A lightweight Kodi add-on that lets you browse and play media files directly from your Jellyfin server within the Kodi interface.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Kodi],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: 'https://github.com/jellyfin/jellycon#installation'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellycon'
+      }
+    ],
+    recommended: true
+  },
+  {
     id: 'jellyfin-kodi',
     name: 'Jellyfin for Kodi',
     description: 'A Kodi add-on that syncs metadata from selected Jellyfin libraries into the local Kodi database.',
@@ -153,30 +177,6 @@ export const officialClients: Array<Client> = [
         url: 'https://github.com/jellyfin/jellyfin-kodi'
       }
     ]
-  },
-  {
-    id: 'jellyfin-expo',
-    name: 'Jellyfin Mobile for iOS',
-    description: 'The official Jellyfin app for iOS and iPadOS devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.IOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/us/app/jellyfin-mobile/id1480192618?mt=8'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-expo'
-      }
-    ],
-    recommended: true
   },
   {
     id: 'jellyfin-media-player',
@@ -206,6 +206,29 @@ export const officialClients: Array<Client> = [
       }
     ],
     recommended: true
+  },
+  {
+    id: 'mopidy',
+    name: 'Mopidy-Jellyfin',
+    description: 'An official plugin for Mopidy that uses Jellyfin as a backend.',
+    clientType: ClientType.Official,
+    deviceTypes: [],
+    licenseType: LicenseType.OpenSource,
+    platforms: [],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: '/docs/general/clients/mopidy'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/mopidy-jellyfin'
+      }
+    ]
   },
   {
     id: 'jellyfin-mpv-shim',
@@ -262,28 +285,28 @@ export const officialClients: Array<Client> = [
     recommended: true
   },
   {
-    id: 'jellyfin-webos',
-    name: 'Jellyfin for WebOS',
-    description: 'The official Jellyfin app for WebOS devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
+    id: 'swiftfin',
+    name: 'Swiftfin',
+    description:
+      'Swiftfin is a modern video client for Jellyfin. Redesigned in Swift to maximize direct play with the power of VLC and look native on all classes of Apple devices.',
+    clientType: ClientType.OfficialBeta,
+    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
     licenseType: LicenseType.OpenSource,
-    platforms: [Platform.WebOS],
+    platforms: [Platform.IOS, Platform.TVOS],
     primaryLinks: [
       {
-        id: 'lg-store',
-        name: 'Content Store',
-        url: 'https://us.lgappstv.com/main/tvapp/detail?appId=1030579'
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
       }
     ],
     secondaryLinks: [
       {
         id: 'github',
         name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-webos'
+        url: 'https://github.com/jellyfin/swiftfin'
       }
-    ],
-    recommended: true
+    ]
   },
   {
     id: 'jellyfin-vue',
@@ -314,6 +337,30 @@ export const officialClients: Array<Client> = [
     ]
   },
   {
+    id: 'jellyfin-webos',
+    name: 'Jellyfin for WebOS',
+    description: 'The official Jellyfin app for WebOS devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.WebOS],
+    primaryLinks: [
+      {
+        id: 'lg-store',
+        name: 'Content Store',
+        url: 'https://us.lgappstv.com/main/tvapp/detail?appId=1030579'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-webos'
+      }
+    ],
+    recommended: true
+  },
+  {
     id: 'jellyfin-xbox',
     name: 'Jellyfin for Xbox',
     description: 'The official Jellyfin app for Xbox consoles.',
@@ -336,53 +383,6 @@ export const officialClients: Array<Client> = [
       }
     ]
   },
-  {
-    id: 'mopidy',
-    name: 'Mopidy-Jellyfin',
-    description: 'An official plugin for Mopidy that uses Jellyfin as a backend.',
-    clientType: ClientType.Official,
-    deviceTypes: [],
-    licenseType: LicenseType.OpenSource,
-    platforms: [],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: '/docs/general/clients/mopidy'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/mopidy-jellyfin'
-      }
-    ]
-  },
-  {
-    id: 'swiftfin',
-    name: 'Swiftfin',
-    description:
-      'Swiftfin is a modern video client for Jellyfin. Redesigned in Swift to maximize direct play with the power of VLC and look native on all classes of Apple devices.',
-    clientType: ClientType.OfficialBeta,
-    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.IOS, Platform.TVOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/swiftfin'
-      }
-    ]
-  }
 ]
 
 export const thirdPartyClients: Array<Client> = [

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -382,7 +382,7 @@ export const officialClients: Array<Client> = [
         url: 'https://github.com/jellyfin/jellyfin-xbox'
       }
     ]
-  },
+  }
 ]
 
 export const thirdPartyClients: Array<Client> = [

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -420,11 +420,6 @@ export const thirdPartyClients: Array<Client> = [
     platforms: [Platform.Desktop],
     primaryLinks: [
       {
-        id: 'browser',
-        name: 'Open in Browser',
-        url: 'https://feishin.vercel.app/'
-      },
-      {
         id: 'gh-downloads',
         name: 'GitHub Downloads',
         url: 'https://github.com/jeffvli/feishin/releases'
@@ -435,7 +430,12 @@ export const thirdPartyClients: Array<Client> = [
         id: 'github',
         name: 'GitHub',
         url: 'https://github.com/jeffvli/feishin'
-      }
+      },
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://feishin.vercel.app/'
+      },
     ]
   },
   {
@@ -954,7 +954,7 @@ export const thirdPartyClients: Array<Client> = [
         url: 'https://github.com/Taiko2k/TauonMusicBox'
       },
       {
-        id: 'tauon',
+        id: 'website',
         name: 'Website',
         url: 'https://tauonmusicbox.rocks'
       }
@@ -1021,7 +1021,7 @@ export const thirdPartyClients: Array<Client> = [
     ],
     secondaryLinks: [
       {
-        id: 'yatse',
+        id: 'website',
         name: 'Website',
         url: 'https://yatse.tv/'
       }

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -544,14 +544,14 @@ export const thirdPartyClients: Array<Client> = [
       {
         id: 'play-store',
         name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=nl.jknaapen.fladder',
+        url: 'https://play.google.com/store/apps/details?id=nl.jknaapen.fladder'
       }
     ],
     secondaryLinks: [
       {
         id: 'github',
         name: 'GitHub',
-        url: 'https://github.com/DonutWare/Fladder',
+        url: 'https://github.com/DonutWare/Fladder'
       }
     ]
   },

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -384,123 +384,26 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'infuse',
-    name: 'Infuse',
-    description: 'A third-party client for iOS, iPadOS, and tvOS devices.',
+    id: 'discord-music-manuel-rw',
+    name: 'Discord Music Bot for Jellyfin by manuel-rw',
+    description:
+      'A fork, based on the original bot by KGT1, that has been refactored and supports the Discord command system',
     clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.Proprietary,
-    platforms: [Platform.IOS, Platform.TVOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/app/id1136220934?mt=8'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'website',
-        name: 'Website',
-        url: 'https://firecore.com/infuse'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyamp',
-    name: 'Jellyamp',
-    description: 'A desktop client for listening to music from a Jellyfin server.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
+    deviceTypes: [],
     licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Desktop],
-    primaryLinks: [
-      {
-        id: 'gh-downloads',
-        name: 'GitHub Downloads',
-        url: 'https://github.com/m0ngr31/jellyamp/releases'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/m0ngr31/jellyamp'
-      }
-    ]
-  },
-  {
-    id: 'preserve',
-    name: 'Preserve',
-    description: 'A music client inspired by players such as foobar2000 or Clementine.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Browser, Platform.Desktop],
-    primaryLinks: [
-      {
-        id: 'browser',
-        name: 'Open in Browser',
-        url: 'https://preserveplayer.com/'
-      },
-      {
-        id: 'gl-downloads',
-        name: 'GitLab Downloads',
-        url: 'https://gitlab.com/tonyfinn/preserve/-/releases'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'gitlab',
-        name: 'GitLab',
-        url: 'https://gitlab.com/tonyfinn/preserve'
-      }
-    ]
-  },
-  {
-    id: 'sonixd',
-    name: 'Sonixd',
-    description: 'A full-featured Subsonic/Jellyfin compatible desktop music player.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Desktop],
+    platforms: [Platform.Discord],
     primaryLinks: [
       {
         id: 'install',
         name: 'Installation Guide',
-        url: 'https://github.com/jeffvli/sonixd#install'
+        url: 'https://github.com/manuel-rw/jellyfin-discord-music-bot/wiki/%F0%9F%9A%80-Initial-Discord-Bot-Creation-Guide'
       }
     ],
     secondaryLinks: [
       {
         id: 'github',
         name: 'GitHub',
-        url: 'https://github.com/jeffvli/sonixd'
-      }
-    ]
-  },
-  {
-    id: 'supersonic',
-    name: 'Supersonic',
-    description: 'A lightweight and full-featured desktop music player for self-hosted servers.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Desktop],
-    primaryLinks: [
-      {
-        id: 'installation',
-        name: 'Installation Guide',
-        url: 'https://github.com/dweymouth/supersonic#installation'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/dweymouth/supersonic'
+        url: 'https://github.com/manuel-rw/jellyfin-discord-music-bot'
       }
     ]
   },
@@ -533,37 +436,121 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'tauon-music-box',
-    name: 'Tauon Music Box',
-    description: "A modern streamlined music player for desktop with a minimal interface that's packed with features!",
+    id: 'finamp',
+    name: 'Finamp',
+    description: 'A third party app for music playback with support for offline mode/downloading songs.',
     clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
+    deviceTypes: [DeviceType.Mobile],
     licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Desktop],
+    platforms: [Platform.Android, Platform.IOS],
     primaryLinks: [
       {
-        id: 'flathub',
-        name: 'Flathub (Linux)',
-        url: 'https://flathub.org/apps/details/com.github.taiko2k.tauonmb'
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/packages/com.unicornsonlsd.finamp/'
       },
       {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/Taiko2k/TauonMusicBox#download-and-install-dizzy'
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=com.unicornsonlsd.finamp'
+      },
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/finamp/id1574922594'
       }
     ],
     secondaryLinks: [
       {
         id: 'github',
         name: 'GitHub',
-        url: 'https://github.com/Taiko2k/TauonMusicBox'
-      },
-      {
-        id: 'tauon',
-        name: 'Website',
-        url: 'https://tauonmusicbox.rocks'
+        url: 'https://github.com/UnicornsOnLSD/finamp'
       }
     ]
+  },
+  {
+    id: 'finer',
+    name: 'Finer',
+    description: 'Jellyfin Music Player for macOS/iPadOS/iOS, built with native technologies.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.MacOS, Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/finer-player/id6738301953'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://monk-studio.com/finer'
+      }
+    ]
+  },
+  {
+    id: 'fintunes',
+    name: 'Fintunes',
+    description: 'Mobile audio streaming app for Jellyfin',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Android, Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/en/packages/nl.moeilijkedingen.jellyfinaudioplayer/'
+      },
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=nl.moeilijkedingen.jellyfinaudioplayer'
+      },
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/nl/app/fintunes/id1527732194'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/leinelissen/jellyfin-audio-player'
+      },
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://fintunes.app'
+      }
+    ]
+  },
+  {
+    id: 'fladder',
+    name: 'Fladder',
+    description: 'A simple, cross-platform Jellyfin frontend built on top of Flutter.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Linux, Platform.Windows, Platform.MacOS, Platform.Android, Platform.Browser],
+    primaryLinks: [
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=nl.jknaapen.fladder',
+      },
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/DonutWare/Fladder',
+      },
+    ],
   },
   {
     id: 'findroid',
@@ -624,121 +611,77 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'finamp',
-    name: 'Finamp',
-    description: 'A third party app for music playback with support for offline mode/downloading songs.',
+    id: 'infuse',
+    name: 'Infuse',
+    description: 'A third-party client for iOS, iPadOS, and tvOS devices.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.IOS, Platform.TVOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/app/id1136220934?mt=8'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://firecore.com/infuse'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyamp',
+    name: 'Jellyamp',
+    description: 'A desktop client for listening to music from a Jellyfin server.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Desktop],
+    primaryLinks: [
+      {
+        id: 'gh-downloads',
+        name: 'GitHub Downloads',
+        url: 'https://github.com/m0ngr31/jellyamp/releases'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/m0ngr31/jellyamp'
+      }
+    ]
+  },
+  {
+    id: 'jellybook',
+    name: 'JellyBook',
+    description: 'A cross platform mobile app for book & comic reading for Jellyfin.',
     clientType: ClientType.ThirdParty,
     deviceTypes: [DeviceType.Mobile],
     licenseType: LicenseType.OpenSource,
     platforms: [Platform.Android, Platform.IOS],
     primaryLinks: [
       {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/packages/com.unicornsonlsd.finamp/'
+        id: 'testflight',
+        name: 'TestFlight',
+        url: 'https://testflight.apple.com/join/lEXKY4Dl'
       },
       {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=com.unicornsonlsd.finamp'
-      },
-      {
-        id: 'app-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/us/app/finamp/id1574922594'
+        id: 'gh-downloads',
+        name: 'GitHub Downloads',
+        url: 'https://github.com/Kara-Zor-El/JellyBook/releases'
       }
     ],
     secondaryLinks: [
       {
         id: 'github',
         name: 'GitHub',
-        url: 'https://github.com/UnicornsOnLSD/finamp'
-      }
-    ]
-  },
-  {
-    id: 'sailfin',
-    name: 'Sailfin',
-    description: 'A Sailfish OS client for Jellyfin.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.SailfishOS],
-    primaryLinks: [
-      {
-        id: 'open-repos',
-        name: 'OpenRepos',
-        url: 'https://openrepos.net/content/ahappyhuman/sailfin'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/heartfin/harbour-sailfin'
-      }
-    ]
-  },
-  {
-    id: 'yatse',
-    name: 'Yatse',
-    description: 'A third party remote control for Jellyfin with support for Chromecast playback.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.Proprietary,
-    platforms: [Platform.Android],
-    primaryLinks: [
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=org.leetzone.android.yatsewidgetfree'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'yatse',
-        name: 'Website',
-        url: 'https://yatse.tv/'
-      }
-    ]
-  },
-  {
-    id: 'volumio',
-    name: 'Jellyfin Plugin for Volumio',
-    description: 'A Volumio plugin for playing audio from one or more Jellyfin servers.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [],
-    licenseType: LicenseType.OpenSource,
-    platforms: [],
-    primaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/patrickkfkan/volumio-jellyfin'
-      }
-    ]
-  },
-  {
-    id: 'discord-music-manuel-rw',
-    name: 'Discord Music Bot for Jellyfin by manuel-rw',
-    description:
-      'A fork, based on the original bot by KGT1, that has been refactored and supports the Discord command system',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Discord],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/manuel-rw/jellyfin-discord-music-bot/wiki/%F0%9F%9A%80-Initial-Discord-Bot-Creation-Guide'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/manuel-rw/jellyfin-discord-music-bot'
+        url: 'https://github.com/Kara-Zor-El/JellyBook'
       }
     ]
   },
@@ -782,6 +725,22 @@ export const Clients: Array<Client> = [
     ]
   },
   {
+    id: 'jellyfin-plugin-for-volumio',
+    name: 'Jellyfin Plugin for Volumio',
+    description: 'A Volumio plugin for playing audio from one or more Jellyfin servers.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [],
+    licenseType: LicenseType.OpenSource,
+    platforms: [],
+    primaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/patrickkfkan/volumio-jellyfin'
+      }
+    ]
+  },
+  {
     id: 'jftui',
     name: 'jftui',
     description: 'A terminal client for Jellyfin built as a REPL interface, that uses mpv for multimedia playback.',
@@ -805,96 +764,99 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'web-scrobbler',
-    name: 'Web Scrobbler',
-    description: 'Web Scrobbler helps online music listeners to scrobble their playback history.',
+    id: 'manet',
+    name: 'Manet',
+    description: 'A third-party music client for iOS and macOS',
     clientType: ClientType.ThirdParty,
-    deviceTypes: [],
+    deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.IOS, Platform.MacOS],
+    primaryLinks: [
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/manet-music/id6470928235'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://tilosoftware.io/manet/'
+      }
+    ]
+  },
+  {
+    id: 'preserve',
+    name: 'Preserve',
+    description: 'A music client inspired by players such as foobar2000 or Clementine.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Desktop],
     licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Browser],
+    platforms: [Platform.Browser, Platform.Desktop],
+    primaryLinks: [
+      {
+        id: 'browser',
+        name: 'Open in Browser',
+        url: 'https://preserveplayer.com/'
+      },
+      {
+        id: 'gl-downloads',
+        name: 'GitLab Downloads',
+        url: 'https://gitlab.com/tonyfinn/preserve/-/releases'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'gitlab',
+        name: 'GitLab',
+        url: 'https://gitlab.com/tonyfinn/preserve'
+      }
+    ]
+  },
+  {
+    id: 'sailfin',
+    name: 'Sailfin',
+    description: 'A Sailfish OS client for Jellyfin.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.SailfishOS],
+    primaryLinks: [
+      {
+        id: 'open-repos',
+        name: 'OpenRepos',
+        url: 'https://openrepos.net/content/ahappyhuman/sailfin'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/heartfin/harbour-sailfin'
+      }
+    ]
+  },
+  {
+    id: 'sonixd',
+    name: 'Sonixd',
+    description: 'A full-featured Subsonic/Jellyfin compatible desktop music player.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Desktop],
     primaryLinks: [
       {
         id: 'install',
         name: 'Installation Guide',
-        url: 'https://github.com/web-scrobbler/web-scrobbler#installation'
+        url: 'https://github.com/jeffvli/sonixd#install'
       }
     ],
     secondaryLinks: [
       {
         id: 'github',
         name: 'GitHub',
-        url: 'https://github.com/web-scrobbler/web-scrobbler'
-      },
-      {
-        id: 'website',
-        name: 'Website',
-        url: 'https://web-scrobbler.com'
-      }
-    ]
-  },
-  {
-    id: 'jellybook',
-    name: 'JellyBook',
-    description: 'A cross platform mobile app for book & comic reading for Jellyfin.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android, Platform.IOS],
-    primaryLinks: [
-      {
-        id: 'testflight',
-        name: 'TestFlight',
-        url: 'https://testflight.apple.com/join/lEXKY4Dl'
-      },
-      {
-        id: 'gh-downloads',
-        name: 'GitHub Downloads',
-        url: 'https://github.com/Kara-Zor-El/JellyBook/releases'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/Kara-Zor-El/JellyBook'
-      }
-    ]
-  },
-  {
-    id: 'fintunes',
-    name: 'Fintunes',
-    description: 'Mobile audio streaming app for Jellyfin',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android, Platform.IOS],
-    primaryLinks: [
-      {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/en/packages/nl.moeilijkedingen.jellyfinaudioplayer/'
-      },
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=nl.moeilijkedingen.jellyfinaudioplayer'
-      },
-      {
-        id: 'app-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/nl/app/fintunes/id1527732194'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/leinelissen/jellyfin-audio-player'
-      },
-      {
-        id: 'website',
-        name: 'Website',
-        url: 'https://fintunes.app'
+        url: 'https://github.com/jeffvli/sonixd'
       }
     ]
   },
@@ -932,50 +894,27 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'manet',
-    name: 'Manet',
-    description: 'A third-party music client for iOS and macOS',
+    id: 'supersonic',
+    name: 'Supersonic',
+    description: 'A lightweight and full-featured desktop music player for self-hosted servers.',
     clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
-    licenseType: LicenseType.Proprietary,
-    platforms: [Platform.IOS, Platform.MacOS],
+    deviceTypes: [DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Desktop],
     primaryLinks: [
       {
-        id: 'app-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/us/app/manet-music/id6470928235'
+        id: 'installation',
+        name: 'Installation Guide',
+        url: 'https://github.com/dweymouth/supersonic#installation'
       }
     ],
     secondaryLinks: [
       {
-        id: 'website',
-        name: 'Website',
-        url: 'https://tilosoftware.io/manet/'
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/dweymouth/supersonic'
       }
     ]
-  },
-  {
-    id: "fladder",
-    name: "Fladder",
-    description: "A simple, cross-platform Jellyfin frontend built on top of Flutter.",
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Linux, Platform.Windows, Platform.MacOS, Platform.Android, Platform.Browser],
-    primaryLinks: [
-      {
-        id: "play-store",
-        name: "Play Store",
-        url: "https://play.google.com/store/apps/details?id=nl.jknaapen.fladder",
-      },
-    ],
-    secondaryLinks: [
-      {
-        id: "github",
-        name: "GitHub",
-        url: "https://github.com/DonutWare/Fladder",
-      },
-    ],
   },
   {
     id: 'symfonium',
@@ -1002,25 +941,86 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'finer',
-    name: 'Finer',
-    description: 'Jellyfin Music Player for macOS/iPadOS/iOS, built with native technologies.',
+    id: 'tauon-music-box',
+    name: 'Tauon Music Box',
+    description: "A modern streamlined music player for desktop with a minimal interface that's packed with features!",
     clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.Proprietary,
-    platforms: [Platform.MacOS, Platform.IOS],
+    deviceTypes: [DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Desktop],
     primaryLinks: [
       {
-        id: 'app-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/us/app/finer-player/id6738301953'
+        id: 'flathub',
+        name: 'Flathub (Linux)',
+        url: 'https://flathub.org/apps/details/com.github.taiko2k.tauonmb'
+      },
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: 'https://github.com/Taiko2k/TauonMusicBox#download-and-install-dizzy'
       }
     ],
     secondaryLinks: [
       {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/Taiko2k/TauonMusicBox'
+      },
+      {
+        id: 'tauon',
+        name: 'Website',
+        url: 'https://tauonmusicbox.rocks'
+      }
+    ]
+  },
+  {
+    id: 'web-scrobbler',
+    name: 'Web Scrobbler',
+    description: 'Web Scrobbler helps online music listeners to scrobble their playback history.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Browser],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: 'https://github.com/web-scrobbler/web-scrobbler#installation'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/web-scrobbler/web-scrobbler'
+      },
+      {
         id: 'website',
         name: 'Website',
-        url: 'https://monk-studio.com/finer'
+        url: 'https://web-scrobbler.com'
+      }
+    ]
+  },
+  {
+    id: 'yatse',
+    name: 'Yatse',
+    description: 'A third party remote control for Jellyfin with support for Chromecast playback.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.Android],
+    primaryLinks: [
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=org.leetzone.android.yatsewidgetfree'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'yatse',
+        name: 'Website',
+        url: 'https://yatse.tv/'
       }
     ]
   }

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -383,7 +383,7 @@ export const officialClients: Array<Client> = [
       }
     ]
   }
-]
+];
 
 export const thirdPartyClients: Array<Client> = [
   {

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -318,8 +318,8 @@ export const officialClients: Array<Client> = [
     platforms: [Platform.Browser],
     primaryLinks: [
       {
-        id: 'browser',
-        name: 'Open in Browser',
+        id: 'website',
+        name: 'Website',
         url: 'https://jf-vue.pages.dev/'
       },
       {
@@ -783,8 +783,8 @@ export const thirdPartyClients: Array<Client> = [
     platforms: [Platform.Browser, Platform.Desktop],
     primaryLinks: [
       {
-        id: 'browser',
-        name: 'Open in Browser',
+        id: 'website',
+        name: 'Website',
         url: 'https://preserveplayer.com/'
       },
       {

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -314,6 +314,29 @@ export const Clients: Array<Client> = [
     ]
   },
   {
+    id: 'jellyfin-xbox',
+    name: 'Jellyfin for Xbox',
+    description: 'The official Jellyfin app for Xbox consoles.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Xbox],
+    primaryLinks: [
+      {
+        id: 'microsoft-store',
+        name: 'Microsoft Store',
+        url: 'https://apps.microsoft.com/detail/9P2DRTG62QF8'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-xbox'
+      }
+    ]
+  },
+  {
     id: 'mopidy',
     name: 'Mopidy-Jellyfin',
     description: 'An official plugin for Mopidy that uses Jellyfin as a backend.',
@@ -998,29 +1021,6 @@ export const Clients: Array<Client> = [
         id: 'website',
         name: 'Website',
         url: 'https://monk-studio.com/finer'
-      }
-    ]
-  },
-  {
-    id: 'jellyfin-xbox',
-    name: 'Jellyfin for Xbox',
-    description: 'The official Jellyfin app for Xbox consoles.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Xbox],
-    primaryLinks: [
-      {
-        id: 'microsoft-store',
-        name: 'Microsoft Store',
-        url: 'https://apps.microsoft.com/detail/9P2DRTG62QF8'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-xbox'
       }
     ]
   }

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -435,7 +435,7 @@ export const thirdPartyClients: Array<Client> = [
         id: 'website',
         name: 'Website',
         url: 'https://feishin.vercel.app/'
-      },
+      }
     ]
   },
   {
@@ -545,15 +545,15 @@ export const thirdPartyClients: Array<Client> = [
         id: 'play-store',
         name: 'Play Store',
         url: 'https://play.google.com/store/apps/details?id=nl.jknaapen.fladder',
-      },
+      }
     ],
     secondaryLinks: [
       {
         id: 'github',
         name: 'GitHub',
         url: 'https://github.com/DonutWare/Fladder',
-      },
-    ],
+      }
+    ]
   },
   {
     id: 'findroid',
@@ -930,7 +930,7 @@ export const thirdPartyClients: Array<Client> = [
   {
     id: 'tauon-music-box',
     name: 'Tauon Music Box',
-    description: "A modern streamlined music player for desktop with a minimal interface that's packed with features!",
+    description: "A modern streamlined music player for desktop with a minimal interface that is packed with features!",
     clientType: ClientType.ThirdParty,
     deviceTypes: [DeviceType.Desktop],
     licenseType: LicenseType.OpenSource,

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -39,6 +39,146 @@ export type Client = {
 
 export const Clients: Array<Client> = [
   {
+    id: 'jellycon',
+    name: 'JellyCon',
+    description:
+      'A lightweight Kodi add-on that lets you browse and play media files directly from your Jellyfin server within the Kodi interface.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Kodi],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: 'https://github.com/jellyfin/jellycon#installation'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellycon'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-android',
+    name: 'Jellyfin for Android',
+    description: 'The official Jellyfin app for Android devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Android],
+    primaryLinks: [
+      {
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/en/packages/org.jellyfin.mobile/'
+      },
+      {
+        id: 'amazon-store',
+        name: 'Amazon Appstore',
+        url: 'https://www.amazon.com/gp/aw/d/B081RFTTQ9'
+      },
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.mobile'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-android'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-androidtv',
+    name: 'Jellyfin for Android TV',
+    description: 'The official Jellyfin app for Android TV and Fire TV devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.AndroidTV, Platform.FireOS],
+    primaryLinks: [
+      {
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/en/packages/org.jellyfin.androidtv/'
+      },
+      {
+        id: 'amazon-store',
+        name: 'Amazon Appstore',
+        url: 'https://www.amazon.com/gp/aw/d/B07TX7Z725'
+      },
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.androidtv'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-androidtv'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-kodi',
+    name: 'Jellyfin for Kodi',
+    description: 'A Kodi add-on that syncs metadata from selected Jellyfin libraries into the local Kodi database.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Kodi],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: '/docs/general/clients/kodi'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-kodi'
+      }
+    ]
+  },
+  {
+    id: 'jellyfin-expo',
+    name: 'Jellyfin Mobile for iOS',
+    description: 'The official Jellyfin app for iOS and iPadOS devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/jellyfin-mobile/id1480192618?mt=8'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-expo'
+      }
+    ],
+    recommended: true
+  },
+  {
     id: 'jellyfin-media-player',
     name: 'Jellyfin Media Player',
     description: 'The official Jellyfin desktop client.',
@@ -96,198 +236,6 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'jellyfin-vue',
-    name: 'Jellyfin Vue',
-    description: 'A modern web client for Jellyfin based on Vue',
-    clientType: ClientType.OfficialBeta,
-    deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Browser],
-    primaryLinks: [
-      {
-        id: 'browser',
-        name: 'Open in Browser',
-        url: 'https://jf-vue.pages.dev/'
-      },
-      {
-        id: 'docker-ghcr',
-        name: 'Docker',
-        url: 'https://github.com/jellyfin/jellyfin-vue/pkgs/container/jellyfin-vue'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-vue'
-      }
-    ]
-  },
-  {
-    id: 'jellycon',
-    name: 'JellyCon',
-    description:
-      'A lightweight Kodi add-on that lets you browse and play media files directly from your Jellyfin server within the Kodi interface.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Kodi],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/jellyfin/jellycon#installation'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellycon'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-kodi',
-    name: 'Jellyfin for Kodi',
-    description: 'A Kodi add-on that syncs metadata from selected Jellyfin libraries into the local Kodi database.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Kodi],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: '/docs/general/clients/kodi'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-kodi'
-      }
-    ]
-  },
-  {
-    id: 'jellyfin-android',
-    name: 'Jellyfin for Android',
-    description: 'The official Jellyfin app for Android devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android],
-    primaryLinks: [
-      {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/en/packages/org.jellyfin.mobile/'
-      },
-      {
-        id: 'amazon-store',
-        name: 'Amazon Appstore',
-        url: 'https://www.amazon.com/gp/aw/d/B081RFTTQ9'
-      },
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.mobile'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-android'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-expo',
-    name: 'Jellyfin Mobile for iOS',
-    description: 'The official Jellyfin app for iOS and iPadOS devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.IOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/us/app/jellyfin-mobile/id1480192618?mt=8'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-expo'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'swiftfin',
-    name: 'Swiftfin',
-    description:
-      'Swiftfin is a modern video client for Jellyfin. Redesigned in Swift to maximize direct play with the power of VLC and look native on all classes of Apple devices.',
-    clientType: ClientType.OfficialBeta,
-    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.IOS, Platform.TVOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/swiftfin'
-      }
-    ]
-  },
-  {
-    id: 'jellyfin-androidtv',
-    name: 'Jellyfin for Android TV',
-    description: 'The official Jellyfin app for Android TV and Fire TV devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.AndroidTV, Platform.FireOS],
-    primaryLinks: [
-      {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/en/packages/org.jellyfin.androidtv/'
-      },
-      {
-        id: 'amazon-store',
-        name: 'Amazon Appstore',
-        url: 'https://www.amazon.com/gp/aw/d/B07TX7Z725'
-      },
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.androidtv'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-androidtv'
-      }
-    ],
-    recommended: true
-  },
-  {
     id: 'jellyfin-roku',
     name: 'Jellyfin for Roku',
     description: 'The official Jellyfin app for Roku devices.',
@@ -338,6 +286,34 @@ export const Clients: Array<Client> = [
     recommended: true
   },
   {
+    id: 'jellyfin-vue',
+    name: 'Jellyfin Vue',
+    description: 'A modern web client for Jellyfin based on Vue',
+    clientType: ClientType.OfficialBeta,
+    deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Browser],
+    primaryLinks: [
+      {
+        id: 'browser',
+        name: 'Open in Browser',
+        url: 'https://jf-vue.pages.dev/'
+      },
+      {
+        id: 'docker-ghcr',
+        name: 'Docker',
+        url: 'https://github.com/jellyfin/jellyfin-vue/pkgs/container/jellyfin-vue'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-vue'
+      }
+    ]
+  },
+  {
     id: 'mopidy',
     name: 'Mopidy-Jellyfin',
     description: 'An official plugin for Mopidy that uses Jellyfin as a backend.',
@@ -357,6 +333,30 @@ export const Clients: Array<Client> = [
         id: 'github',
         name: 'GitHub',
         url: 'https://github.com/jellyfin/mopidy-jellyfin'
+      }
+    ]
+  },
+  {
+    id: 'swiftfin',
+    name: 'Swiftfin',
+    description:
+      'Swiftfin is a modern video client for Jellyfin. Redesigned in Swift to maximize direct play with the power of VLC and look native on all classes of Apple devices.',
+    clientType: ClientType.OfficialBeta,
+    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.IOS, Platform.TVOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/swiftfin'
       }
     ]
   },


### PR DESCRIPTION
1. splitting into Official and third Party (separate lists)
2. enforce alphabetical sorting in the list
3. removed non-existant `iPadOS` Platform from `streamyfin`

Proposal for future changes: 
Cleanup of the clients file!
Some of them appear to be unmaintained and/or no longer compatible with the latest Version of Jellyfin.
If that is the case, these clients should be removed. 