### PR TITLE
make proxy-header config slightly more obvious

### DIFF
--- a/docs/general/post-install/networking/8_reverse-proxy/index.md
+++ b/docs/general/post-install/networking/8_reverse-proxy/index.md
@@ -27,7 +27,7 @@ When traffic is forwarded through a reverse proxy, Jellyfin sees the proxy’s I
 This introduces potential security risks and can also break compatibility, since Jellyfin will not be able to differentiate between local and remote connections.
 Therefore, if set up incorrectly, all limitations for external access will not work.
 
-Therefore, the IP address(es) of your reverse proxy must be configured under “Known Proxies” in Jellyfin’s **Network** settings.
+Therefore, **the IP address(es) of your reverse proxy must be configured under “Known Proxies”** in Jellyfin’s Network settings.
 This allows Jellyfin to respect the `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers and use the associated value as the source IP address. By default, Jellyfin will discard all forwarded-for headers that do not originate from a "known Proxy". This is so that malicious devices will not be able to hide their IP address by providing a forwarded-for header.
 
 This assumes that the reverse proxy is set up to include this header, which is not always the case by default.

--- a/docs/general/post-install/networking/index.md
+++ b/docs/general/post-install/networking/index.md
@@ -66,7 +66,7 @@ These ranges can be configured under `Networking` -> `Local Networks` using comm
 
 Global external access settings can be configured under `Networking` -> `Remote Access Settings`.
 User-specific external access permissions can be configured under `Users` -> `Edit User` -> `Allow remote connections to this server`.
-External access settings through a reverse proxy will only work if [proxy headers](./8_reverse-proxy/index.md#forwarded-for-headers) are set up correctly!
+External access settings through a reverse proxy will only work if [known proxies](./8_reverse-proxy/index.md#forwarded-for-headers) are set up correctly!
 
 Ensure that the configured access permissions align with the network scope defined in the local network settings.
 

--- a/docs/general/post-install/networking/index.md
+++ b/docs/general/post-install/networking/index.md
@@ -66,6 +66,7 @@ These ranges can be configured under `Networking` -> `Local Networks` using comm
 
 Global external access settings can be configured under `Networking` -> `Remote Access Settings`.
 User-specific external access permissions can be configured under `Users` -> `Edit User` -> `Allow remote connections to this server`.
+External access settings through a reverse proxy will only work if [proxy headers](./8_reverse-proxy/index.md#forwarded-for-headers) are set up correctly!
 
 Ensure that the configured access permissions align with the network scope defined in the local network settings.
 


### PR DESCRIPTION
Since a lot of bug-reports and troubleshooting comes from users not setting the `Known Proxies` within Jellyfin, this needs to be made more obvious in the documentation.

This is not really an Ideal fix, but at least references to this are added.
- add forwarded-for reference to the "external access controls" Section
- set "known proxies" Text to bold

feature requested by @theguymadmax 