### PR TITLE
fix(branding): Correct GitHub account URL typo

### DIFF
--- a/docs/project/branding.md
+++ b/docs/project/branding.md
@@ -9,7 +9,7 @@ title: Branding
 
 The name "Jellyfin" and the primary logo (two integrated triangular shapes, a stylized "fin") are trademarks in Canada, the United States, the European Union, and China of "Jellyfin, Inc.", an Ontario, Canada-based not-for-profit corporation.
 
-A perpetual, no cost license is hereby granted to all members of the Jellyfin organization ("team") and projects under [our GitHub account](https://github.com/jelyfin) to use the name and logo in furtherance of the Jellyfin project.
+A perpetual, no cost license is hereby granted to all members of the Jellyfin organization ("team") and projects under [our GitHub account](https://github.com/jellyfin) to use the name and logo in furtherance of the Jellyfin project.
 
 For all others, you are **not** free to use the name "Jellyfin" or our logo without the explicit permission of the [project leadership team](/docs/general/about#core-team), with the following exceptions:
 


### PR DESCRIPTION
**Changes**
Fix the url poining to the GitHub account of the project.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [ ] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
