### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -132,6 +132,7 @@ Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/
     // Others
     ['@docusaurus/plugin-sitemap', {} satisfies Sitemap.Options],
     ['docusaurus-plugin-sass', {}],
+    'docusaurus-plugin-copy-page-button',
     ['@docusaurus/plugin-svgr', {}],
     [
       '@docusaurus/plugin-client-redirects',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@mdx-js/react": "3.1.1",
         "@svgr/webpack": "8.1.0",
         "clsx": "2.1.1",
+        "docusaurus-plugin-copy-page-button": "0.6.1",
         "docusaurus-plugin-sass": "0.2.6",
         "file-loader": "6.2.0",
         "react": "18.3.1",
@@ -10528,6 +10529,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.1.tgz",
+      "integrity": "sha512-84LUG23owdGlUx5rgg7lcyuuxFZ+84u9u+adYjFZ1E5lM+g6bkduOGcZXLUqbI0R2Ve2RjG0OPv2KaL01tGW4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/docusaurus-plugin-sass": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@mdx-js/react": "3.1.1",
     "@svgr/webpack": "8.1.0",
     "clsx": "2.1.1",
+    "docusaurus-plugin-copy-page-button": "0.6.1",
     "docusaurus-plugin-sass": "0.2.6",
     "file-loader": "6.2.0",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary
- add `docusaurus-plugin-copy-page-button` to the docs dependencies
- register the plugin in `docusaurus.config.ts`

## Why
Jellyfin docs include setup, administration, and user reference pages that are useful to bring into AI tools. This adds a page-level copy/open button that exports the current page as clean markdown and includes one-click Open in ChatGPT, Claude, and Gemini actions.

I checked the repo first for existing page-level copy/Open-in-AI UI and LLM export features (`CopyPageButton`, `DocActionsDropdown`, `copy as markdown`, `Open in ChatGPT`, `Open in Claude`, `llms.txt`, `docusaurus-plugin-llms`, and similar terms) and did not find an overlapping feature.

The plugin has no runtime dependencies and uses peer dependencies for Docusaurus and React.

## Validation
- `git diff --check`
- package manifest, lockfile, and config sanity check

Not run locally: full docs build.