### PR TITLE
Move client filter into filter card

### DIFF
--- a/src/pages/downloads/clients/index.tsx
+++ b/src/pages/downloads/clients/index.tsx
@@ -106,23 +106,6 @@ export default function ClientsPage({ recommended = true }: { recommended?: bool
               </div>
             </div>
 
-            <div className={clsx('col', 'margin-bottom--md', styles['header-pills-middle'])}>
-              <div className='pills'>
-                <Link
-                  to={`/downloads/clients${location.search}`}
-                  className={clsx('pills__item', { 'pills__item--active': filter.recommended })}
-                >
-                  Recommended
-                </Link>
-                <Link
-                  to={`/downloads/clients/all${location.search}`}
-                  className={clsx('pills__item', { 'pills__item--active': !filter.recommended })}
-                >
-                  All
-                </Link>
-              </div>
-            </div>
-
             <div className={clsx('col', 'margin-bottom--md', styles['header-pills-end'])}>
               <button
                 className={clsx(
@@ -146,6 +129,23 @@ export default function ClientsPage({ recommended = true }: { recommended?: bool
           {isFiltersVisible && (
             <div className='card card--outline margin-bottom--md'>
               <div className='card__body'>
+                <div className={clsx('pills', styles['filter-pills'], 'margin-bottom--md')}>
+                  <div className='pills'>
+                    <Link
+                      to={`/downloads/clients/all${location.search}`}
+                      className={clsx('pills__item', { 'pills__item--active': !filter.recommended })}
+                    >
+                      All Clients
+                    </Link>
+                    <Link
+                      to={`/downloads/clients${location.search}`}
+                      className={clsx('pills__item', { 'pills__item--active': filter.recommended })}
+                    >
+                      Recommended
+                    </Link>
+                  </div>
+                </div>
+
                 <ul className={clsx('pills', styles['filter-pills'], 'margin-bottom--md')}>
                   <Pill
                     active={filter.deviceTypes.length === 0}


### PR DESCRIPTION
<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
This PR moves the  `all`/`recommended` filter into the filter box.
This is in order to improve the readability of the page and in preparation for the redesign discussed https://github.com/jellyfin/jellyfin.org/issues/1878
This also goes hand in hand with https://github.com/jellyfin/jellyfin.org/pull/1886 where filters will always be visible.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [ ] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
