### PR TITLE
docs(plugins): add WeTrakr to 3rd-party plugins and repositories

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -353,6 +353,14 @@ Local AI-powered subtitle generation using whisper.cpp. Generates SRT subtitles 
 
 - [GitHub](https://github.com/GeiserX/whisper-subs)
 
+#### WeTrakr
+
+Automatic scrobbling of Jellyfin playback (movies and episodes — start, progress, pause, resume, stop) to your [WeTrakr](https://wetrakr.com) profile. One-click pairing via OAuth Device Code.
+
+**Links:**
+
+- [GitHub](https://github.com/wetrakr/wetrakr-jellyfin)
+
 ## Repositories
 
 import { OfficialPluginRepositories, ThirdPartyRepositories } from '../../../../src/data/pluginRepositories';

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -137,5 +137,13 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     includes: {
       WhisperSubs: 'https://github.com/GeiserX/whisper-subs'
     }
+  },
+  {
+    id: 'gh:wetrakr/wetrakr-jellyfin',
+    name: 'WeTrakr Repo',
+    url: 'https://wetrakr.github.io/wetrakr-jellyfin/manifest.json',
+    includes: {
+      WeTrakr: 'https://github.com/wetrakr/wetrakr-jellyfin'
+    }
   }
 ];


### PR DESCRIPTION
## Summary

Adds [WeTrakr](https://wetrakr.com) — a film and series tracking service — to the **3rd-Party Plugins** section and the corresponding **3rd-Party Plugin Repositories** entry.

The Jellyfin plugin scrobbles playback events (start, progress, pause, resume, stop) for movies and episodes to a WeTrakr profile, with one-click OAuth Device Code pairing (no API keys to copy by hand).

## Plugin facts

| | |
|---|---|
| Plugin repo | https://github.com/wetrakr/wetrakr-jellyfin |
| Manifest URL | https://wetrakr.github.io/wetrakr-jellyfin/manifest.json |
| Latest release | v0.1.11 |
| Target Jellyfin | 10.11+ |
| Source | open source, MIT |
| Branding | https://github.com/wetrakr/wetrakr-jellyfin/blob/master/branding/thumbnail.png |

## Changes

- `docs/general/server/plugins/index.mdx` — append `#### WeTrakr` entry under `### 3rd-Party Plugins` (matches the format of the surrounding entries).
- `src/data/pluginRepositories.ts` — append entry to `ThirdPartyRepositories` so the `<PluginRepositoryList />` shows the manifest URL.

## Test plan

- [x] No formatting changes outside the new entries.
- [x] Manifest URL is publicly reachable: returns the JSON manifest from gh-pages.
- [x] GUID `eaa1f0a3-7e4c-4c6f-9b80-0a2c1c5e2f01` is unique (verified — no other plugin in the catalog uses it).
- [x] Plugin works against current stable Jellyfin (10.11.x).