### PR TITLE
add css to draw tabs border

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -132,3 +132,9 @@ a.pills__item:not(.pills__item--active) {
     display: none;
   }
 }
+
+.tabs-container {
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 16px;
+}


### PR DESCRIPTION
#1564 is turning out to be much harder than originally anticipated, and after some discussions on Matrix it seems like that one is not going to be mergeable any time soon.

This PR adds something simple for the time being, since not marking where the tabs end is still not ideal.

Matrix discussion for reference: https://matrix.to/#/!VKEyKBCclqOAGAZKOr:matrix.org/$2fllrnW2m9cnG2JaGzpT0v5wPa_IslAYyVliRB6_CDw?via=bonifacelabs.ca&via=im.jellyfin.org&via=matrix.org