### PR TITLE
rephrase IPv6 local DNS note

### DIFF
--- a/docs/general/post-install/networking/index.md
+++ b/docs/general/post-install/networking/index.md
@@ -48,12 +48,12 @@ However its also possible to create a local DNS entry that will point to your Je
 <details>
 <summary>Learn more about limitations with local DNS</summary>
 
-Devices like Google Chromecast or Google Streamer use hardcoded DNS Servers - therefore they will not make use of your local DNS entries.
-There are multiple workarounds for this issue.
+Devices like Google Chromecast or Google TV Streamer may ignore the DNS server provided by your local network.
+As a result, they may not resolve custom local DNS entries correctly.
 
-The easiest involves the usage of IPv6 Entries in the public DNS.
-Since IPv6 addresses do not differentiate between local and public, the address will be able to be resolved locally.
-This, however, requires the use of a public DNS server - The Jellyfin Server does not have to be accessible from the outside though!
+One option to work around this is to publish an IPv6 DNS record through a public DNS provider.
+If your Jellyfin server has a globally routable IPv6 address, devices can resolve it without relying on your local DNS server.
+The server itself does not need to be publicly accessible. Inbound access can still be restricted through your firewall.
 
 </details>
 


### PR DESCRIPTION
Rephrases the local DNS IPv6 to account for ULA's.
It has to be a globally routable adress.
Also changed the overall wording of the section minimally.