### PR TITLE
remove web scrobbler

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -809,34 +809,6 @@ const thirdPartyClients: Array<Client> = [
     ]
   },
   {
-    id: 'web-scrobbler',
-    name: 'Web Scrobbler',
-    description: 'Web Scrobbler helps online music listeners to scrobble their playback history.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Browser],
-    primaryLinks: [
-      {
-        id: 'install',
-        name: 'Installation Guide',
-        url: 'https://github.com/web-scrobbler/web-scrobbler#installation'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/web-scrobbler/web-scrobbler'
-      },
-      {
-        id: 'website',
-        name: 'Website',
-        url: 'https://webscrobbler.com'
-      }
-    ]
-  },
-  {
     id: 'jellybook',
     name: 'JellyBook',
     description: 'A cross platform mobile app for book & comic reading for Jellyfin.',


### PR DESCRIPTION
Removes `web-scrobbler` from the Client list.

Web Scrobbler is a Browser Plugin to sync your Played Music with Last.FM, Libre.fm and ListenBrainz.
Additionaly Jellyfin is supported on an Emby basis (The option is literally named "Emby/Jellyfin")

This is not a Jellyfin client,
It is a Browser Plugin also supporting "Emby/Jellyfin"

I think listing this in the clients page is quite missleading!