### PR TITLE
Add link for Intel graphics architechure

### DIFF
--- a/docs/general/post-install/transcoding/hardware-acceleration/intel.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/intel.md
@@ -777,7 +777,7 @@ More detail information about Intel video hardware can be found [on the Intel me
 
 :::note
 
-Gen X refers to Intel graphics architechure instead of the CPU generation. (i.e. Gen 9 graphics ≠ 9th Gen processors)
+Gen X refers to [Intel graphics architecture](https://en.wikipedia.org/wiki/Intel_Graphics_Technology) instead of the CPU generation. (i.e. Gen 9 graphics ≠ 9th Gen processors)
 
 :::
 


### PR DESCRIPTION
**Changes**

Intel's confusing naming between processor generations and graphics architecture makes it hard for users to know what they actually have. Searching the Intel website, I could not find a good link that describes these architectures and allows someone to find out which generation they have.

However, Wikipedia has a nice table, allowing someone to determine their generation if they know the name of their GPU, e.g. from running `lspci`, or by looking up their CPU on the Intel website (in case of iGPU).

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
