### PR TITLE
Fix XDG specification link in configuration instructions

### DIFF
--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -19,7 +19,7 @@ Documentation for the available command line options can be obtained by adding t
 
 ## Server Paths
 
-The file paths used by the server are determined according to the rules outlined below. In general, the [XDG specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) is followed by default for non-Windows systems.
+The file paths used by the server are determined according to the rules outlined below. In general, the [XDG specification](https://specifications.freedesktop.org/basedir-spec/latest/) is followed by default for non-Windows systems.
 
 ### Data Directory
 


### PR DESCRIPTION
**Changes**
Simply update the url of the XDG specification to the new location.

**Copyediting**
- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).
- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**
closes #1652