### PR TITLE
fail2ban log level and file name update

### DIFF
--- a/docs/general/post-install/networking/9_advanced/fail2ban.md
+++ b/docs/general/post-install/networking/9_advanced/fail2ban.md
@@ -13,7 +13,7 @@ Jellyfin produces logs that can be monitored by Fail2ban to prevent brute-force 
 - Jellyfin remotely accessible
 - Fail2ban installed and running
 - Knowing where the logs for Jellyfin are stored: by default `/var/log/jellyfin/` for desktop and `/config/log/` for docker containers.
-- Jellyfin log level set to `Info` (failed authentication entries are not logged at `Error`). This setting is in `logging.json`, located in the regular Jellyfin config folder or in `/etc/jellyfin/`.
+- Jellyfin log level set to `Info` (failed authentication entries are not logged at `Error`). This setting is can be found in `logging.json`
 
 ## Step one: create the jail
 


### PR DESCRIPTION
I had some issues when setting up fail2ban that I resolved and added what I did to the documentation. Some of this might collide with https://github.com/jellyfin/jellyfin.org/pull/1676

**Changes**

- Fixed log file name
- Added info about log level required to receive authentication failure message
    - Log level for Proxmox LXC containers was set to Error by default

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

