### PR TITLE
Restructure metadata mediasegments

### DIFF
--- a/docs/general/server/metadata/media-segments.md
+++ b/docs/general/server/metadata/media-segments.md
@@ -17,7 +17,7 @@ Jellyfin can store this information and provide it to clients. Clients can then 
 
 There's a few steps to follow if you want to use media segments:
 
-1. Install one or multiple media segment providers. Read the [plugins section](#plugin-support) below to find out more.
+1. Install one or multiple media segment providers. Read the [plugins section](#plugins) below to find out more.
 2. Run the `Media segment scan` task in the dashboard to create segments immediately, this task also runs automatically in the background.
 3. Set actions for the different segment types, the way you do this differs per client, but they are generally found in the playback settings of the client.
 


### PR DESCRIPTION
This PR is meant to update and restructure the media segments Guide.

## Changes
- Using docusaurus-style h1 headings instead of markdown-style.
- Removed "supported clients" list - Its hard to track, as a lot of clients (e.g. Android Mobile) use the Web-Player and therefore support Actions based on media segments
- Removed "this is a new feature" disclaimer
- Removed "update Server to 10.10" from `Getting Started` (instead, added "first introduced in")
- Restructure to have less repetitive information and enhance readability.

I was unabled to find any refering links to this page in the documentation that would have to be updated due to the restructure.