### PR TITLE
initial issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Jellyfin contact
+    url: https://jellyfin.org/contact/
+    about: Our community is ready to help you get started with Jellyfin

--- a/.github/ISSUE_TEMPLATE/incorrect_documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/incorrect_documentation.yaml
@@ -1,0 +1,56 @@
+name: Incorrect documentation
+description: Report outdated or incorrect documentation.
+labels:
+  - bug
+  - documentation
+body:
+  - type: checkboxes
+    id: before-posting
+    attributes:
+      label: 'This issue respects the following points:'
+      description: All conditions are **required**.
+      options:
+        - label: This issue is **not** already reported on [GitHub](https://github.com/jellyfin/jellyfin.org/issues?q=is%3Aopen+is%3Aissue) _(I've searched it)_.
+          required: true
+        - label: I agree to follow Jellyfin's [Code of Conduct](https://jellyfin.org/docs/general/community-standards.html#code-of-conduct).
+          required: true
+        - label: This report addresses only a single issue; If you encounter multiple issues, kindly create separate reports for each one.
+          required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Documentation information
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the incorrect documentation
+      description: |
+        A clear and exact description of the incorrect documentation.
+      placeholder: |
+        Under `Post-Install Setup > Networking`, Port 8096 is listed as the default port for HTTP, but it should be XYZ.
+        This came with the release of Jellyfin 10.1.1, where the default port was changed to XYZ.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: suggestion
+      description: |
+        Suggest how to correct the documentation.
+      placeholder: |
+        The default port for HTTP should be XYZ.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Additional
+  - type: input
+    id: other-sources
+    attributes:
+      label: Other sources
+      description: Please link the related forum topics or chat messages that prompted you open this issue.
+      placeholder: https://forum.jellyfin.org/…
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new_documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/new_documentation.yaml
@@ -1,0 +1,55 @@
+name: New/expand documentation
+description: Request new documentation for a feature or functionality that is missing.
+labels:
+  - enhancement
+  - documentation
+body:
+  - type: checkboxes
+    id: before-posting
+    attributes:
+      label: 'This issue respects the following points:'
+      description: All conditions are **required**.
+      options:
+        - label: This issue is **not** already reported on [GitHub](https://github.com/jellyfin/jellyfin.org/issues?q=is%3Aopen+is%3Aissue) _(I've searched it)_.
+          required: true
+        - label: I agree to follow Jellyfin's [Code of Conduct](https://jellyfin.org/docs/general/community-standards.html#code-of-conduct).
+          required: true
+        - label: This report addresses only a single issue; If you encounter multiple issues, kindly create separate reports for each one.
+          required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Documentation information
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the missing documentation
+      description: |
+        A clear and exact description of the missing documentation.
+      placeholder: |
+        There is no documentation on how to install Jellyfin on Docker. This would be helpful for ...
+    validations:
+      required: true
+  - type: textarea
+    id: reasoning
+    attributes:
+      label: reasoning
+      description: |
+        Explain why this documentation is needed.
+      placeholder: |
+        This documentation would help users who are new to Docker and want to run Jellyfin in a container.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Additional
+  - type: input
+    id: other-sources
+    attributes:
+      label: Other sources
+      description: Please link the related forum topics or chat messages that prompted you open this issue.
+      placeholder: https://forum.jellyfin.org/…
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/website_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/website_issue.yaml
@@ -1,0 +1,66 @@
+name: Website problem or improvement
+description: Report a website bug, rendering issue, navigation problem, search issue, accessibility concern, or a suggestion for improvement.
+labels:
+  - bug
+  - enhancement
+body:
+  - type: checkboxes
+    id: before-posting
+    attributes:
+      label: 'This issue respects the following points:'
+      description: All conditions are **required**.
+      options:
+        - label: This issue is **not** already reported on [GitHub](https://github.com/jellyfin/jellyfin.org/issues?q=is%3Aopen+is%3Aissue) _(I've searched it)_.
+          required: true
+        - label: I agree to follow Jellyfin's [Code of Conduct](https://jellyfin.org/docs/general/community-standards.html#code-of-conduct).
+          required: true
+        - label: This report addresses only a single issue; If you encounter multiple issues, kindly create separate reports for each one.
+          required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Website information
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the website issue or improvement
+      description: |
+        A clear and exact description of the problem or the improvement you would like to see.
+      placeholder: |
+        The mobile navigation menu overlaps the page content on the downloads page and cannot be closed.
+        The search box should return relevant results for docs and blog posts.
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Where does it happen?
+      description: |
+        Specify the affected page, section, or component.
+      placeholder: |
+        The home page hero section, the downloads page, the top navigation, the search bar, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: expectation
+    attributes:
+      label: What is the expected behavior?
+      description: |
+        Explain what should happen instead or how the improvement should work.
+      placeholder: |
+        The menu should open and close correctly, and the search should return useful results without breaking the page.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Additional
+  - type: input
+    id: other-sources
+    attributes:
+      label: Other sources
+      description: Please link any related forum topics, screenshots, or chat messages that prompted you to open this issue.
+      placeholder: https://forum.jellyfin.org/…
+    validations:
+      required: false


### PR DESCRIPTION
Issues on the Jellydocs have mostly gone untriaged.
Part of this is the fact that there are no suggested fixes or even clear issue descriptions.

Since I have had some time, I decided to FINALLY add those to the GitHub Repo.
Please feel free to provide feedback on them.

They are heavily based on the issue forms from the other Jelly fin-repositories at the moment.
