### PR TITLE
Adding doc for Chapter Images

### DIFF
--- a/docs/general/server/metadata/chapter-images.md
+++ b/docs/general/server/metadata/chapter-images.md
@@ -9,8 +9,6 @@ Not to be confused with chapters, which are the ticks you see in the timeline wh
 
 :::
 
-# Chapter Images
-
 Chapter images are a type of metadata for video media files stored in Jellyfin. They are images that correspond to chapters and give a preview of the video at that timestamp.
 
 Jellyfin stores the chapter images within the metadata directory, which should be located inside your server's config directory.


### PR DESCRIPTION
Document for Chapter Image feature

<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
I'm adding some documentation around the Chapter Images feature. I was confused what the difference is between the "ticks" in the timeline and the "Chapter Image" settings in the dashboard.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [x] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
None