### PR TITLE
Change download status for Arch Linux to Community

### DIFF
--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -299,7 +299,7 @@ sudo apt install jellyfin`}
     id: 'arch',
     name: 'Arch Linux',
     osTypes: [OsType.Linux],
-    status: DownloadStatus.OsPackage,
+    status: DownloadStatus.Community,
     features: [Feature.CustomFFmpeg],
     platforms: [Platform.Arch],
     description: 'Install Jellyfin via Arch-Extra Repository.',


### PR DESCRIPTION
**Changes**
Change download status for Arch Linux to Community as its not maintained by us and makes this circumstance much clearer then the "OsDownload" label

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [x] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [x] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
