### PR TITLE
Fix 10.11.0 GitHub release urls

### DIFF
--- a/blog/2025/10-19-jellyfin-release-10.11.0/index.mdx
+++ b/blog/2025/10-19-jellyfin-release-10.11.0/index.mdx
@@ -8,7 +8,7 @@ tags: [release, server]
 
 We are pleased to bring you Jellyfin 10.11.0, our new stable release. This is probably one of, if not the, biggest and most impactful releases we've done yet, with some massive backend changes to improve performance and long-term expandability and maintainability. This release has been a long time coming, with over 6 months of development and another 6 months of RC testing, throwing our planned 6-month release schedule completely out of whack, but we definitely think the results are worth it - both for users right now, and for the long-term health of the project.
 
-If you just want a quick summary of what you **need to know** (and you **DO** need to know!) to get your system upgraded and running, please read on to the "TL; DR" section just below, or keep reading for a full explanation of all the major features and improvements in Jellyfin 10.11.0! You can also view full changelogs on the [server](https://github.com/jellyfin/jellyfin/releases/tags/v10.11.0) and [web](https://github.com/jellyfin/jellyfin-web/releases/tags/v10.11.0) GitHub releases.
+If you just want a quick summary of what you **need to know** (and you **DO** need to know!) to get your system upgraded and running, please read on to the "TL; DR" section just below, or keep reading for a full explanation of all the major features and improvements in Jellyfin 10.11.0! You can also view full changelogs on the [server](https://github.com/jellyfin/jellyfin/releases/tag/v10.11.0) and [web](https://github.com/jellyfin/jellyfin-web/releases/tag/v10.11.0) GitHub releases.
 
 \- Joshua
 


### PR DESCRIPTION
<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
Updated the v10.11.0 GitHub release urls (both for the server and the web), as they contained a typo which redirect to a `Not Found` page.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [x] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
