### PR TITLE
Add `Jellyfin Team` to Authors List

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,3 +1,9 @@
+jellyfin:
+  name: Jellyfin Team
+  title: Jellyfin Team
+  url: https://jellyfin.org/
+  image_url: https://avatars.githubusercontent.com/u/45698031?s=200&v=4
+
 1hitsong:
   name: 1hitsong
   title: Roku Team


### PR DESCRIPTION
**Changes**
I've added the Jellyfin Team as a generic author for State of the Fin updates since it's compiled from various authors programmatically. I included at the top which is out of alphabetical order since it's a group / composite of everyone. Let me know if I should alphabetize it in there normally.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [x] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [x] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

`None`