### PR TITLE
clean clients.ts

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -410,6 +410,57 @@ export const thirdPartyClients: Array<Client> = [
     ]
   },
   {
+    id: 'preserve',
+    name: 'Preserve',
+    description: 'A music client inspired by players such as foobar2000 or Clementine.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Browser, Platform.Desktop],
+    primaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://preserveplayer.com/'
+      },
+      {
+        id: 'gl-downloads',
+        name: 'GitLab Downloads',
+        url: 'https://gitlab.com/tonyfinn/preserve/-/releases'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'gitlab',
+        name: 'GitLab',
+        url: 'https://gitlab.com/tonyfinn/preserve'
+      }
+    ]
+  },
+  {
+    id: 'sonixd',
+    name: 'Sonixd',
+    description: 'A full-featured Subsonic/Jellyfin compatible desktop music player.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Desktop],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: 'https://github.com/jeffvli/sonixd#install'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jeffvli/sonixd'
+      }
+    ]
+  },
+  {
     id: 'supersonic',
     name: 'Supersonic',
     description: 'A lightweight and full-featured desktop music player for self-hosted servers.',
@@ -753,6 +804,34 @@ export const thirdPartyClients: Array<Client> = [
         id: 'github',
         name: 'GitHub',
         url: 'https://github.com/Aanok/jftui'
+      }
+    ]
+  },
+  {
+    id: 'web-scrobbler',
+    name: 'Web Scrobbler',
+    description: 'Web Scrobbler helps online music listeners to scrobble their playback history.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Browser],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: 'https://github.com/web-scrobbler/web-scrobbler#installation'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/web-scrobbler/web-scrobbler'
+      },
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://webscrobbler.com'
       }
     ]
   },

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -514,7 +514,7 @@ export const thirdPartyClients: Array<Client> = [
   {
     id: 'tauon-music-box',
     name: 'Tauon Music Box',
-    description: "A modern streamlined music player for desktop with a minimal interface that's packed with features!",
+    description: "A modern streamlined music player for desktop with a minimal interface that is packed with features!",
     clientType: ClientType.ThirdParty,
     deviceTypes: [DeviceType.Desktop],
     licenseType: LicenseType.OpenSource,

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -37,7 +37,7 @@ export type Client = {
   recommended?: boolean;
 };
 
-export const officialClients: Array<Client> = [
+const officialClients: Array<Client> = [
   {
     id: 'jellyfin-media-player',
     name: 'Jellyfin Media Player',
@@ -105,8 +105,8 @@ export const officialClients: Array<Client> = [
     platforms: [Platform.Browser],
     primaryLinks: [
       {
-        id: 'website',
-        name: 'Website',
+        id: 'browser',
+        name: 'Open in browser',
         url: 'https://jf-vue.pages.dev/'
       },
       {
@@ -385,7 +385,7 @@ export const officialClients: Array<Client> = [
   }
 ];
 
-export const thirdPartyClients: Array<Client> = [
+const thirdPartyClients: Array<Client> = [
   {
     id: 'jellyamp',
     name: 'Jellyamp',
@@ -419,8 +419,8 @@ export const thirdPartyClients: Array<Client> = [
     platforms: [Platform.Browser, Platform.Desktop],
     primaryLinks: [
       {
-        id: 'website',
-        name: 'Website',
+        id: 'browser',
+        name: 'Open in browser',
         url: 'https://preserveplayer.com/'
       },
       {
@@ -493,8 +493,8 @@ export const thirdPartyClients: Array<Client> = [
     platforms: [Platform.Desktop],
     primaryLinks: [
       {
-        id: 'website',
-        name: 'Website',
+        id: 'browser',
+        name: 'Open in browser',
         url: 'https://feishin.vercel.app/'
       },
       {

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -206,8 +206,8 @@ export const officialClients: Array<Client> = [
     recommended: true
   },
   {
-    id: 'jellyfin-expo',
-    name: 'Jellyfin Mobile for iOS',
+    id: 'jellyfin-ios',
+    name: 'Jellyfin for iOS',
     description: 'The official Jellyfin app for iOS and iPadOS devices.',
     clientType: ClientType.Official,
     deviceTypes: [DeviceType.Mobile],

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -410,34 +410,6 @@ export const thirdPartyClients: Array<Client> = [
     ]
   },
   {
-    id: 'preserve',
-    name: 'Preserve',
-    description: 'A music client inspired by players such as foobar2000 or Clementine.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Browser, Platform.Desktop],
-    primaryLinks: [
-      {
-        id: 'website',
-        name: 'Website',
-        url: 'https://preserveplayer.com/'
-      },
-      {
-        id: 'gl-downloads',
-        name: 'GitLab Downloads',
-        url: 'https://gitlab.com/tonyfinn/preserve/-/releases'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'gitlab',
-        name: 'GitLab',
-        url: 'https://gitlab.com/tonyfinn/preserve'
-      }
-    ]
-  },
-  {
     id: 'supersonic',
     name: 'Supersonic',
     description: 'A lightweight and full-featured desktop music player for self-hosted servers.',

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -105,8 +105,8 @@ export const officialClients: Array<Client> = [
     platforms: [Platform.Browser],
     primaryLinks: [
       {
-        id: 'browser',
-        name: 'Open in Browser',
+        id: 'website',
+        name: 'Website',
         url: 'https://jf-vue.pages.dev/'
       },
       {
@@ -419,8 +419,8 @@ export const thirdPartyClients: Array<Client> = [
     platforms: [Platform.Browser, Platform.Desktop],
     primaryLinks: [
       {
-        id: 'browser',
-        name: 'Open in Browser',
+        id: 'website',
+        name: 'Website',
         url: 'https://preserveplayer.com/'
       },
       {
@@ -493,8 +493,8 @@ export const thirdPartyClients: Array<Client> = [
     platforms: [Platform.Desktop],
     primaryLinks: [
       {
-        id: 'browser',
-        name: 'Open in Browser',
+        id: 'website',
+        name: 'Website',
         url: 'https://feishin.vercel.app/'
       },
       {
@@ -538,7 +538,7 @@ export const thirdPartyClients: Array<Client> = [
         url: 'https://github.com/Taiko2k/TauonMusicBox'
       },
       {
-        id: 'tauon',
+        id: 'website',
         name: 'Website',
         url: 'https://tauonmusicbox.rocks'
       }
@@ -675,7 +675,7 @@ export const thirdPartyClients: Array<Client> = [
     ],
     secondaryLinks: [
       {
-        id: 'yatse',
+        id: 'website',
         name: 'Website',
         url: 'https://yatse.tv/'
       }

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -831,7 +831,7 @@ export const thirdPartyClients: Array<Client> = [
       {
         id: 'website',
         name: 'Website',
-        url: 'https://web-scrobbler.com'
+        url: 'https://webscrobbler.com'
       }
     ]
   },

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -438,29 +438,6 @@ export const thirdPartyClients: Array<Client> = [
     ]
   },
   {
-    id: 'sonixd',
-    name: 'Sonixd',
-    description: 'A full-featured Subsonic/Jellyfin compatible desktop music player.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Desktop],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/jeffvli/sonixd#install'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jeffvli/sonixd'
-      }
-    ]
-  },
-  {
     id: 'supersonic',
     name: 'Supersonic',
     description: 'A lightweight and full-featured desktop music player for self-hosted servers.',

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -908,7 +908,7 @@ export const thirdPartyClients: Array<Client> = [
     clientType: ClientType.ThirdParty,
     deviceTypes: [DeviceType.Mobile],
     licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android, Platform.IOS, Platform.iPadOS],
+    platforms: [Platform.Android, Platform.IOS],
     primaryLinks: [
       {
         id: 'app-store',

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -37,7 +37,7 @@ export type Client = {
   recommended?: boolean;
 };
 
-export const Clients: Array<Client> = [
+export const officialClients: Array<Client> = [
   {
     id: 'jellyfin-media-player',
     name: 'Jellyfin Media Player',
@@ -96,29 +96,6 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'jellyamp',
-    name: 'Jellyamp',
-    description: 'A desktop client for listening to music from a Jellyfin server.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Desktop],
-    primaryLinks: [
-      {
-        id: 'gh-downloads',
-        name: 'GitHub Downloads',
-        url: 'https://github.com/m0ngr31/jellyamp/releases'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/m0ngr31/jellyamp'
-      }
-    ]
-  },
-  {
     id: 'jellyfin-vue',
     name: 'Jellyfin Vue',
     description: 'A modern web client for Jellyfin based on Vue',
@@ -143,6 +120,292 @@ export const Clients: Array<Client> = [
         id: 'github',
         name: 'GitHub',
         url: 'https://github.com/jellyfin/jellyfin-vue'
+      }
+    ]
+  },
+  {
+    id: 'jellycon',
+    name: 'JellyCon',
+    description:
+      'A lightweight Kodi add-on that lets you browse and play media files directly from your Jellyfin server within the Kodi interface.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Kodi],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: 'https://github.com/jellyfin/jellycon#installation'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellycon'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-kodi',
+    name: 'Jellyfin for Kodi',
+    description: 'A Kodi add-on that syncs metadata from selected Jellyfin libraries into the local Kodi database.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Kodi],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: '/docs/general/clients/kodi'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-kodi'
+      }
+    ]
+  },
+  {
+    id: 'jellyfin-android',
+    name: 'Jellyfin for Android',
+    description: 'The official Jellyfin app for Android devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Android],
+    primaryLinks: [
+      {
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/en/packages/org.jellyfin.mobile/'
+      },
+      {
+        id: 'amazon-store',
+        name: 'Amazon Appstore',
+        url: 'https://www.amazon.com/gp/aw/d/B081RFTTQ9'
+      },
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.mobile'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-android'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-expo',
+    name: 'Jellyfin Mobile for iOS',
+    description: 'The official Jellyfin app for iOS and iPadOS devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/jellyfin-mobile/id1480192618?mt=8'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-expo'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'swiftfin',
+    name: 'Swiftfin',
+    description:
+      'Swiftfin is a modern video client for Jellyfin. Redesigned in Swift to maximize direct play with the power of VLC and look native on all classes of Apple devices.',
+    clientType: ClientType.OfficialBeta,
+    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.IOS, Platform.TVOS],
+    primaryLinks: [
+      {
+        id: 'apple-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/swiftfin'
+      }
+    ]
+  },
+  {
+    id: 'jellyfin-androidtv',
+    name: 'Jellyfin for Android TV',
+    description: 'The official Jellyfin app for Android TV and Fire TV devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.AndroidTV, Platform.FireOS],
+    primaryLinks: [
+      {
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/en/packages/org.jellyfin.androidtv/'
+      },
+      {
+        id: 'amazon-store',
+        name: 'Amazon Appstore',
+        url: 'https://www.amazon.com/gp/aw/d/B07TX7Z725'
+      },
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.androidtv'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-androidtv'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-roku',
+    name: 'Jellyfin for Roku',
+    description: 'The official Jellyfin app for Roku devices.',
+    smallDescription:
+      'Due to a technical limitation of the Roku store, the Jellyfin app for Roku may state that a cable or satellite subscription is required. However, no subscription of any form is required to use the Jellyfin server or any official client.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Roku],
+    primaryLinks: [
+      {
+        id: 'roku-store',
+        name: 'Channel Store',
+        url: 'https://channelstore.roku.com/details/592369/jellyfin'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-roku'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'jellyfin-webos',
+    name: 'Jellyfin for WebOS',
+    description: 'The official Jellyfin app for WebOS devices.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.WebOS],
+    primaryLinks: [
+      {
+        id: 'lg-store',
+        name: 'Content Store',
+        url: 'https://us.lgappstv.com/main/tvapp/detail?appId=1030579'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-webos'
+      }
+    ],
+    recommended: true
+  },
+  {
+    id: 'mopidy',
+    name: 'Mopidy-Jellyfin',
+    description: 'An official plugin for Mopidy that uses Jellyfin as a backend.',
+    clientType: ClientType.Official,
+    deviceTypes: [],
+    licenseType: LicenseType.OpenSource,
+    platforms: [],
+    primaryLinks: [
+      {
+        id: 'install',
+        name: 'Installation Guide',
+        url: '/docs/general/clients/mopidy'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/mopidy-jellyfin'
+      }
+    ]
+  },
+  {
+    id: 'jellyfin-xbox',
+    name: 'Jellyfin for Xbox',
+    description: 'The official Jellyfin app for Xbox consoles.',
+    clientType: ClientType.Official,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Xbox],
+    primaryLinks: [
+      {
+        id: 'microsoft-store',
+        name: 'Microsoft Store',
+        url: 'https://apps.microsoft.com/detail/9P2DRTG62QF8'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jellyfin/jellyfin-xbox'
+      }
+    ]
+  }
+];
+
+export const thirdPartyClients: Array<Client> = [
+  {
+    id: 'jellyamp',
+    name: 'Jellyamp',
+    description: 'A desktop client for listening to music from a Jellyfin server.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Desktop],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Desktop],
+    primaryLinks: [
+      {
+        id: 'gh-downloads',
+        name: 'GitHub Downloads',
+        url: 'https://github.com/m0ngr31/jellyamp/releases'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/m0ngr31/jellyamp'
       }
     ]
   },
@@ -278,136 +541,6 @@ export const Clients: Array<Client> = [
         id: 'tauon',
         name: 'Website',
         url: 'https://tauonmusicbox.rocks'
-      }
-    ]
-  },
-  {
-    id: 'jellycon',
-    name: 'JellyCon',
-    description:
-      'A lightweight Kodi add-on that lets you browse and play media files directly from your Jellyfin server within the Kodi interface.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Kodi],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/jellyfin/jellycon#installation'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellycon'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-kodi',
-    name: 'Jellyfin for Kodi',
-    description: 'A Kodi add-on that syncs metadata from selected Jellyfin libraries into the local Kodi database.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Kodi],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: '/docs/general/clients/kodi'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-kodi'
-      }
-    ]
-  },
-  {
-    id: 'jellyfin-android',
-    name: 'Jellyfin for Android',
-    description: 'The official Jellyfin app for Android devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android],
-    primaryLinks: [
-      {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/en/packages/org.jellyfin.mobile/'
-      },
-      {
-        id: 'amazon-store',
-        name: 'Amazon Appstore',
-        url: 'https://www.amazon.com/gp/aw/d/B081RFTTQ9'
-      },
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.mobile'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-android'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-expo',
-    name: 'Jellyfin Mobile for iOS',
-    description: 'The official Jellyfin app for iOS and iPadOS devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.IOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/us/app/jellyfin-mobile/id1480192618?mt=8'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-expo'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'swiftfin',
-    name: 'Swiftfin',
-    description:
-      'Swiftfin is a modern video client for Jellyfin. Redesigned in Swift to maximize direct play with the power of VLC and look native on all classes of Apple devices.',
-    clientType: ClientType.OfficialBeta,
-    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.IOS, Platform.TVOS],
-    primaryLinks: [
-      {
-        id: 'apple-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/ca/app/swiftfin/id1604098728'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/swiftfin'
       }
     ]
   },
@@ -549,90 +682,6 @@ export const Clients: Array<Client> = [
     ]
   },
   {
-    id: 'jellyfin-androidtv',
-    name: 'Jellyfin for Android TV',
-    description: 'The official Jellyfin app for Android TV and Fire TV devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.AndroidTV, Platform.FireOS],
-    primaryLinks: [
-      {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/en/packages/org.jellyfin.androidtv/'
-      },
-      {
-        id: 'amazon-store',
-        name: 'Amazon Appstore',
-        url: 'https://www.amazon.com/gp/aw/d/B07TX7Z725'
-      },
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=org.jellyfin.androidtv'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-androidtv'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-roku',
-    name: 'Jellyfin for Roku',
-    description: 'The official Jellyfin app for Roku devices.',
-    smallDescription:
-      'Due to a technical limitation of the Roku store, the Jellyfin app for Roku may state that a cable or satellite subscription is required. However, no subscription of any form is required to use the Jellyfin server or any official client.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Roku],
-    primaryLinks: [
-      {
-        id: 'roku-store',
-        name: 'Channel Store',
-        url: 'https://channelstore.roku.com/details/592369/jellyfin'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-roku'
-      }
-    ],
-    recommended: true
-  },
-  {
-    id: 'jellyfin-webos',
-    name: 'Jellyfin for WebOS',
-    description: 'The official Jellyfin app for WebOS devices.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.WebOS],
-    primaryLinks: [
-      {
-        id: 'lg-store',
-        name: 'Content Store',
-        url: 'https://us.lgappstv.com/main/tvapp/detail?appId=1030579'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-webos'
-      }
-    ],
-    recommended: true
-  },
-  {
     id: 'infuse',
     name: 'Infuse',
     description: 'A third-party client for iOS, iPadOS, and tvOS devices.',
@@ -655,29 +704,6 @@ export const Clients: Array<Client> = [
       }
     ],
     recommended: true
-  },
-  {
-    id: 'mopidy',
-    name: 'Mopidy-Jellyfin',
-    description: 'An official plugin for Mopidy that uses Jellyfin as a backend.',
-    clientType: ClientType.Official,
-    deviceTypes: [],
-    licenseType: LicenseType.OpenSource,
-    platforms: [],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: '/docs/general/clients/mopidy'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/mopidy-jellyfin'
-      }
-    ]
   },
   {
     id: 'volumio',
@@ -1000,28 +1026,10 @@ export const Clients: Array<Client> = [
         url: 'https://monk-studio.com/finer'
       }
     ]
-  },
-  {
-    id: 'jellyfin-xbox',
-    name: 'Jellyfin for Xbox',
-    description: 'The official Jellyfin app for Xbox consoles.',
-    clientType: ClientType.Official,
-    deviceTypes: [DeviceType.TV],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Xbox],
-    primaryLinks: [
-      {
-        id: 'microsoft-store',
-        name: 'Microsoft Store',
-        url: 'https://apps.microsoft.com/detail/9P2DRTG62QF8'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-xbox'
-      }
-    ]
   }
+];
+
+export const Clients: Array<Client> = [
+  ...officialClients,
+  ...thirdPartyClients
 ];

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -808,34 +808,6 @@ export const thirdPartyClients: Array<Client> = [
     ]
   },
   {
-    id: 'web-scrobbler',
-    name: 'Web Scrobbler',
-    description: 'Web Scrobbler helps online music listeners to scrobble their playback history.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Browser],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/web-scrobbler/web-scrobbler#installation'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/web-scrobbler/web-scrobbler'
-      },
-      {
-        id: 'website',
-        name: 'Website',
-        url: 'https://webscrobbler.com'
-      }
-    ]
-  },
-  {
     id: 'jellybook',
     name: 'JellyBook',
     description: 'A cross platform mobile app for book & comic reading for Jellyfin.',


### PR DESCRIPTION
This PR contains multiple changes regarding the Clients list on the Downloads page.
1. Ordering official clients first
2. Splitting official and unofficial clients into separate lists. 
3. fixing some website-id's not being called "website"
4. minor fixes, see commits

Removal of Clients has been reverted.