### PR TITLE
Mitigate pull_request_target privilege escalation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches: [master]
 
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Add comment
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.JF_BOT_TOKEN }}
           message: |
@@ -68,12 +68,12 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy build --project-name=jellyfin-org --branch=${{
-            (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository)
+            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
             && (github.event.pull_request.head.ref || github.ref_name)
             || format('{0}/{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.head.ref)
             }} --commit-hash=${{ github.event.pull_request.head.sha || github.sha }}
       - name: Update status comment (Success)
-        if: ${{ github.event_name == 'pull_request_target' && success() }}
+        if: ${{ github.event_name == 'pull_request' && success() }}
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           github-token: ${{ secrets.JF_BOT_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
           comment-tag: CFPages-deployment
           mode: recreate
       - name: Update status comment (Failure)
-        if: ${{ github.event_name == 'pull_request_target' && failure() }}
+        if: ${{ github.event_name == 'pull_request' && failure() }}
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           github-token: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
Hotfix: replace `pull_request_target` with `pull_request` to stop granting write permissions and secret access to fork PRs.

Some workflows will break (PR comments, labeling, deploy previews). Can be restored later with `workflow_run`.

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

See also: https://github.com/jellyfin/jellyfin.org/pull/1750