### PR TITLE
Add documentation for external artist images

### DIFF
--- a/docs/general/server/media/_metadata-images.md
+++ b/docs/general/server/media/_metadata-images.md
@@ -6,7 +6,6 @@ Images can either be provided as external files within the media folders, or emb
 
 Similar to media folders, an artist image can be placed in the root of an artist’s folder. It will be shown both when browsing artists and on the artist’s detail page.
 
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -89,7 +88,6 @@ Unless otherwise noted, all filenames can be used either standalone (e.g. `logo.
 | clearlogo                | Logo      | ✅ <sup>2</sup> | ✅     | ✅     |         | ✅    |        |
 | landscape                | Thumb     | ✅              | ✅     | ✅     |         | ✅    |        |
 | thumb                    | Thumb     | ✅              | ✅     | ✅     |         | ✅    |        |
-
 
 <sup>1</sup> For example: `S01E01 Some Episode-thumb.jpg` <br />
 <sup>2</sup> These file names can also be embedded in supported media containers (e.g. mkv) and will be used when the `Embedded Image Extractor` source is enabled for movies.


### PR DESCRIPTION
**Changes**
The use of external artist images was previously not documented despite the functionality being present.

These changes explain how and where artist images can be put alongside the media files.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- ~~[ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).~~   Rather simple changes
