### PR TITLE
clients.ts: remove Gelli, add Gelli fork Jamfish

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -524,35 +524,6 @@ const thirdPartyClients: Array<Client> = [
     ]
   },
   {
-    id: 'gelli',
-    name: 'Gelli',
-    description:
-      'A native music player for Android devices with transcoding support, gapless playback, favorites, playlists, and many other features.',
-    clientType: ClientType.ThirdParty,
-    deviceTypes: [DeviceType.Mobile],
-    licenseType: LicenseType.OpenSource,
-    platforms: [Platform.Android],
-    primaryLinks: [
-      {
-        id: 'gh-downloads',
-        name: 'GitHub Downloads',
-        url: 'https://github.com/dkanada/gelli/releases'
-      },
-      {
-        id: 'fdroid',
-        name: 'F-Droid',
-        url: 'https://f-droid.org/packages/com.dkanada.gramophone/'
-      }
-    ],
-    secondaryLinks: [
-      {
-        id: 'github',
-        name: 'GitHub',
-        url: 'https://github.com/dkanada/gelli'
-      }
-    ]
-  },
-  {
     id: 'finamp',
     name: 'Finamp',
     description: 'A third party app for music playback with support for offline mode/downloading songs.',
@@ -1002,6 +973,35 @@ const thirdPartyClients: Array<Client> = [
         id: 'website',
         name: 'Website',
         url: 'https://jellify.app'
+      }
+    ]
+  },
+    {
+    id: 'jamfish',
+    name: 'Jamfish',
+    description:
+      'Delicious native Android music player for Jellyfin, based on Gelli.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile],
+    licenseType: LicenseType.OpenSource,
+    platforms: [Platform.Android],
+    primaryLinks: [
+      {
+        id: 'gh-downloads',
+        name: 'GitHub Downloads',
+        url: 'https://github.com/adrianvic/jamfish/releases'
+      },
+      {
+        id: 'fdroid',
+        name: 'F-Droid',
+        url: 'https://f-droid.org/en/packages/org.adrianvictor.geleia/'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/adrianvic/jamfish'
       }
     ]
   }


### PR DESCRIPTION
Gelli is now archived. However, Jamfish is a fork of Gelli which appears to be maintained.

**Changes**
Update clients list.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [ ] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
  - --> trivial change
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).
  - --> trivial change

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**
None.
