### PR TITLE
Fix misrouted link

### DIFF
--- a/docs/general/post-install/networking/9_advanced/monitoring.md
+++ b/docs/general/post-install/networking/9_advanced/monitoring.md
@@ -30,4 +30,4 @@ Jellyfin can make [Prometheus](https://prometheus.io/) metrics available at `/me
 <EnableMetrics>false</EnableMetrics>
 ```
 
-If you have a [reverse proxy](../../reverse-proxy/) configured, you can configure it to block access to the `/metrics` endpoint except for your internal network.
+If you have a [reverse proxy](/general/post-install/networking/reverse-proxy/) configured, you can configure it to block access to the `/metrics` endpoint except for your internal network.


### PR DESCRIPTION
The current reverse-proxy link on the monitoring page does not work. This fixes it.