### PR TITLE
Isolate PR build from secrets and token permissions

### DIFF
--- a/.github/workflows/__build.yml
+++ b/.github/workflows/__build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      upload-pages-artifact:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: 20
+      - name: Configure Pages
+        if: inputs.upload-pages-artifact
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - name: Run build
+        run: |
+          npm ci --no-audit
+          npm run build
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: jellyfin-org__build
+          path: build
+      - name: Upload pages artifact
+        if: inputs.upload-pages-artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,44 +9,20 @@ on:
   push:
     branches: [master]
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        with:
-          cache: npm
-          node-version: 20
-      - name: Configure Pages
-        if: github.event_name == 'push' && github.repository == 'jellyfin/jellyfin.org'
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-      - name: Run build
-        run: |
-          npm ci --no-audit
-          npm run build
-      - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: jellyfin-org__build
-          path: build
-      - name: Upload pages artifact
-        if: github.event_name == 'push' && github.repository == 'jellyfin/jellyfin.org'
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
-        with:
-          path: build
+    uses: ./.github/workflows/__build.yml
+    permissions: {}
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      upload-pages-artifact: ${{ github.event_name == 'push' && github.repository == 'jellyfin/jellyfin.org' }}
 
   deploy:
     if: github.event_name == 'push' && github.repository == 'jellyfin/jellyfin.org'
     name: Deploy to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
     concurrency: build-deploy-pages
     environment:
       name: github-pages


### PR DESCRIPTION
**Changes**
Prevent leaking secrets during the build phase.

**Copyediting**
To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [X] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [X] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [n/a] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [n/a] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).
