### PR TITLE
remove preserve-player

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -411,34 +411,6 @@ const thirdPartyClients: Array<Client> = [
     ]
   },
   {
-    id: 'preserve',
-    name: 'Preserve',
-    description: 'A music client inspired by players such as foobar2000 or Clementine.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Desktop],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Browser, Platform.Desktop],
-    primaryLinks: [
-      {
-        id: 'browser',
-        name: 'Open in browser',
-        url: 'https://preserveplayer.com/'
-      },
-      {
-        id: 'gl-downloads',
-        name: 'GitLab Downloads',
-        url: 'https://gitlab.com/tonyfinn/preserve/-/releases'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'gitlab',
-        name: 'GitLab',
-        url: 'https://gitlab.com/tonyfinn/preserve'
-      }
-    ]
-  },
-  {
     id: 'sonixd',
     name: 'Sonixd',
     description: 'A full-featured Subsonic/Jellyfin compatible desktop music player.',


### PR DESCRIPTION
Removes `preserve-player` from the Client list.

Preserve is a Client with its last release being from 2021.
https://gitlab.com/preserve/preserve/-/releases

Additionally it offers minimal Support of Jellyfins features.
It is a music Only client that does not support audio transcoding at all.

In todays times I do not think this is a Jellyfin Client that we should "recommend" to anyone!
There are a lot of alternatives in the "basic music player" category, and I think this one does not stand out.

We had a discussion about this in the documentation chat, which resulted in me creating my own Jellyfin Client specifically to showcase the lack of features Preserve comes with.