### PR TITLE
Remove 'idmbid' field from metadata documentation

### DIFF
--- a/docs/general/server/metadata/nfo.md
+++ b/docs/general/server/metadata/nfo.md
@@ -126,7 +126,6 @@ Jellyfin can write metadata to .nfo files. To enable this option, select the "Nf
 | imdb_id                   | only for TV shows                                                                                                             |
 | imdbid                    | for all other media types                                                                                                     |
 | tvdbid                    |                                                                                                                               |
-| idmbid                    |                                                                                                                               |
 | tmdbid                    |                                                                                                                               |
 | language                  |                                                                                                                               |
 | countrycode               |                                                                                                                               |


### PR DESCRIPTION
No reference on https://kodi.wiki/view/NFO_files/Movies
No reference on jellyfin server code

Looks like is a 'imdbid' but for some reason get in.