### PR TITLE
Remove streamyfin from clients

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -903,39 +903,6 @@ const thirdPartyClients: Array<Client> = [
     ]
   },
   {
-    id: 'streamyfin',
-    name: 'Streamyfin',
-    description: 'A third-party client for iOS, iPadOS and Android with download capability',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android, Platform.IOS],
-    primaryLinks: [
-      {
-        id: 'app-store',
-        name: 'App Store',
-        url: 'https://apps.apple.com/app/streamyfin/id6593660679'
-      },
-      {
-        id: 'play-store',
-        name: 'Play Store',
-        url: 'https://play.google.com/store/apps/details?id=com.fredrikburmester.streamyfin'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/fredrikburmester/streamyfin'
-      },
-      {
-        id: 'website',
-        name: 'Website',
-        url: 'https://streamyfin.app'
-      }
-    ]
-  },
-  {
     id: 'manet',
     name: 'Manet',
     description: 'A third-party music client for iOS and macOS',


### PR DESCRIPTION
We are proposing removal of Streamyfin from the clients list for the following reasons:

1. Poor behavior within the Jellyfin community and ecosystem.

   * Publishing unreleased changes before official clients without consultation.
   * Failure to contribute back upstream.
   * License violations and misattribution of source code.
   * Poor representation of Jellyfin to a wider audience.

2. For these reasons, we as a project no longer wish to endorse this client officially.