### PR TITLE
Switch from dpkg to apt for install .debs

### DIFF
--- a/docs/general/installation/advanced/manual.md
+++ b/docs/general/installation/advanced/manual.md
@@ -361,22 +361,10 @@ The repository is the preferred way to obtain Jellyfin on Debian and Ubuntu syst
 
 2. Download the desired `jellyfin-server`, `jellyfin-web`, and `jellyfin-ffmpeg` `.deb` packages from the repository; `jellyfin` is a metapackage and is not required.
 
-3. Install the downloaded `.deb` packages:
+3. Install the downloaded `.deb` packages with `apt` to handle dependency resolution:
 
    ```sh
-   sudo dpkg -i jellyfin_*.deb jellyfin-ffmpeg_*.deb
-   ```
-
-   :::note
-
-   This step may throw errors; continue to the next step to resolve them.
-
-   :::
-
-4. Use `apt` to install any missing dependencies:
-
-   ```sh
-   sudo apt -f install
+   sudo apt install ./jellyfin-server_*.deb ./jellyfin-web_*.deb ./jellyfin-ffmpeg_*.deb
    ```
 
 5. Manage the Jellyfin system service:


### PR DESCRIPTION
This is the recommended process on recent Debian releases and simplifies installation into one step while ensuring dependencies are properly installed.