### PR TITLE
remove h2 heading from caddy page

### DIFF
--- a/docs/general/post-install/networking/8_reverse-proxy/caddy.md
+++ b/docs/general/post-install/networking/8_reverse-proxy/caddy.md
@@ -4,8 +4,6 @@ title: Caddy
 sidebar-position: 1
 ---
 
-## Caddy
-
 > **Note:** For HTTP/3 support, ensure UDP port 443 is forwarded/opened on your firewall, as HTTP/3 uses UDP.
 
 "[Caddy](https://caddyserver.com/), sometimes clarified as the Caddy web server, is an open source, HTTP/2-enabled web server written in Go. It uses the Go standard library for its HTTP functionality." - [Wikipedia](<https://en.wikipedia.org/wiki/Caddy_(web_server)>)


### PR DESCRIPTION
Changes:

- fix duplicate headings on caddy page (due to h2 heading)