### PR TITLE
update docusaurus config for v4

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -15,7 +15,6 @@ const config: Config = {
   baseUrl: '/',
   onBrokenAnchors: process.env.CI ? 'throw' : 'warn',
   onBrokenLinks: process.env.CI ? 'throw' : 'warn',
-  onBrokenMarkdownLinks: process.env.CI ? 'throw' : 'warn',
   onDuplicateRoutes: process.env.CI ? 'throw' : 'warn',
   favicon: 'images/favicon.ico',
   organizationName: 'jellyfin',
@@ -104,7 +103,10 @@ Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/
     }
   },
   markdown: {
-    mermaid: true
+    mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: process.env.CI ? 'throw' : 'warn'
+    }
   },
   plugins: [
     // Main content


### PR DESCRIPTION
Updates the docusaurus config to support the new v4 markdown hooks.

Fixes https://github.com/jellyfin/jellyfin.org/issues/1586