### PR TITLE
Backup fixes

### DIFF
--- a/docs/general/administration/backup-and-restore.md
+++ b/docs/general/administration/backup-and-restore.md
@@ -33,7 +33,7 @@ To take a new Backup, enter the Jellyfin Dashboard, open the `Backups` tab and c
 - Subtitles. All extracted subtitles including downloaded ones.
 - Trickplay. All trickplay data that is stored not alongside media.
 
-The Backup system will check for at least 4GB of free space in the backup folder where backups a written to. However this can easily not be enough if you also backup Subtitles and Trickplay so ensure you have enough free space there.
+The Backup system will check for at least 5GB of free space in the backup folder where backups a written to. However this can easily not be enough if you also backup Subtitles and Trickplay so ensure you have enough free space there.
 The Backup folder is located within your Jellyfin data directory, by default:
 
 - Official Docker: `<volume path>/config/data/backups` where `<volume path>` is where your `/config` volume is sourced from; this is set in your `docker-compose.yml` or in your `-v` options to `docker run`.


### PR DESCRIPTION
**Changes**
Backing up jellyfin servers is an important part of administration, especially because it's the only way to rollback to a previous version or recover from errors during an upgrade. However, some details in the docs are unclear or incorrect. This PR aims to fix and clarify the backup and restore documentation to help admins keep their data safe. I also cleaned up a couple pre-existing typos and formatting errors.

**Copyediting**

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).
- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

resolves #1645
