### PR TITLE
Docs: Update web-config.md and fix web config volume

### DIFF
--- a/docs/general/clients/web-config.md
+++ b/docs/general/clients/web-config.md
@@ -20,7 +20,7 @@ The configuration can be found at `/usr/share/jellyfin/web/config.json`. This fi
 Overriding the default `config.json` can be done with an additional volume parameter to your `docker run` command, e.g.
 
 ```sh
---volume /path/to/config/web-config.json:/jellyfin/jellyfin-web/config.json
+--volume /path/to/config/web-config.json:/usr/share/jellyfin/web/config.json
 ```
 
 :::caution


### PR DESCRIPTION
This PR fix the docker volume example for web config file.

`--volume /path/to/config/web-config.json:/jellyfin/jellyfin-web/config.json` did not work for me, but i use the linuxserver image.
I'm not sure if that was the problem.