### PR TITLE
Make server downloads single page

### DIFF
--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -13,11 +13,11 @@ export enum Feature {
 }
 
 export enum OsType {
-  Docker,
-  Linux,
-  MacOS,
-  Windows,
-  DotNet,
+  Docker = "Docker",
+  Linux = "Linux",
+  MacOS = "MacOS",
+  Windows = "Windows",
+  DotNet = "DotNet",
 }
 
 export type Button = {

--- a/src/pages/downloads/docker.tsx
+++ b/src/pages/downloads/docker.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-import DownloadsPage from './server';
-import { OsType } from '../../data/downloads';
-
-export default function DockerDownloads() {
-  return <DownloadsPage osType={OsType.Docker} />;
-}

--- a/src/pages/downloads/dotnet.tsx
+++ b/src/pages/downloads/dotnet.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-import DownloadsPage from './server';
-import { OsType } from '../../data/downloads';
-
-export default function DotNetDownloads() {
-  return <DownloadsPage osType={OsType.DotNet} />;
-}

--- a/src/pages/downloads/linux.tsx
+++ b/src/pages/downloads/linux.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-import DownloadsPage from './server';
-
-export default function LinuxDownloads() {
-  return <DownloadsPage />;
-}

--- a/src/pages/downloads/macos.tsx
+++ b/src/pages/downloads/macos.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-import DownloadsPage from './server';
-import { OsType } from '../../data/downloads';
-
-export default function MacOSDownloads() {
-  return <DownloadsPage osType={OsType.MacOS} />;
-}

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -1,3 +1,4 @@
+import { useHistory,useLocation } from '@docusaurus/router';
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
 import React, { useState } from 'react';
@@ -10,10 +11,37 @@ import { Downloads, OsType } from '../../data/downloads';
 
 import styles from './index.module.scss';
 
-export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsType }) {
+export default function DownloadsPage() {
+  const history = useHistory();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
   const [isStableLinks, setIsStableLinks] = useState<boolean>(true);
   const [isStableHelpVisible, setIsStableHelpVisible] = useState<boolean>(false);
   const [activeButton, setActiveButton] = useState<string>();
+
+
+  const [osType, _setOsType] = useState<OsType>(searchParams.get('type') as OsType ?? OsType.Linux )
+
+const setOsType = (osType: OsType | undefined) => {
+    const search = new URLSearchParams();
+
+    if (osType) {
+      search.set('type', osType);
+    }
+    history.push({
+      search: search.toString()
+    });
+
+    _setOsType(osType);
+  };
+
+const items = Downloads.filter(
+  (download) =>
+    // OS Type matches filter
+    download.osTypes.includes(osType) &&
+    // Ensure there are unstable links if unstable is selected
+    (isStableLinks || download.unstableButtons.length > 0)
+)
 
   return (
     <Layout title='Downloads'>
@@ -38,36 +66,36 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
 
             <div className={clsx('col', 'margin-bottom--md', styles['header-pills-middle'])}>
               <div className='pills' style={{ overflowX: 'auto' }}>
-                <Link
-                  to='/downloads/linux'
-                  className={clsx('pills__item', { 'pills__item--active': osType === OsType.Linux })}
+                <Pill
+                  active={osType === OsType.Linux}
+                  onClick={() => setOsType(OsType.Linux )}
                 >
                   Linux
-                </Link>
-                <Link
-                  to='/downloads/docker'
-                  className={clsx('pills__item', { 'pills__item--active': osType === OsType.Docker })}
+                </Pill>
+                <Pill
+                  active={osType === OsType.Docker}
+                  onClick={() => setOsType(OsType.Docker )}
                 >
                   Docker
-                </Link>
-                <Link
-                  to='/downloads/windows'
-                  className={clsx('pills__item', { 'pills__item--active': osType === OsType.Windows })}
+                </Pill>
+                <Pill
+                  active={osType === OsType.Windows}
+                  onClick={() => setOsType(OsType.Windows )}
                 >
                   Windows
-                </Link>
-                <Link
-                  to='/downloads/macos'
-                  className={clsx('pills__item', { 'pills__item--active': osType === OsType.MacOS })}
+                </Pill>
+                <Pill
+                  active={osType === OsType.MacOS}
+                  onClick={() => setOsType(OsType.MacOS )}
                 >
                   macOS
-                </Link>
-                <Link
-                  to='/downloads/dotnet'
-                  className={clsx('pills__item', { 'pills__item--active': osType === OsType.DotNet })}
+                </Pill>
+                <Pill
+                  active={osType === OsType.DotNet}
+                  onClick={() => setOsType(OsType.DotNet )}
                 >
                   .NET
-                </Link>
+                </Pill>
               </div>
             </div>
 
@@ -127,13 +155,7 @@ export default function DownloadsPage({ osType = OsType.Linux }: { osType?: OsTy
             </Admonition>
           )}
 
-          {Downloads.filter(
-            (download) =>
-              // OS Type matches filter
-              download.osTypes.includes(osType) &&
-              // Ensure there are unstable links if unstable is selected
-              (isStableLinks || download.unstableButtons.length > 0)
-          ).map((download) => (
+          {items.map((download) => (
             <DownloadDetails
               key={download.id}
               download={download}

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -1,4 +1,4 @@
-import { useHistory,useLocation } from '@docusaurus/router';
+import { useHistory, useLocation } from '@docusaurus/router';
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
 import React, { useState } from 'react';
@@ -19,10 +19,9 @@ export default function DownloadsPage() {
   const [isStableHelpVisible, setIsStableHelpVisible] = useState<boolean>(false);
   const [activeButton, setActiveButton] = useState<string>();
 
+  const [osType, _setOsType] = useState<OsType>((searchParams.get('os') as OsType) ?? OsType.Linux);
 
-  const [osType, _setOsType] = useState<OsType>(searchParams.get('os') as OsType ?? OsType.Linux )
-
-const setOsType = (osType: OsType | undefined) => {
+  const setOsType = (osType: OsType | undefined) => {
     const search = new URLSearchParams();
 
     if (osType) {
@@ -34,14 +33,6 @@ const setOsType = (osType: OsType | undefined) => {
 
     _setOsType(osType);
   };
-
-const items = Downloads.filter(
-  (download) =>
-    // OS Type matches filter
-    download.osTypes.includes(osType) &&
-    // Ensure there are unstable links if unstable is selected
-    (isStableLinks || download.unstableButtons.length > 0)
-)
 
   return (
     <Layout title='Downloads'>
@@ -66,34 +57,19 @@ const items = Downloads.filter(
 
             <div className={clsx('col', 'margin-bottom--md', styles['header-pills-middle'])}>
               <div className='pills' style={{ overflowX: 'auto' }}>
-                <Pill
-                  active={osType === OsType.Linux}
-                  onClick={() => setOsType(OsType.Linux )}
-                >
+                <Pill active={osType === OsType.Linux} onClick={() => setOsType(OsType.Linux)}>
                   Linux
                 </Pill>
-                <Pill
-                  active={osType === OsType.Docker}
-                  onClick={() => setOsType(OsType.Docker )}
-                >
+                <Pill active={osType === OsType.Docker} onClick={() => setOsType(OsType.Docker)}>
                   Docker
                 </Pill>
-                <Pill
-                  active={osType === OsType.Windows}
-                  onClick={() => setOsType(OsType.Windows )}
-                >
+                <Pill active={osType === OsType.Windows} onClick={() => setOsType(OsType.Windows)}>
                   Windows
                 </Pill>
-                <Pill
-                  active={osType === OsType.MacOS}
-                  onClick={() => setOsType(OsType.MacOS )}
-                >
+                <Pill active={osType === OsType.MacOS} onClick={() => setOsType(OsType.MacOS)}>
                   macOS
                 </Pill>
-                <Pill
-                  active={osType === OsType.DotNet}
-                  onClick={() => setOsType(OsType.DotNet )}
-                >
+                <Pill active={osType === OsType.DotNet} onClick={() => setOsType(OsType.DotNet)}>
                   .NET
                 </Pill>
               </div>
@@ -144,18 +120,23 @@ const items = Downloads.filter(
           {isStableHelpVisible && (
             <Admonition type='tip' title='Stable or Unstable?'>
               <p>
-                Generally, if you&apos;re a new user or don&apos;t want your server to change often, use the Stable version.
-                If you want to help test the latest improvements and features and can handle some occasional breakage,
-                use the Unstable version. New Unstable releases are published Weekly on Monday mornings (~05:00 UTC).
-                NOTE: Always back up your existing configuration before testing Unstable releases as there is NO
-                DOWNGRADE PATH; you must restore your Stable configuration from a backup.
-
-                For more details, [please see this documentation](/docs/general/testing/upgrading-and-downgrading).
+                Generally, if you&apos;re a new user or don&apos;t want your server to change often, use the Stable
+                version. If you want to help test the latest improvements and features and can handle some occasional
+                breakage, use the Unstable version. New Unstable releases are published Weekly on Monday mornings
+                (~05:00 UTC). NOTE: Always back up your existing configuration before testing Unstable releases as there
+                is NO DOWNGRADE PATH; you must restore your Stable configuration from a backup. For more details,
+                [please see this documentation](/docs/general/testing/upgrading-and-downgrading).
               </p>
             </Admonition>
           )}
 
-          {items.map((download) => (
+          {Downloads.filter(
+            (download) =>
+              // OS Type matches filter
+              download.osTypes.includes(osType) &&
+              // Ensure there are unstable links if unstable is selected
+              (isStableLinks || download.unstableButtons.length > 0)
+          ).map((download) => (
             <DownloadDetails
               key={download.id}
               download={download}

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -20,13 +20,13 @@ export default function DownloadsPage() {
   const [activeButton, setActiveButton] = useState<string>();
 
 
-  const [osType, _setOsType] = useState<OsType>(searchParams.get('type') as OsType ?? OsType.Linux )
+  const [osType, _setOsType] = useState<OsType>(searchParams.get('os') as OsType ?? OsType.Linux )
 
 const setOsType = (osType: OsType | undefined) => {
     const search = new URLSearchParams();
 
     if (osType) {
-      search.set('type', osType);
+      search.set('os', osType);
     }
     history.push({
       search: search.toString()

--- a/src/pages/downloads/windows.tsx
+++ b/src/pages/downloads/windows.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-import DownloadsPage from './server';
-import { OsType } from '../../data/downloads';
-
-export default function WindowsDownloads() {
-  return <DownloadsPage osType={OsType.Windows} />;
-}


### PR DESCRIPTION
This PR makes the server downloads a single page.
It uses an `os` search param to switch to and store the selected os, like the client downloads page does.