### PR TITLE
Move server filters into card

### DIFF
--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -60,8 +60,51 @@ export default function DownloadsPage(options: { osType?: OsType }) {
               </div>
             </div>
 
-            <div className={clsx('col', 'margin-bottom--md', styles['header-pills-middle'])}>
-              <div className='pills' style={{ overflowX: 'auto' }}>
+            <div className={clsx('col', 'margin-bottom--md', styles['header-pills-end'])}>
+              <a href='https://github.com/jellyfin/jellyfin/releases/latest'>
+                <img alt='Current Release' src='https://img.shields.io/github/release/jellyfin/jellyfin.svg' />
+              </a>
+            </div>
+          </div>
+
+          <div className='card card--outline margin-bottom--md'>
+            <div className='card__body'>
+              <div className={clsx('pills', styles['filter-pills'], 'margin-bottom--md')}>
+                <ul className={clsx('pills', 'margin-bottom--none', styles['stable-links'])}>
+                  <Pill
+                    active={!isStableLinks}
+                    onClick={() => {
+                      setIsStableLinks(false);
+                      setActiveButton(null);
+                    }}
+                  >
+                    Unstable
+                  </Pill>
+                  <Pill
+                    active={isStableLinks}
+                    onClick={() => {
+                      setIsStableLinks(true);
+                      setActiveButton(null);
+                    }}
+                  >
+                    Stable
+                  </Pill>
+                </ul>
+
+                <button
+                  className='button button--link'
+                  onClick={() => {
+                    setIsStableHelpVisible(!isStableHelpVisible);
+                  }}
+                  style={{
+                    verticalAlign: 'baseline'
+                  }}
+                >
+                  Help?
+                </button>
+              </div>
+
+              <div className={clsx('pills', styles['filter-pills'], 'margin-bottom--md')}>
                 <Link
                   to='/downloads/linux'
                   className={clsx('pills__item', { 'pills__item--active': osType === OsType.Linux })}
@@ -94,47 +137,6 @@ export default function DownloadsPage(options: { osType?: OsType }) {
                 </Link>
               </div>
             </div>
-
-            <div className={clsx('col', 'margin-bottom--md', styles['header-pills-end'])}>
-              <ul className={clsx('pills', 'margin-bottom--none', styles['stable-links'])}>
-                <Pill
-                  active={!isStableLinks}
-                  onClick={() => {
-                    setIsStableLinks(false);
-                    setActiveButton(null);
-                  }}
-                >
-                  Unstable
-                </Pill>
-                <Pill
-                  active={isStableLinks}
-                  onClick={() => {
-                    setIsStableLinks(true);
-                    setActiveButton(null);
-                  }}
-                >
-                  Stable
-                </Pill>
-              </ul>
-
-              <button
-                className='button button--link'
-                onClick={() => {
-                  setIsStableHelpVisible(!isStableHelpVisible);
-                }}
-                style={{
-                  verticalAlign: 'baseline'
-                }}
-              >
-                Help?
-              </button>
-            </div>
-          </div>
-
-          <div className='text--center margin-bottom--md'>
-            <a href='https://github.com/jellyfin/jellyfin/releases/latest'>
-              <img alt='Current Release' src='https://img.shields.io/github/release/jellyfin/jellyfin.svg' />
-            </a>
           </div>
 
           {isStableHelpVisible && (

--- a/src/pages/downloads/server.tsx
+++ b/src/pages/downloads/server.tsx
@@ -104,7 +104,7 @@ export default function DownloadsPage(options: { osType?: OsType }) {
                 </button>
               </div>
 
-              <div className={clsx('pills', styles['filter-pills'], 'margin-bottom--md')}>
+              <div className={clsx('pills', styles['filter-pills'])}>
                 <Link
                   to='/downloads/linux'
                   className={clsx('pills__item', { 'pills__item--active': osType === OsType.Linux })}


### PR DESCRIPTION
<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
This PR moves stable/unstable and OS selection into a card like on the client downloads page.
This is in order to improve the readability of the page and in preparation for the redesign discussed https://github.com/jellyfin/jellyfin.org/issues/1878

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [ ] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
