### PR TITLE
align book examples with wording

### DIFF
--- a/docs/general/server/media/books.md
+++ b/docs/general/server/media/books.md
@@ -13,7 +13,8 @@ Books should be organized by type (Audiobooks, Books, Comics), then optionally b
 Books
 ├── Audiobooks
 │   ├── Author
-│   │   ├── Book1.flac
+│   │   ├── Book1
+│   │   │   └── Book1.flac
 │   │   └── Book2
 │   │       └── Book2.mp3
 │   └── Book3


### PR DESCRIPTION
Technically this is supported, but it is not recommend.
It also differs from the wording just above.

Fixes https://github.com/jellyfin/jellyfin.org/issues/1830