### PR TITLE
Add troubleshooting note to the HWA On Rockchip guide

### DIFF
--- a/docs/general/post-install/transcoding/hardware-acceleration/rockchip.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/rockchip.md
@@ -213,6 +213,12 @@ Root permission is required.
     jellyfin/jellyfin
    ```
 
+:::note
+
+Make sure you have read access to the devices inside the container.
+
+:::
+
 2. Check the OpenCL runtime status, make sure you have installed the GPU firmware of the libmali.
 
    :::note

--- a/docs/general/post-install/transcoding/hardware-acceleration/rockchip.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/rockchip.md
@@ -213,11 +213,11 @@ Root permission is required.
     jellyfin/jellyfin
    ```
 
-:::note
+   :::note
 
-Make sure you have read access to the devices inside the container.
+   Make sure you have read access to the devices inside the container.
 
-:::
+   :::
 
 2. Check the OpenCL runtime status, make sure you have installed the GPU firmware of the libmali.
 


### PR DESCRIPTION
# Context
I was having trouble making HW acceleration to work inside the Docker container on my RK3588.

FFMpeg error:
```
[hevc_rkmpp @ 0xaaaad6fe7d90] Failed to init MPP context: -1
[vist#0:0/hevc @ 0xaaaad6fc0190] [dec:hevc_rkmpp @ 0xaaaad6fe0ee0] Error while opening decoder: Generic error in an external library
```

I'm not running the container with `sudo` / the root user, but a user that belongs to the `docker` group. Also I'm setting the `user` UID / GID. Maybe these were the source of my problem.

In the host:
```shell
# > ls -l /dev | grep -E "mpp|rga|dri|dma_heap"
drwxrwxrwx  2 root root          80 Jan  1  1970 dma_heap
drwxr-xr-x  3 root root         140 Aug 25 13:51 dri
crw-rw----  1 root video   241,   0 Aug 26 13:20 mpp_service
crw-rw----  1 root video    10, 123 Aug 26 13:20 rga
```

```shell
# > id
uid=1000(redacted) gid=1000(redacted) groups=1000(redacted),44(video),988(docker),992(render)
```

In the container I had no read access to some of the devices
```shell
# > test -r /dev/rga $$ "Yes" || "No"
No
```

In my case, to fix the problem I used `group_add` with the IDs of both `video` and `render` groups (though I suspect `render` is not needed). 

<details><summary>This is how (part of) my docker compose file looks now</summary>
<p>

```yaml
services:
  jellyfin:
    user: 1000:1000
    group_add:
      - 44 # video
      - 992 # render
    devices:
      - '/dev/dri:/dev/dri'
      - '/dev/dma_heap:/dev/dma_heap'
      - '/dev/mali0:/dev/mali0'
      - '/dev/rga:/dev/rga'
      - '/dev/mpp_service:/dev/mpp_service'
    security_opt:
      - systempaths=unconfined
      - apparmor=unconfined
```

</p>
</details>

# Proposal

Add some troubleshooting guidance about testing read permissions inside the container.