### PR TITLE
add troubleshooting info about db locked on lxc

### DIFF
--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -240,3 +240,7 @@ Stop your Jellyin server and navigate to its config directory. There are a lot o
 ```
 
 then start your jellyfin instance again. If this still does not help with the issues, you can try setting the `LockingBehavior` to `Pessimistic` instead but this comes with a significant performance impact so it is only recommended when `Optimistic` does not help with the issues.
+
+### LXC specific issues
+
+It has been brought to the team's attention that there are issues with LXC specifically. If you are getting such errors on LXC after setting lock mode to `Optimistic`, it is recommended that you migrate to full virtualization (virtual machines) or Docker. There is unlikely to be a solution for LXC any time soon, and we will be unable to provide any support for database locked problems on LXC.


### PR DESCRIPTION
Discussed on matrix with @JPVenson 

Summary:
The common denominator with database locked issues now seems to be LXC, [even on EXT4](https://github.com/jellyfin/jellyfin/issues/15101#issuecomment-3435004493). Probably safe to assume something is wrong with LXC even though we don't know what is actually wrong. Only thing we can do is to tell people to not use LXC if they face this issue.