### PR TITLE
Update Intel BMG ReBAR requirement tips to the correct section

### DIFF
--- a/docs/general/post-install/transcoding/hardware-acceleration/intel.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/intel.md
@@ -121,12 +121,6 @@ Note that Jasper Lake and Elkhart Lake processors are 10th Gen Pentium/Celeron/A
 
 :::
 
-:::warning
-
-Intel ARC B series cards require ReBar to be enabled.
-
-:::
-
 ### Transcode Other Codecs
 
 Please refer to these links:
@@ -197,7 +191,7 @@ You only need to follow the [Windows Setups](./intel.md#windows-setups) and [Lin
 
 :::tip
 
-- [Resizable-BAR](https://game.intel.com/story/intel-arc-graphics-resizable-bar/) is not mandatory for hardware acceleration, but it can affect the graphics performance. It's recommended to enable the Resizable-BAR if the processor, motherboard and BIOS support it.
+- [Resizable-BAR](https://game.intel.com/story/intel-arc-graphics-resizable-bar/) is only mandatory for hardware acceleration on ARC **B-series** cards, or the media driver will crash the transcoder. For ARC **A-series** cards, the media driver can tolerate not having it enabled but it's also recommended to enable Resizable-BAR if the processor, motherboard and BIOS support it, to achieve the best performance.
 
 - [ASPM](https://www.intel.com/content/www/us/en/support/articles/000092564/graphics.html) should be enabled in the BIOS if supported. This greatly reduces the idle power consumption of the ARC GPU.
 

--- a/docs/general/post-install/transcoding/hardware-acceleration/intel.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/intel.md
@@ -191,7 +191,7 @@ You only need to follow the [Windows Setups](./intel.md#windows-setups) and [Lin
 
 :::tip
 
-- [Resizable-BAR](https://game.intel.com/story/intel-arc-graphics-resizable-bar/) is only mandatory for hardware acceleration on ARC **B-series** cards, or the media driver will crash the transcoder. For ARC **A-series** cards, the media driver can tolerate not having it enabled but it's also recommended to enable Resizable-BAR if the processor, motherboard and BIOS support it, to achieve the best performance.
+- [Resizable-BAR](https://www.intel.com/content/www/us/en/support/articles/000090831/graphics.html) is only mandatory for hardware acceleration on ARC **B-series** cards, or the media driver will crash the transcoder. For ARC **A-series** cards, the media driver can tolerate not having it enabled but it's also recommended to enable Resizable-BAR if the processor, motherboard and BIOS support it, to achieve the best performance.
 
 - [ASPM](https://www.intel.com/content/www/us/en/support/articles/000092564/graphics.html) should be enabled in the BIOS if supported. This greatly reduces the idle power consumption of the ARC GPU.
 

--- a/docs/general/post-install/transcoding/hardware-acceleration/known-issues.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/known-issues.md
@@ -86,6 +86,8 @@ This page lists all known issues and limitations of hardware acceleration with J
 
 13. Intel Compute-Runtime versions starting at 25.18.33578.6 are broken for certain GPUs. The issue has been verified on Arc A series GPUs. If you are using one of the effected models it will be necessary to install the latest known working version of 25.13.33276.16 until the [issue](https://github.com/intel/compute-runtime/issues/831) is fixed. This can effect containers as well, if you are not using the [official image](https://hub.docker.com/r/jellyfin/jellyfin), check your version in container as well.
 
+14. Resizable-BAR is mandatory for hardware acceleration on BMG / ARC B-series cards, or the [media driver will crash the transcoder](https://github.com/intel/media-driver/issues/1893).
+
 ## Nvidia
 
 1. Consumer targeted [Geforce and some entry-level Quadro](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new) cards have an artificial limit on the number of concurrent NVENC encoding sessions. This restriction can be circumvented by applying an [unofficial patch](https://github.com/keylase/nvidia-patch) to the NVIDIA Linux and Windows driver.


### PR DESCRIPTION
Update Intel BMG ReBAR requirement tips to the correct section. It was under the "Transcode AV1" section.