### PR TITLE
fix: add actions:read permission for cross-run artifact downloads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
 
     name: Deploy to GitHub Pages
     permissions:
+      actions: read
       pages: write
       id-token: write
     concurrency: build-deploy-pages
@@ -55,6 +56,8 @@ jobs:
       github.repository == 'jellyfin/jellyfin.org'
 
     name: Deploy to Cloudflare Pages
+    permissions:
+      actions: read
     runs-on: ubuntu-latest
     steps:
       - name: Set PR metadata


### PR DESCRIPTION
The deploy and publish jobs use download-artifact with run-id to fetch artifacts from the triggering build workflow. This requires actions:read permission, which was missing from both jobs.