### PR TITLE
Fix monospace ligature bug on macOS

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -5,6 +5,15 @@
  * work well for content-centric websites.
  */
 
+html {
+  /* Note: "normal" activates all common ligatures */
+  font-variant-ligatures: normal;
+}
+
+code {
+  font-variant-ligatures: none;
+}
+
 :root {
   /* base font */
   --ifm-font-family-base: 'Noto Sans', sans-serif;


### PR DESCRIPTION
<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
<!-- Describe a little about what you've changed and why. -->

This PR fixes a bug on macOS, where an "fi" ligature is rendered in monospaced text:

Before:
<img width="573" height="109" alt="before" src="https://github.com/user-attachments/assets/2aed2a27-ae2c-4a5b-9315-6a12d0af3a59" />

After:
<img width="573" height="98" alt="after" src="https://github.com/user-attachments/assets/13019753-9332-45b3-82e3-09d88f7e27bc" />

The bug is fixed by removing all custom CSS that deals with ligatures. 

After testing on multiple operating systems (Windows and macOS), and multiple browsers (Firefox, Safari and Edge), I could not find a single place on the website where ligatures are rendered, except the buggy "fi" ligature on macOS. 

This is why I'd recommend to remove the custom ligature CSS altogether.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [ ] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
