### PR TITLE
move docker on windows warning

### DIFF
--- a/docs/general/installation/_container-docker-cli.md
+++ b/docs/general/installation/_container-docker-cli.md
@@ -2,19 +2,6 @@
 
 [Docker](https://www.docker.com/) allows you to run containers on Linux, Windows and MacOS.
 
-:::warning
-
-If you wish to use Windows or macOS, please install Jellyfin natively instead. [Windows](/docs/general/installation/windows) [macOS](/docs/general/installation/macos).
-
-While it is possible to run Jellyfin in Docker on a Windows or macOS host, it is NOT supported. Some features are known to be broken when running in Docker on platforms other than Linux, Notably:
-
-- Hardware Accelerated Transcoding
-- [Scanning on macOS in Docker](https://github.com/jellyfin/jellyfin/issues/13093)
-
-You WILL NOT receive any support for running Jellyfin in Docker on platforms other than Linux.
-
-:::
-
 The basic steps to create and run a Jellyfin container using Docker are as follows.
 
 1. Follow the [official installation guide to install Docker](https://docs.docker.com/engine/install).

--- a/docs/general/installation/_container-docker-compose.md
+++ b/docs/general/installation/_container-docker-compose.md
@@ -1,18 +1,5 @@
 <!-- markdownlint-disable MD041 -->
 
-:::warning
-
-If you wish to use Windows or macOS, please install Jellyfin natively instead. [Windows](/docs/general/installation/windows) [macOS](/docs/general/installation/macos).
-
-While it is possible to run Jellyfin in Docker on a Windows or macOS host, it is NOT supported. Some features are known to be broken when running in Docker on platforms other than Linux, Notably:
-
-- Hardware Accelerated Transcoding
-- [Scanning on macOS in Docker](https://github.com/jellyfin/jellyfin/issues/13093)
-
-You WILL NOT receive any support for running Jellyfin in Docker on platforms other than Linux.
-
-:::
-
 Create a `docker-compose.yml` file like the following.
 
 ```yml

--- a/docs/general/installation/container.md
+++ b/docs/general/installation/container.md
@@ -31,6 +31,19 @@ Additionally, there are several third parties providing unofficial container ima
 
 ## Installation Instructions
 
+:::warning
+
+If you wish to use [Windows](/docs/general/installation/windows) or [macOS](/docs/general/installation/macos), please install Jellyfin natively instead.
+
+While it is possible to run Jellyfin in a Container on a Windows or macOS host, it is NOT supported. Some features are known to be broken when running in a Container on platforms other than Linux, Notably:
+
+- Hardware Accelerated Transcoding
+- [Scanning on macOS in Docker](https://github.com/jellyfin/jellyfin/issues/13093)
+
+You WILL NOT receive any support for running Jellyfin in a Container on platforms other than Linux.
+
+:::
+
 Replace `uid:gid` if you want to run jellyfin as a specific user/group. Exclude the `user` argument entirely if you want to use the default user.
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
The install Instructions for Docker/Compose/Podman are in reusable "Tabs".
The warning to not install within a Container is universal for all three.

Additionally this makes reusing the Container Tabs (e.g. in the proposed QNAP Guide in the documentation Chatroom) a lot harder, since it is specifically mentioning Windows.

This PR moves the admonition outside of the reusable tabs and places it directly above.
Since podman also exists for Windows and will also run in WSL2, the admonition phrasing has been changed from "Docker" to "a Container".

Bonus:
Embedded the references to the Platform specific guides to avoid ending a sentence with: Windows MacOS :moyai: 

Before:
<img width="925" height="110" alt="grafik" src="https://github.com/user-attachments/assets/92272aa6-d574-4307-a3eb-61e9300cffda" />


Now:
<img width="682" height="104" alt="grafik" src="https://github.com/user-attachments/assets/054ee61e-c71b-4bd0-bf02-bd2120742ee8" />
