### PR TITLE
Update Watchtower reference to fork

### DIFF
--- a/docs/general/clients/jellyfin-vue.md
+++ b/docs/general/clients/jellyfin-vue.md
@@ -54,7 +54,7 @@ services:
 
   watchtower:
     container_name: watchtower
-    image: ghcr.io/containrrr/watchtower
+    image: ghcr.io/nicholas-fedor/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
@@ -77,7 +77,9 @@ located where the `docker-compose.yml` file is.
 With this compose file:
 
 - Jellyfin Vue will be accessible on `8080` port of the machine that's running the containers
-- Watchtower takes care of updating the container to the latest commit available on the [repository](https://github.com/jellyfin/jellyfin-vue).
+- Watchtower (fork, [the original is unmaintained](https://github.com/containrrr/watchtower/issues/2067))
+takes care of updating the container to the latest commit available on the
+[repository](https://github.com/jellyfin/jellyfin-vue).
   This is a good idea because:
   - As of now, stable releases don't exist and there have only been prereleases that don't necessarily meet a quality criteria, but
     [major development milestones](https://jellyfin.org/posts/vue-vue3/).


### PR DESCRIPTION
<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
The original watchtower no longer works with the Docker v29, so I updated all the references to the most widely accepted fork out there.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

*Intentionally left in blank*
