### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -139,7 +139,8 @@ Site content is licensed <a href='http://creativecommons.org/licenses/by-nd/4.0/
         fromExtensions: ['html'],
         redirects: redirects
       } satisfies ClientRedirects.Options
-    ]
+    ],
+    'docusaurus-plugin-copy-page-button'
   ],
   themes: [
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@mdx-js/react": "3.1.1",
         "@svgr/webpack": "8.1.0",
         "clsx": "2.1.1",
+        "docusaurus-plugin-copy-page-button": "0.6.2",
         "docusaurus-plugin-sass": "0.2.6",
         "file-loader": "6.2.0",
         "react": "18.3.1",
@@ -10528,6 +10529,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.2.tgz",
+      "integrity": "sha512-RbldmCJ6FEYx515ptp1Ei9WwQAQyK6ty5UaHVaSlOyBfh/Nm+wu+6y3g/V7sVejBrMCxpGLnAuIJn3h8nqdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/docusaurus-plugin-sass": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@mdx-js/react": "3.1.1",
     "@svgr/webpack": "8.1.0",
     "clsx": "2.1.1",
+    "docusaurus-plugin-copy-page-button": "0.6.2",
     "docusaurus-plugin-sass": "0.2.6",
     "file-loader": "6.2.0",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary

Adds [`docusaurus-plugin-copy-page-button`](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) to the Jellyfin docs site so readers can copy any documentation page as clean markdown — handy for piping install/config troubleshooting context into ChatGPT, Claude, Perplexity, or Gemini.

The plugin auto-injects a small "Copy page" button + dropdown into the doc page's table-of-contents area. The dropdown offers:

- Copy as markdown
- View as markdown
- Open in ChatGPT / Claude / Perplexity / Gemini

Live preview of the UI: https://portdeveloper.github.io/copy-page-button-showcase/

## Adoption

The plugin currently ships on the docs sites for React Native (just merged via facebook/react-native-website#5085), Puppeteer, Arbitrum, Cardano, Sui, Ethereum execution-apis, and several others — full list in the [project README](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button#used-by).

## Changes

- Added `'docusaurus-plugin-copy-page-button'` to the `plugins` array in `docusaurus.config.ts`
- Added `docusaurus-plugin-copy-page-button@0.6.2` to `dependencies`
- Resulting `package-lock.json` updates

`npm run build` passes locally.

## Copyediting

Config-only change — no prose to spellcheck, so the template's `aspell` / peer-copyediting items don't apply. Happy to adjust if anything in the docs/config needs tweaking.