### PR TITLE
Describe where to set JELLYFIN_WEB_DIR

### DIFF
--- a/docs/general/contributing/development.md
+++ b/docs/general/contributing/development.md
@@ -58,7 +58,14 @@ The first step is to set up a copy of the Git repository of the project you want
 
 5. Build the Jellyfin Web project with NPM, and copy the location of the resulting `dist` folder.
 
-6. In your `Jellyfin.Server` project add an environment variable named `JELLYFIN_WEB_DIR` with the value set to the full path of your `dist` folder.
+6. In your `Jellyfin.Server` project add an environment variable named `JELLYFIN_WEB_DIR` with the value set to the full path of your `dist` folder. You can set this path in your project by modifying the **environmentVariables** in the `Jellyfin.Server/Properties/launchSettings.json` file:
+
+   ```json
+   "environmentVariables": {
+      "ASPNETCORE_ENVIRONMENT": "Development",
+      "JELLYFIN_WEB_DIR": "/path/to/your/jellyfin-web/dist"
+   }
+   ```
 
 You will now be ready to begin building or modifying the project.
 


### PR DESCRIPTION
<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
 
Adds a reference to the specific file to edit to set the `JELLYFIN_WEB_DIR` environment variable. This adds extra context to help with setting up the jellyfin project for the first time.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [x] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

Closes #1771 

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
