### PR TITLE
[Docs] [Minor edit] Keep the built-in vs manual distinction for restores

### DIFF
--- a/docs/general/administration/backup-and-restore.md
+++ b/docs/general/administration/backup-and-restore.md
@@ -50,7 +50,7 @@ The Backup folder is located within your Jellyfin data directory which is locate
 
 After clicking on the `Create` button all data will be written into a new zip archive.
 
-### Restore from Built-in Backup
+### Restore from a Built-in Backup
 
 To restore from a Backup you can either use the webUI by navigating to the same view as for the step above and clicking on the restore button in the list of backups, or you can start jellyfin with the `--restore-archive PATH_TO_BACKUP_ZIP` argument. Note that when you start a restore from the webUI, you server will immediately restart for this process to take place and will be unavailable for that time.
 
@@ -94,7 +94,7 @@ Taking a manual Backup essentially involves you copying all the data jellyfin re
 
 3. Start up Jellyfin again, either after upgrading or on the current version. You now have a safe copy of your data in the path chosen in step 2.
 
-### Restoring a Manual Backup
+### Restoring from a Manual Backup
 
 This process assumes you followed the steps above to take the backup.
 


### PR DESCRIPTION
The original formatting had two different restore sections: one under the built-in backup section and one as a top-level section (on this page).

This proposed (minor) edit puts the second one as a sub-section of the manual backup section.

This, I believe, better aligns with the intent of the author or at least keeps the consistency across the two backup methods documented.

<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
<!-- Describe a little about what you've changed and why. -->

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
