### PR TITLE
Updated flathub & github addresses for the official client

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -40,7 +40,7 @@ export type Client = {
 const officialClients: Array<Client> = [
   {
     id: 'jellyfin-media-player',
-    name: 'Jellyfin Media Player',
+    name: 'Jellyfin Desktop',
     description: 'The official Jellyfin desktop client.',
     clientType: ClientType.Official,
     deviceTypes: [DeviceType.Desktop],
@@ -50,19 +50,19 @@ const officialClients: Array<Client> = [
       {
         id: 'flathub',
         name: 'Flathub (Linux)',
-        url: 'https://flathub.org/apps/details/com.github.iwalton3.jellyfin-media-player'
+        url: 'https://flathub.org/en/apps/org.jellyfin.JellyfinDesktop'
       },
       {
         id: 'gh-downloads',
         name: 'GitHub Downloads',
-        url: 'https://github.com/jellyfin/jellyfin-media-player/releases'
+        url: 'https://github.com/jellyfin/jellyfin-desktop/releases'
       }
     ],
     secondaryLinks: [
       {
         id: 'github',
         name: 'GitHub',
-        url: 'https://github.com/jellyfin/jellyfin-media-player'
+        url: 'https://github.com/jellyfin/jellyfin-desktop'
       }
     ],
     recommended: true


### PR DESCRIPTION
**Changes**
Since the name of the official client for desktop was changed to Jellyfin Desktop, the flathub and github addresses have changed as well. This commit updates the website's links to point to the new addresses.