### PR TITLE
add old blogposts to ignores

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,16 @@ export default ts.config([
       }
     },
 
+    ignores: [
+      'blog/2019/**',
+      'blog/2020/**',
+      'blog/2021/**',
+      'blog/2022/**',
+      'blog/2023/**',
+      'blog/2024/**',
+      'blog/2025/**'
+    ],
+
     settings: {
       react: {
         version: 'detect'


### PR DESCRIPTION
Some of the old blog-posts have linting and spelling errors appear.
To prevent `eslint` from running on those files (now and in the future), this aims to disable it.

Since `eslint` SHOULD run on new blog posts, this is quite the perfect timing to add this.

Just an Idea to solve issues like this:
https://github.com/jellyfin/jellyfin.org/actions/runs/21069274923/job/60594286766

Note that actual linting errors (with the current config) only appear in the `2020` blog-posts folder.
If the linting rules will ever change they MIGHT touch the old blog posts though.