### PR TITLE
change book indent

### DIFF
--- a/docs/general/server/media/books.md
+++ b/docs/general/server/media/books.md
@@ -13,8 +13,7 @@ Books should be organized by type (Audiobooks, Books, Comics), then optionally b
 Books
 ├── Audiobooks
 │   ├── Author
-│   │   ├── Book1
-│   │   │   └── Book1.flac
+│   │   ├── Book1.flac
 │   │   └── Book2
 │   │       └── Book2.mp3
 │   └── Book3


### PR DESCRIPTION
Audiobooks in the Author folder do not `require` a Subfolder to be present.
This PR fixes that.

Additionaly this is trying to resolve https://github.com/jellyfin/jellyfin.org/pull/1157
Note that part of that already was resolved by https://github.com/jellyfin/jellyfin.org/pull/1320

This is realy only the last step there.