### PR TITLE
Add LetterboxdSync to third-party plugins

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -355,10 +355,11 @@ Local AI-powered subtitle generation using whisper.cpp. Generates SRT subtitles 
 
 #### Letterboxd Sync
 
-<!-- TODO: replace this comment with a 1–2 sentence description in your own words. See https://jellyfin.org/docs/general/contributing/llm-policies/ -->
+LetterboxdSync logs every film you watch in Jellyfin straight to your Letterboxd diary. It's real-time, multi-user and supports a 'letterboxd watchlist -> seer -> jellyfin playlist' workflow. 
 
 **Links:**
 
+- [Website](https://lachlanyoung.dev/jellyfin-plugin-letterboxd/)
 - [GitHub](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd)
 
 ## Repositories

--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -353,6 +353,14 @@ Local AI-powered subtitle generation using whisper.cpp. Generates SRT subtitles 
 
 - [GitHub](https://github.com/GeiserX/whisper-subs)
 
+#### Letterboxd Sync
+
+<!-- TODO: replace this comment with a 1–2 sentence description in your own words. See https://jellyfin.org/docs/general/contributing/llm-policies/ -->
+
+**Links:**
+
+- [GitHub](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd)
+
 ## Repositories
 
 import { OfficialPluginRepositories, ThirdPartyRepositories } from '../../../../src/data/pluginRepositories';

--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -353,9 +353,9 @@ Local AI-powered subtitle generation using whisper.cpp. Generates SRT subtitles 
 
 - [GitHub](https://github.com/GeiserX/whisper-subs)
 
-#### Letterboxd Sync
+#### LetterboxdSync
 
-LetterboxdSync logs every film you watch in Jellyfin straight to your Letterboxd diary. It's real-time, multi-user and supports a 'letterboxd watchlist -> seer -> jellyfin playlist' workflow. 
+LetterboxdSync logs every film you watch in Jellyfin straight to your Letterboxd diary. It's real-time, multi-user, and supports a 'Letterboxd watchlist → Seer → Jellyfin playlist' workflow.
 
 **Links:**
 

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -140,10 +140,10 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
   },
   {
     id: 'gh:builtbyproxy/jellyfin-plugin-letterboxd',
-    name: "builtbyproxy's Letterboxd Sync Repo",
+    name: "builtbyproxy's LetterboxdSync Repo",
     url: 'https://raw.githubusercontent.com/builtbyproxy/jellyfin-plugin-letterboxd/main/manifest.json',
     includes: {
-      'Letterboxd Sync': 'https://github.com/builtbyproxy/jellyfin-plugin-letterboxd'
+      LetterboxdSync: 'https://github.com/builtbyproxy/jellyfin-plugin-letterboxd'
     }
   }
 ];

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -137,5 +137,13 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     includes: {
       WhisperSubs: 'https://github.com/GeiserX/whisper-subs'
     }
+  },
+  {
+    id: 'gh:builtbyproxy/jellyfin-plugin-letterboxd',
+    name: "builtbyproxy's Letterboxd Sync Repo",
+    url: 'https://raw.githubusercontent.com/builtbyproxy/jellyfin-plugin-letterboxd/main/manifest.json',
+    includes: {
+      'Letterboxd Sync': 'https://github.com/builtbyproxy/jellyfin-plugin-letterboxd'
+    }
   }
 ];


### PR DESCRIPTION
## Summary

Adds **LetterboxdSync** to the third-party plugin list and repository index.

- **Repo:** https://github.com/builtbyproxy/jellyfin-plugin-letterboxd
- **Manifest:** https://raw.githubusercontent.com/builtbyproxy/jellyfin-plugin-letterboxd/main/manifest.json

LetterboxdSync is the successor to a few now-outdated plugins designed to sync watch activity of movies to  Letterboxd. This plugin successfully does that by: 
- Allowing users to configure their own letterboxd accounts in the sidebar:
<img width="470" height="392" alt="CleanShot 2026-05-07 at 12 37 39@2x" src="https://github.com/user-attachments/assets/584a83ed-2764-479b-a540-11639da94042" />

- Using the native android API as a backup for Cloudflare's 403 errors
- Allowing multiple ways to sync activity including: 
  - Daily
  - When a movie is finished
  - Manually with the 'Run Sync Now' button in the letterboxd sidebar ^ 

It supports multiple helpful features including:
- Automatic import from a watchlist -> Seer to request -> Jellyfin playlist
- Reviewing in the letterboxd dashboard
- Logs available in the Admin console for debugging

I am planning to build additional features based on reddit feedback and github issues. Up next is [multiple letterboxd accounts per jellyfin user, to help when one account is being used on a TV for multiple people](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/pull/28)

This plugin has been in development for over a month now and has gone through substantial work to improve/debug with users. It is written with the help of AI off the back of my 10 years of experience as a software engineer and maintains a strong test coverage of over 80%

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [X] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [X] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).
  - This is pending 👍
