### PR TITLE
Networking mode (switch from host)

### DIFF
--- a/docs/general/installation/_container-docker-cli.md
+++ b/docs/general/installation/_container-docker-cli.md
@@ -56,7 +56,8 @@ Using host networking (`--net=host`) is optional but required in order to use DL
 docker run -d \
  --name jellyfin \
  --user uid:gid \
- --net=host \
+ -p 8096:8096/tcp \
+ -p 7359:7359/udp \
  --volume /path/to/config:/config \ # Alternatively --volume jellyfin-config:/config
  --volume /path/to/cache:/cache \ # Alternatively --volume jellyfin-cache:/cache
  --mount type=bind,source=/path/to/media,target=/media \

--- a/docs/general/installation/_container-docker-compose.md
+++ b/docs/general/installation/_container-docker-compose.md
@@ -21,7 +21,9 @@ services:
     image: jellyfin/jellyfin
     container_name: jellyfin
     user: uid:gid
-    network_mode: 'host'
+    ports:
+      - 8096:8096/tcp
+      - 7359:7359/udp
     volumes:
       - /path/to/config:/config
       - /path/to/cache:/cache

--- a/docs/general/installation/_container-podman.md
+++ b/docs/general/installation/_container-podman.md
@@ -29,7 +29,7 @@ Steps to run Jellyfin using Podman are similar to the Docker steps.
 
 3. Open the necessary ports in your machine's firewall if you wish to permit access to the Jellyfin server from outside the host.
    This is not done automatically when using rootless Podman.
-   If your distribution uses `firewalld`, the following commands save and load a new firewall rule opening the HTTP port `8096` for TCP connections. Additionaly port 7359 needs to be opened for auto discovery.
+   If your distribution uses `firewalld`, the following commands save and load a new firewall rule opening the HTTP port `8096` for TCP connections. Additionaly port 7359 UDP needs to be opened for auto discovery.
 
    ```sh
    sudo firewall-cmd --add-port=8096/tcp --permanent

--- a/docs/general/installation/_container-podman.md
+++ b/docs/general/installation/_container-podman.md
@@ -16,7 +16,8 @@ Steps to run Jellyfin using Podman are similar to the Docker steps.
     --detach \
     --label "io.containers.autoupdate=registry" \
     --name myjellyfin \
-    --network host \
+    --publish 8096:8096/tcp \
+    --publish 7359:7359/udp \
     --rm \
     --user $(id -u):$(id -g) \
     --userns keep-id \
@@ -28,10 +29,11 @@ Steps to run Jellyfin using Podman are similar to the Docker steps.
 
 3. Open the necessary ports in your machine's firewall if you wish to permit access to the Jellyfin server from outside the host.
    This is not done automatically when using rootless Podman.
-   If your distribution uses `firewalld`, the following commands save and load a new firewall rule opening the HTTP port `8096` for TCP connections.
+   If your distribution uses `firewalld`, the following commands save and load a new firewall rule opening the HTTP port `8096` for TCP connections. Additionaly port 7359 needs to be opened for auto discovery.
 
    ```sh
    sudo firewall-cmd --add-port=8096/tcp --permanent
+   sudo firewall-cmd --add-port=7359/udp --permanent
    sudo firewall-cmd --reload
    ```
 

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -46,3 +46,7 @@ import Podman from './\_container-podman.md';
 
 </TabItem>
 </Tabs>
+
+The above configuration uses a so-called bridge network, which causes the source IP address of client connections to appear as the bridge gateway rather than the actual client.
+To preserve correct client IP information, Jellyfin must be configured to treat the bridge network as a known proxy.
+Detailed instructions can be found on our [reverse proxy guide](../post-install/networking/8_reverse-proxy/index.md).

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -46,7 +46,3 @@ import Podman from './\_container-podman.md';
 
 </TabItem>
 </Tabs>
-
-The above configuration uses a so-called bridge network, which causes the source IP address of client connections to appear as the bridge gateway rather than the actual client.
-To preserve correct client IP information, Jellyfin must be configured to treat the bridge network as a known proxy.
-Detailed instructions can be found on our [reverse proxy guide](../post-install/networking/8_reverse-proxy/index.md).


### PR DESCRIPTION
I am unsure if the known proxies configuration will actually work!
I found that docker does have its issues with handling `x-forwarded-for` headers.
https://github.com/docker/roadmap/issues/157

In general this PR aims to migrate the example configurations into the more secure and robust `bridge` networking mode.

Concerns like DLNA Support requiring Host mode are solved by the DLNA Documentation specifically mentioning the required `host`-networking mode.