### PR TITLE
Document NAXSI WAF setup for Jellyfin in nginx

### DIFF
--- a/docs/general/post-install/networking/8_reverse-proxy/nginx.md
+++ b/docs/general/post-install/networking/8_reverse-proxy/nginx.md
@@ -114,15 +114,15 @@ map $request $secretfilter {
 access_log /var/log/nginx/access.log stripsecrets;
 ```
 
-### NAXSI WAF module for nginx
+### NAXSI WAF module for Nginx
 
 If you want to protect Jellyfin with a Web Application Firewall (WAF), you can compile nginx with the [naxsi module](https://github.com/wargio/naxsi) and use the jellyfin.rules whitelist to mitigate false positives. Naxsi is an open-source WAF that is easy to configure and create rules for.
 
-#### Install nginx with naxsi
+#### Install Nginx with Naxsi
 
 Follow the steps on [Naxsi's GitHub](https://github.com/wargio/naxsi?tab=readme-ov-file#build-naxsi) or on its [webpage](https://wargio.github.io/naxsi/build-naxsi.html). Ensure you use the correct nginx version, as the module will fail to build if the version is incorrect.
 
-#### Configure nginx
+#### Configure Nginx
 
 Add the following to your `nginx.conf` in the `http` block. This loads the default blocking rules and a generic whitelist for all your sites. Verify the paths to the actual rules, as they may vary depending on your setup. You can find the default rules in the [Naxsi Repository](https://github.com/wargio/naxsi/tree/main/naxsi_rules). In this example, the `naxsi` folder was created manually, and the rules were copied into it.
 
@@ -273,6 +273,6 @@ Adjust your logging configuration to match your needs. A specific error log path
     access_log /var/log/nginx/access/jellyfin_example_org_access.log combined if=$loggable;
 ```
 
-#### learning mode
+#### Learning Mode
 
 It is recommended to enable learning mode for the first few weeks to detect false positives and add them to the whitelist. Enable learning mode by uncommenting the `LearningMode;` line. To create your own whitelists, follow the [Naxsi documentation on whitelists](https://wargio.github.io/naxsi/whitelist.html).


### PR DESCRIPTION
Added instructions for configuring NAXSI WAF with nginx to protect Jellyfin. Including installation, configuration, and logging details.

<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
<!-- Describe a little about what you've changed and why. -->
I used the Naxsi nginx module to protect my jellyfin for some weeks now. It seems like a really simple WAF to use and is one of the few open source web application firewalls actually worth looking into. As I just finished up the whitelist for jellyfin, I figured others might also like to add some security to their jellyfin webpage. Therefore I created a small documentation to getting started with Naxsi for jellyfin.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn. I'll look at some other PRs while I'm at it.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).