### PR TITLE
Add WeTrakr to 3rd-party plugins list

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -353,6 +353,14 @@ Local AI-powered subtitle generation using whisper.cpp. Generates SRT subtitles 
 
 - [GitHub](https://github.com/GeiserX/whisper-subs)
 
+#### WeTrakr
+
+Automatic scrobbling of Jellyfin playback (movies and episodes — start, progress, pause, resume, stop) to your [WeTrakr](https://wetrakr.com) profile. One-click pairing via OAuth Device Code.
+
+**Links:**
+
+- [GitHub](https://github.com/wetrakr/wetrakr-jellyfin)
+
 ## Repositories
 
 import { OfficialPluginRepositories, ThirdPartyRepositories } from '../../../../src/data/pluginRepositories';

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -137,5 +137,13 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     includes: {
       WhisperSubs: 'https://github.com/GeiserX/whisper-subs'
     }
+  },
+  {
+    id: 'gh:wetrakr/wetrakr-jellyfin',
+    name: 'WeTrakr Repo',
+    url: 'https://wetrakr.github.io/wetrakr-jellyfin/manifest.json',
+    includes: {
+      WeTrakr: 'https://github.com/wetrakr/wetrakr-jellyfin'
+    }
   }
 ];


### PR DESCRIPTION
Hi, I'm Alberto Aznar, an indie developer who has created WeTrakr, a platform for tracking movies and series. I'd like to add the plugin we've built for Jellyfin to the 3rd-party plugins list.

The plugin scrobbles and tracks events (start, progress, pause, resume, stop...) so your viewing progress shows up on your WeTrakr profile.

Repo: https://github.com/wetrakr/wetrakr-jellyfin
Manifest: https://wetrakr.github.io/wetrakr-jellyfin/manifest.json