### PR TITLE
Remove note about installing `jellyfin-server` and `jellyfin-web`

### DIFF
--- a/docs/general/installation/advanced/manual.md
+++ b/docs/general/installation/advanced/manual.md
@@ -315,18 +315,6 @@ If you would prefer to install everything manually, the full steps are as follow
    sudo apt install jellyfin
    ```
 
-   :::note
-
-   If you want to be explicit, instead of the metapackage, you can install the sub-packages individually:
-
-   ```sh
-   sudo apt install jellyfin-server jellyfin-web
-   ```
-
-   The `jellyfin-server` package will automatically select the right `jellyfin-ffmpeg` package for you as well.
-
-   :::
-
 7. Manage the Jellyfin system service:
 
    ```sh


### PR DESCRIPTION
The note being removed says that instead of installing `jellyfin`, the user can install `jellyfin-web` and `jellyfin-server` packages instead. 

**This is wrong and leads to a broken install** because only the `jellyfin` metapackage depends on `jellyfin-ffmpeg7` package without which the server refuses to start.

The part of the note that says:

> The jellyfin-server package will automatically select the right jellyfin-ffmpeg package for you as well.

is also incorrect; the `jellyfin-server` package did _not_ pull in `jellyfin-ffmpeg7`; it's only a "Recommends" dependency, not a "Depends" dependency.

In short, just tell the user to install `jellyfin` and don't over-complicate matters. :)

<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
<!-- Describe a little about what you've changed and why. -->

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
