### PR TITLE
Prevent deployment CI from running on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,9 @@ jobs:
         with:
           cache: npm
           node-version: 20
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - name: Configure Pages
+        if: github.event_name == 'push' && github.repository == 'jellyfin/jellyfin.org'
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Run build
         run: |
           npm ci --no-audit
@@ -37,13 +39,13 @@ jobs:
           name: jellyfin-org__build
           path: build
       - name: Upload pages artifact
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'jellyfin/jellyfin.org'
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: build
 
   deploy:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'jellyfin/jellyfin.org'
     name: Deploy to GitHub Pages
     concurrency: build-deploy-pages
     environment:


### PR DESCRIPTION
Thanks to @nielsvanvelzen for the help 👍 

Adds a check to some of the build workflows to make sure they only run on the `jellyfin.org` repo and don't run on forks.
This way the CF Deployment will no longer try to run on forks (where cf pages obviously is not set up!)