### PR TITLE
add upgrade instuctions for linux

### DIFF
--- a/docs/general/installation/linux.md
+++ b/docs/general/installation/linux.md
@@ -51,8 +51,6 @@ It is very important to note your current Jellyfin version before attempting to 
 jellyfin --version
 ```
 
-Read more about this, [here](/blog/2025/10-19-jellyfin-release-10.11.0/index.mdx).
-
 First, make a backup of your current data. Instructions can be found [here](/docs/general/administration/backup-and-restore.md).
 
 ### From version 10.10.7 or above
@@ -62,6 +60,8 @@ sudo apt upgrade jellyfin
 ```
 
 ### From version 10.10.6 or below
+
+You must first upgrade to the 10.10.7 release, before upgrading to the 10.11.0 stable version and beyond. Check the relevant release notes for more information.
 
 Check what Jellyfin versions are available:
 ```sh


### PR DESCRIPTION
<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
There are currently not official upgrade instructions for Linux. This is important especially considering the breaking update of 10.11.0. It is no longer safe to simply run `sudo apt upgrade jellyfin` so the alternate route should be made very clear

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
