### PR TITLE
add LAN Subnet config section

### DIFF
--- a/docs/general/post-install/networking/index.md
+++ b/docs/general/post-install/networking/index.md
@@ -57,6 +57,18 @@ This, however, requires the use of a public DNS server - The Jellyfin Server doe
 
 </details>
 
+### Allowing Access
+
+Jellyfin provides flexible access control options. External access can either be completely disabled or selectively enabled for individual users.
+
+For these controls to function correctly, Jellyfin must know which IP ranges should be considered part of the local network.
+These ranges can be configured under `Networking` -> `Local Networks` using comma-separated CIDR notation entries.
+
+Global external access settings can be configured under `Networking` -> `Remote Access Settings`.
+User-specific external access permissions can be configured under `Users` -> `Edit User` -> `Allow remote connections to this server`.
+
+Ensure that the configured access permissions align with the network scope defined in the local network settings.
+
 ### Firewall / Port Forwarding
 
 Networks are usually divided from each other by firewalls. These block all incoming traffic and are meant to protect the network.

--- a/docs/general/post-install/setup-wizard.md
+++ b/docs/general/post-install/setup-wizard.md
@@ -33,7 +33,11 @@ Select a preferred language and region for metadata fetching as the server-wide 
 
 ## Networking Settings
 
-Some basic options for networking can be set on this page. For most users, it is recommended to **enable** the "Allow remote access to this server" option, and **disable** the "Enable automatic port mapping" option.
+Some basic networking options can be configured on this page. For most users, it is recommended to **enable** the "Allow remote access to this server" option.
+Detailed information about remote access configuration can be found in our dedicated [Networking Guide](./networking/index.md#allowing-access).
+
+Since "automatic port mapping" relies on UPnP, a protocol commonly associated with security concerns, it is recommended to **disable** this option unless it is specifically required.
+
 ![Setup Wizard Networking Page](/images/docs/post-install/setup-wizard/setup-wizard-6-networking.png)
 
 ## Next Steps


### PR DESCRIPTION
Adds a dedicated guide regarding Local Subnet configuration and its effect on the `External Access` settings.

Also adds a reference for the NETWORKING WIZARD 🗿 
<img width="314" height="314" alt="grafik" src="https://github.com/user-attachments/assets/1214b16a-f6c6-4a00-93b6-2245b3b7b0c3" />



Fixes https://github.com/jellyfin/jellyfin.org/issues/1689