### PR TITLE
Prevent pages deployment on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
 
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' && github.repository == 'jellyfin/jellyfin.org' }}
 
     name: Deploy to GitHub Pages
     permissions:


### PR DESCRIPTION
Since `metadata` requires the PR target to be `jellyfin/jellyfin.org`, PRs will not get previews deployed when opened on a fork.
HOWEVER we do not check the repository when running prod builds after changes on master.

This results in GitHub Actions trying to deploy your own Version of the Jellyfin docs (and likely failing to do so due to GHPages not being set up on the repo)

This PR ads a repo check to the prod deployment as well 🤡