### PR TITLE
Add Yomu (iOS/iPadOS/macOS manga reader) to third-party clients

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -1005,6 +1005,30 @@ const thirdPartyClients: Array<Client> = [
       }
     ]
   }
+  {
+    id: 'yomu',
+    name: 'Yomu',
+    description: 'A native manga, webtoon, and manhwa reader for iPhone, iPad, and Mac with built-in Jellyfin support. Reads CBZ, CBR, EPUB, and PDF book libraries served by Jellyfin.',
+    smallDescription: 'A native manga / comic reader for iPhone, iPad, and Mac.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile, DeviceType.Desktop],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.IOS, Platform.MacOS],
+    primaryLinks: [
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/app/yomu/id6760745234'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://yomureader.app'
+      }
+    ]
+  },
 ];
 
 export const Clients: Array<Client> = [...officialClients, ...thirdPartyClients];


### PR DESCRIPTION
Adds [Yomu](https://yomureader.app/) to the third-party clients list.

Yomu is a free native iOS / iPadOS / macOS reader for manga, webtoons, manhwa, and self-hosted comic libraries. It includes built-in Jellyfin support — users can connect a Jellyfin server (with manga/comic library) directly from the app and browse/read CBZ, CBR, EPUB, and PDF content.

- App Store: https://apps.apple.com/app/yomu/id6760745234
- Website: https://yomureader.app
- Platforms: iOS, iPadOS, macOS
- License: Proprietary (free with optional in-app purchase)

Note: I'm not 100% sure the alphabetical position is correct in the patch — happy to amend if maintainers prefer a specific spot in `thirdPartyClients`.