### PR TITLE
docs: remove legacy caution warning

### DIFF
--- a/docs/general/server/media/excluding-directory.md
+++ b/docs/general/server/media/excluding-directory.md
@@ -29,9 +29,3 @@ Shows
         ├── .ignore
         └── ...
 ```
-
-:::caution
-
-Currently, placing a `.ignore` file inside an [`Extras`](/docs/general/server/media/shows#extras-folders) directory [does not work](https://github.com/jellyfin/jellyfin/issues/9571).
-
-:::


### PR DESCRIPTION
The linked issue in the caution says it was fixed by https://github.com/jellyfin/jellyfin/pull/13906 and so it is no longer true presumably