### PR TITLE
Update recommended TLD in internal networking

### DIFF
--- a/docs/general/post-install/networking/index.md
+++ b/docs/general/post-install/networking/index.md
@@ -43,7 +43,7 @@ This section focusses on how to make Jellyfin Available within Networks.
 Here you will find descriptions on how to make Jellyfin accessible both only locally and through the Internet.
 
 In general, Jellyfin will be available locally on the specified port over the host-ip - e.g. `http://10.0.0.2:8096`.
-However its also possible to create a local DNS entry that will point to your Jellyfin-Server - e.g. `http://jellyfin.local:8096`.
+However its also possible to create a local DNS entry that will point to your Jellyfin-Server - e.g. `http://jellyfin.internal:8096`.
 
 <details>
 <summary>Learn more about limitations with local DNS</summary>


### PR DESCRIPTION
Switch from .local to .internal, as .local is bad practice for internal DNS (conflicts with mDNS). .internal is a reserved TLD more appropriate for such use cases.

See e. g. https://unix.stackexchange.com/questions/92441/whats-the-difference-between-local-home-and-lan for more information.

Alternatively, .home.arpa is another reserved TLD for internal use.

<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
<!-- Describe a little about what you've changed and why. -->

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
