### PR TITLE
update firefox mkv support status

### DIFF
--- a/docs/general/clients/codec-support.md
+++ b/docs/general/clients/codec-support.md
@@ -198,21 +198,19 @@ If the container is unsupported, this will result in remuxing. The video and aud
 |                               Container                               | Chrome | Edge | Firefox | Safari | Android | Android TV | Kodi | Roku |
 | :-------------------------------------------------------------------: | :----: | :--: | :-----: | :----: | :-----: | :--------: | :--: | :--: |
 |    [MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>    |   ✅   |  ✅  |   ✅    |   ✅   |   ✅    |     ✅     |  ✅  |  ✅  |
-|     [MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>      |   ❌   |  ✅  |   ❌    |   ❌   |   ✅    |     ✅     |  ✅  |  ✅  |
-|     [WebM](https://en.wikipedia.org/wiki/WebM)<sup>3, 5, 6</sup>      |   ✅   |  ✅  |   ✅    |   ✅   |   ✅    |     ✅     |  ✅  |  ✅  |
-| [TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)<sup>4</sup> |   ✅   |  ✅  |   ✅    |   ✅   |   ✅    |     ✅     |  ✅  |  ✅  |
-|        [OGG](https://en.wikipedia.org/wiki/Ogg)<sup>5, 7</sup>        |   ✅   |  ✅  |   ✅    |   ✅   |   ✅    |     ✅     |  ✅  |  ✅  |
+|     [MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2</sup>      |   ❌   |  ✅  |   ✅    |   ❌   |   ✅    |     ✅     |  ✅  |  ✅  |
+|     [WebM](https://en.wikipedia.org/wiki/WebM)<sup>4, 5</sup>      |   ✅   |  ✅  |   ✅    |   ✅   |   ✅    |     ✅     |  ✅  |  ✅  |
+| [TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)<sup>3</sup> |   ✅   |  ✅  |   ✅    |   ✅   |   ✅    |     ✅     |  ✅  |  ✅  |
+|        [OGG](https://en.wikipedia.org/wiki/Ogg)<sup>4, 6</sup>        |   ✅   |  ✅  |   ✅    |   ✅   |   ✅    |     ✅     |  ✅  |  ✅  |
 
 <sup>1</sup>MP4 containers are one of the few containers that will not remux.
 <br />
-<sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in Firefox and will remux.
+<sup>2</sup>MKV on FireFox requires at least version 145.
 <br />
-<sup>3</sup>MKV containers are improperly labeled as WebM in Firefox during playback.
+<sup>3</sup>TS is one of the primary containers for streaming for Jellyfin.
 <br />
-<sup>4</sup>TS is one of the primary containers for streaming for Jellyfin.
+<sup>4</sup>WebM and OGG have limited codec support (by design), refer to <a href="https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#WebM">this</a> for WebM and <a href="https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#Ogg">this</a> for OGG.
 <br />
-<sup>5</sup>WebM and OGG have limited codec support (by design), refer to <a href="https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#WebM">this</a> for WebM and <a href="https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#Ogg">this</a> for OGG.
+<sup>5</sup>WebM on Safari requires at least Safari 14.
 <br />
-<sup>6</sup>WebM on Safari requires at least Safari 14.
-<br />
-<sup>7</sup>OGG on Safari requires at least iOS 18.4 / macOS 15.4
+<sup>6</sup>OGG on Safari requires at least iOS 18.4 / macOS 15.4


### PR DESCRIPTION
https://www.firefox.com/en-US/firefox/145.0beta/releasenotes/

Starting with FireFox 145, it supports MKV containers by default, test with 145.0b3:
<img width="1562" height="431" alt="image" src="https://github.com/user-attachments/assets/de219753-b348-4433-9e49-df8d390bd327" />

from https://github.com/jellyfin/jellyfin-web/blob/4c14a8b529128636d5cb597f58d8eff9e732ee1b/src/scripts/browserDeviceProfile.js#L207-L226 , frontend js is nothing to do, when FireFox 145 released, the docs shoule be updated.