### PR TITLE
Add Dorsal to the clients list (iOS, OSS)

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -1004,6 +1004,34 @@ const thirdPartyClients: Array<Client> = [
         url: 'https://jellify.app'
       }
     ]
+  },
+  {
+    id: 'dorsal',
+    name: 'Dorsal',
+    description: 'An album-focused iOS/iPadOS music player for Jellyfin.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.IOS],
+    primaryLinks: [
+      {
+        id: 'testflight',
+        name: 'TestFlight',
+        url: 'https://testflight.apple.com/join/p3cMepSH'
+      },
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/dorsal-music/id6762251157'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/jaredreich/dorsal'
+      },
+    ]
   }
 ];
 


### PR DESCRIPTION
Hi there! Huge thank you to all the Jellyfin maintainers. I've had a blast over the last year setting up and perfecting my Jellyfin server. Over the last few months I've developed [Dorsal](https://github.com/jaredreich/dorsal), an album-focused, iOS-native music player and have just released and open sourced it, was hoping to add it to the clients list.

- [x] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews)
I did a tiny review of https://github.com/jellyfin/jellyfin.org/pull/1820, though I found it hard to figure out what consitutes a documentation PR that would be appropriate for a non-maintainer to help out with, sorry!

Thanks again to the maintainers. Cheers!