### PR TITLE
Add SmartCovers to third-party plugins

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -289,14 +289,6 @@ A plugin to integrate your Shoko database with the Jellyfin media server.
 
 - [GitHub](https://github.com/ShokoAnime/Shokofin)
 
-#### SmartCovers
-
-Fallback cover-image provider for books, audiobooks, and PDFs. Extracts covers from files locally (EPUB, PDF, audio embedded art) and fetches from Open Library and Google Books when local extraction fails.
-
-**Links:**
-
-- [GitHub](https://github.com/GeiserX/smart-covers)
-
 #### Skin Manager
 
 Download and manage the most popular skins.
@@ -344,6 +336,14 @@ Downloads Hebrew subtitles from WizdomSubs for your media files. This plugin pro
 **Links:**
 
 - [GitHub](https://github.com/DeDuplicate/Jellyfin_wizdomsubs_downloader)
+
+#### SmartCovers
+
+Fallback cover-image provider for books, audiobooks, and PDFs. Extracts covers from files locally (EPUB, PDF, audio embedded art) and fetches from Open Library and Google Books when local extraction fails.
+
+**Links:**
+
+- [GitHub](https://github.com/GeiserX/smart-covers)
 
 ## Repositories
 

--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -289,6 +289,14 @@ A plugin to integrate your Shoko database with the Jellyfin media server.
 
 - [GitHub](https://github.com/ShokoAnime/Shokofin)
 
+#### SmartCovers
+
+Fallback cover-image provider for books, audiobooks, and PDFs. Extracts covers from files locally (EPUB, PDF, audio embedded art) and fetches from Open Library and Google Books when local extraction fails.
+
+**Links:**
+
+- [GitHub](https://github.com/GeiserX/smart-covers)
+
 #### Skin Manager
 
 Download and manage the most popular skins.

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -121,5 +121,13 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     includes: {
       'WizdomSubs Downloader': 'https://github.com/DeDuplicate/Jellyfin_wizdomsubs_downloader'
     }
+  },
+  {
+    id: 'gh:GeiserX/smart-covers',
+    name: "GeiserX's SmartCovers Repo",
+    url: 'https://geiserx.github.io/smart-covers/manifest.json',
+    includes: {
+      SmartCovers: 'https://github.com/GeiserX/smart-covers'
+    }
   }
 ];


### PR DESCRIPTION
## Summary

Adds **SmartCovers** to the third-party plugin list and repository index.

- **Repo:** https://github.com/GeiserX/smart-covers
- **Manifest:** https://geiserx.github.io/smart-covers/manifest.json

SmartCovers is a fallback cover-image provider for books and audiobooks. It extracts covers from files locally (EPUB, PDF, audio embedded art) and fetches from Open Library and Google Books when local extraction fails.

This was originally part of #1806, which has been closed and split into separate PRs per reviewer request. The plugin was also renamed from "Jelly Covers" to "SmartCovers" to comply with branding guidelines.

### How SmartCovers differs from Bookshelf

SmartCovers is a **dedicated cover-image provider** designed to complement Bookshelf, not replace it. Both plugins support books and audiobooks, but they focus on different things:

- **Bookshelf** is a full metadata suite — titles, authors, series, ratings, genres — plus cover images from EPUB/OPF, comic archives, Google Books, and Comic Vine.
- **SmartCovers** is image-only and targets the gaps Bookshelf doesn't cover:

| Gap | Details |
|---|---|
| **PDF cover extraction** | SmartCovers renders the first page via `pdftoppm`. Bookshelf lists PDF as a supported file type but has no PDF cover extraction code. |
| **Audio embedded art** | SmartCovers extracts covers from audio files via `ffmpeg` with magic-byte codec detection, fixing Jellyfin's built-in extractor crash on mismatched ID3 tags. Bookshelf has no audio cover extraction. |
| **EPUB fallback** | Bookshelf extracts EPUB covers via OPF metadata (the standard approach). SmartCovers adds a 3-tier heuristic fallback (filename → path → largest image) that catches malformed EPUBs where OPF parsing fails. |
| **Open Library** | SmartCovers searches Open Library by title/author as an additional online source. Bookshelf does not use Open Library. |
| **Google Books without prior metadata** | Bookshelf's Google Books image provider requires the Google Books provider ID to already exist on the item (set by its own metadata provider running first). SmartCovers searches Google Books directly by title/author, so it works even when no metadata provider has run. |

SmartCovers runs at lower priority than Bookshelf. It only activates when Bookshelf (and Jellyfin's built-in providers) return no image. The typical use case is: Bookshelf handles most books; SmartCovers catches PDFs, broken EPUBs, and items that slipped through without a cover.