### PR TITLE
enable lock file Maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>jellyfin/.github//renovate-presets/nodejs",
-    ":semanticCommitsDisabled"
-  ],
+  "extends": ["github>jellyfin/.github//renovate-presets/nodejs", ":semanticCommitsDisabled"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "description": "Disable major updates for React",
-      "matchPackageNames": [
-        "@types/react",
-        "@types/react-helmet",
-        "@types/react-router-dom",
-        "react{/,}**"
-      ],
+      "matchPackageNames": ["@types/react", "@types/react-helmet", "@types/react-router-dom", "react{/,}**"],
       "matchUpdateTypes": "major",
       "enabled": false
     }


### PR DESCRIPTION
It seems to be recommended to enable `LockFileMaintenance` to keep the browserlist-db up-to-date.
https://github.com/renovatebot/renovate/issues/8615

Alternatively we could add it directly to the project dependencies, but I think this will do the trick for us.

Fixes https://github.com/jellyfin/jellyfin.org/issues/1851