### PR TITLE
update arch urls

### DIFF
--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -307,12 +307,7 @@ sudo apt install jellyfin`}
       {
         id: 'arch-stable-link',
         name: 'Arch Downloads',
-        url: 'https://archlinux.org/packages/?q=jellyfin'
-      },
-      {
-        id: 'arch-aur-link',
-        name: 'AUR Downloads',
-        url: 'https://aur.archlinux.org/packages/?K=jellyfin'
+        url: 'https://archlinux.org/packages/extra/x86_64/jellyfin-server/'
       }
     ],
     unstableButtons: [
@@ -332,7 +327,7 @@ makepkg -si`}
       {
         id: 'arch-aur-link',
         name: 'AUR Downloads',
-        url: 'https://aur.archlinux.org/packages/?K=jellyfin'
+        url: 'https://aur.archlinux.org/packages/jellyfin-server-git'
       }
     ],
     otherButtons: []


### PR DESCRIPTION
Rework of https://github.com/jellyfin/jellyfin.org/pull/1669
1. remove Jellyfin AUR from Stable Downloads - There is an OS Package for Jellyfin-Server. There is no need to recommend the AUR.
2. Provide link to packages, not package search.