### PR TITLE
Fixed minor typo

### DIFF
--- a/docs/general/post-install/networking/index.md
+++ b/docs/general/post-install/networking/index.md
@@ -52,7 +52,7 @@ Devices like Google Chromecast or Google Streamer use hardcoded DNS Servers - th
 There are multiple workarounds for this issue.
 
 The easiest involves the usage of IPv6 Entries in the public DNS.
-Since IPv6 addresses do not differentiate between local and public, the address will be abled to be resolved locally.
+Since IPv6 addresses do not differentiate between local and public, the address will be able to be resolved locally.
 This, however, requires the use of a public DNS server - The Jellyfin Server does not have to be accessible from the outside though!
 
 </details>


### PR DESCRIPTION
Fixed typo in networking documentation regarding IPv6 addresses.

<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
<!-- Describe a little about what you've changed and why. -->

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [-] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [-] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [N/A] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
