### PR TITLE
Document SQLite database tuning and cache_size for large libraries

### DIFF
--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -114,7 +114,7 @@ This section lists all the configuration options available and explains their fu
 
 ## Database
 
-Jellyfin stores its library metadata in a SQLite database (`jellyfin.db`) inside the [data directory](#data-directory). Since 10.11 the SQLite provider can be tuned through a `database.xml` file in the [configuration directory](#configuration-directory). This file is optional. If it is missing, the built in defaults are used.
+By default, Jellyfin stores its library metadata in a SQLite database (`<Data Directory>/jellyfin.db`) in the [data directory](#data-directory). Set the `path` custom database option to use a different database file. Since 10.11 the SQLite provider can be tuned through a `database.xml` file in the [configuration directory](#configuration-directory). This file is optional. If it is missing, the built in defaults are used.
 
 Most installs never need to touch this. The main reason to tune it is a large library (roughly 100k+ items) where broad queries such as `/Artists`, `/Studios` and `/Genres` feel slow, which is usually the SQLite page cache being too small to hold the working set (see [jellyfin/jellyfin#17405](https://github.com/jellyfin/jellyfin/issues/17405)).
 
@@ -127,10 +127,10 @@ Most installs never need to touch this. The main reason to tune it is a large li
   <LockingBehavior>NoLock</LockingBehavior>
   <CustomProviderOptions>
     <Options>
-      <!-- 1024 * 1024 * 1024 / 4096 = 1G -->
+      <!-- 256 MiB: negative cache_size values specify KiB -->
       <CustomDatabaseOption>
         <Key>cacheSize</Key>
-        <Value>262144</Value>
+        <Value>-262144</Value>
       </CustomDatabaseOption>
     </Options>
   </CustomProviderOptions>
@@ -141,7 +141,8 @@ Each knob is a `CustomDatabaseOption` with a `Key` and a `Value` child element. 
 
 | Key                 | Default            | Description                                                                                                             |
 | ------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `cacheSize`         | unset (SQLite 2 MiB) | SQLite `cache_size`. A **positive** value is a number of pages, so the resulting memory depends on the page size (`262144` pages is ~1 GiB at a 4 KiB page size). A **negative** value is a size in KiB and is page-size independent, so `-262144` is always 256 MiB. Prefer the negative form to get a predictable memory footprint. Applied per connection. |
+| `path`              | `<Data Directory>/jellyfin.db` | SQLite database file path.                                                                                             |
+| `cacheSize`         | unset (~2 MiB)     | SQLite `cache_size`. A **positive** value is a page count, so the resulting memory depends on the page size (`262144` pages is ~1 GiB at a 4 KiB page size). A **negative** value requests approximately that many KiB, which SQLite converts to a page count using the current page size, so `-262144` requests approximately 256 MiB. Prefer the negative form instead of choosing a page count manually. Applied per connection. |
 | `lockingmode`       | `NORMAL`           | SQLite `locking_mode`.                                                                                                   |
 | `journalsizelimit`  | `134217728`        | SQLite `journal_size_limit` in bytes.                                                                                    |
 | `tempstoremode`     | `2`                | SQLite `temp_store` (`2` is memory).                                                                                     |
@@ -160,7 +161,7 @@ Any additional PRAGMA can be set by prefixing the key with `#PRAGMA:`, for examp
 
 ### Cache size and large libraries
 
-`cacheSize` is the setting that matters most for large libraries. SQLite defaults to a 2 MiB page cache. On a large database the metadata queries touch more pages than that in a single request, so the cache thrashes and pages are re-read from disk on every call.
+`cacheSize` is the setting that matters most for large libraries. When it is unset, Jellyfin does not emit `PRAGMA cache_size`, so SQLite's default suggested cache size of `-2000` (2,048,000 bytes, approximately 2 MiB) applies. On a large database the metadata queries touch more pages than that in a single request, so the cache thrashes and pages are re-read from disk on every call.
 
 Raising `cache_size` so the hot working set stays in memory removes the thrashing. On a 189k item library, setting `cacheSize` to `-262144` (256 MiB) dropped `/Studios` from tens of seconds to roughly 2 to 3 seconds. The gain flattens out once the cache is large enough to hold the working set, so there is little point going much beyond a couple hundred MiB.
 

--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -114,9 +114,19 @@ This section lists all the configuration options available and explains their fu
 
 ## Database
 
+:::danger
+
+The options below are for advanced users only.
+
+A wrong value can corrupt the database. Back up the database before you change any option here.
+
+These options are not part of the stable API. Jellyfin can change or remove them in any release. Jellyfin does not migrate the values you set.
+
+:::
+
 By default, Jellyfin stores its library metadata in a SQLite database (`<Data Directory>/jellyfin.db`) in the [data directory](#data-directory). Set the `path` custom database option to use a different database file. Since 10.11 the SQLite provider can be tuned through a `database.xml` file in the [configuration directory](#configuration-directory). This file is optional. If it is missing, the built in defaults are used.
 
-Most installs never need to touch this. The main reason to tune it is a large library (roughly 100k+ items) where broad queries such as `/Artists`, `/Studios` and `/Genres` feel slow, which is usually the SQLite page cache being too small to hold the working set (see [jellyfin/jellyfin#17405](https://github.com/jellyfin/jellyfin/issues/17405)).
+Most installs keep the defaults. These options exist for administrators of very large libraries who investigate slow metadata queries (see [jellyfin/jellyfin#17405](https://github.com/jellyfin/jellyfin/issues/17405)).
 
 ### database.xml
 
@@ -142,7 +152,7 @@ Each knob is a `CustomDatabaseOption` with a `Key` and a `Value` child element. 
 | Key                 | Default            | Description                                                                                                             |
 | ------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | `path`              | `<Data Directory>/jellyfin.db` | SQLite database file path.                                                                                             |
-| `cacheSize`         | unset (~2 MiB)     | SQLite `cache_size`. A **positive** value is a page count, so the resulting memory depends on the page size (`262144` pages is ~1 GiB at a 4 KiB page size). A **negative** value requests approximately that many KiB, which SQLite converts to a page count using the current page size, so `-262144` requests approximately 256 MiB. Prefer the negative form instead of choosing a page count manually. Applied per connection. |
+| `cacheSize`         | unset              | SQLite `cache_size`, applied per connection. A positive value is a page count. A negative value is a size in KiB, so `-262144` is about 256 MiB. See the [SQLite documentation](https://www.sqlite.org/pragma.html#pragma_cache_size). |
 | `lockingmode`       | `NORMAL`           | SQLite `locking_mode`.                                                                                                   |
 | `journalsizelimit`  | `134217728`        | SQLite `journal_size_limit` in bytes.                                                                                    |
 | `tempstoremode`     | `2`                | SQLite `temp_store` (`2` is memory).                                                                                     |
@@ -161,16 +171,11 @@ Any additional PRAGMA can be set by prefixing the key with `#PRAGMA:`, for examp
 
 ### Cache size and large libraries
 
-`cacheSize` is the setting that matters most for large libraries. When it is unset, Jellyfin does not emit `PRAGMA cache_size`, so SQLite's default suggested cache size of `-2000` (2,048,000 bytes, approximately 2 MiB) applies. On a large database the metadata queries touch more pages than that in a single request, so the cache thrashes and pages are re-read from disk on every call.
+Some users report that a higher `cacheSize` speeds up broad metadata queries on very large libraries. Other users see no change.
 
-Raising `cache_size` so the hot working set stays in memory removes the thrashing. On a 189k item library, setting `cacheSize` to `-262144` (256 MiB) dropped `/Studios` from tens of seconds to roughly 2 to 3 seconds. The gain flattens out once the cache is large enough to hold the working set, so there is little point going much beyond a couple hundred MiB.
+Query speed depends on many things. Storage speed, free memory, CPU and the library contents all affect it. A higher `cacheSize` is not a general recommendation.
 
-Guidance:
-
-- Small libraries or low memory devices (Raspberry Pi, small NAS): leave it unset, or set a modest `-16384` (16 MiB).
-- Large libraries with memory to spare: `-131072` (128 MiB) or `-262144` (256 MiB).
-
-The value is per connection and allocated lazily, so it is an upper bound rather than a fixed reservation. Pick a value that fits comfortably within the memory available to the server. `cache_size` only affects performance, never query results, so it is safe to change.
+To test `cacheSize` on your server, raise the value in steps and measure each step. The value applies per connection, so keep it well inside the memory available to Jellyfin. If you leave `cacheSize` unset, SQLite uses its own default.
 
 ## Fonts
 

--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -126,13 +126,16 @@ Most installs never need to touch this. The main reason to tune it is a large li
   <DatabaseType>Jellyfin-SQLite</DatabaseType>
   <CustomProviderOptions>
     <Options>
-      <CustomDatabaseOption Key="cacheSize" Value="-262144" />
+      <CustomDatabaseOption>
+        <Key>cacheSize</Key>
+        <Value>-262144</Value>
+      </CustomDatabaseOption>
     </Options>
   </CustomProviderOptions>
 </DatabaseConfigurationOptions>
 ```
 
-Each knob is a `CustomDatabaseOption` with a `Key` and a `Value`. The available keys:
+Each knob is a `CustomDatabaseOption` with a `Key` and a `Value` child element. The available keys:
 
 | Key                 | Default            | Description                                                                                                             |
 | ------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |

--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -139,7 +139,7 @@ Each knob is a `CustomDatabaseOption` with a `Key` and a `Value` child element. 
 
 | Key                 | Default            | Description                                                                                                             |
 | ------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `cacheSize`         | unset (SQLite 2 MiB) | SQLite `cache_size`. A positive value is a page count. A negative value is a size in KiB, so `-262144` is 256 MiB. Applied per connection. |
+| `cacheSize`         | unset (SQLite 2 MiB) | SQLite `cache_size`. A **positive** value is a number of pages, so the resulting memory depends on the page size (`262144` pages is ~1 GiB at a 4 KiB page size). A **negative** value is a size in KiB and is page-size independent, so `-262144` is always 256 MiB. Prefer the negative form to get a predictable memory footprint. Applied per connection. |
 | `lockingmode`       | `NORMAL`           | SQLite `locking_mode`.                                                                                                   |
 | `journalsizelimit`  | `134217728`        | SQLite `journal_size_limit` in bytes.                                                                                    |
 | `tempstoremode`     | `2`                | SQLite `temp_store` (`2` is memory).                                                                                     |

--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -112,6 +112,53 @@ This section lists all the configuration options available and explains their fu
 | `FFmpeg:analyzeduration` | `"200M"`                               | The value to set for the FFmpeg `analyzeduration` format option. See the FFmpg [documentation](https://ffmpeg.org/ffmpeg-formats.html#Format-Options) for more details. |
 | `PublishedServerUrl`     | Server Url based on primary IP address | The Server URL to publish in udp Auto Discovery response.                                                                                                               |
 
+## Database
+
+Jellyfin stores its library metadata in a SQLite database (`jellyfin.db`) inside the [data directory](#data-directory). Since 10.11 the SQLite provider can be tuned through a `database.xml` file in the [configuration directory](#configuration-directory). This file is optional. If it is missing, the built in defaults are used.
+
+Most installs never need to touch this. The main reason to tune it is a large library (roughly 100k+ items) where broad queries such as `/Artists`, `/Studios` and `/Genres` feel slow, which is usually the SQLite page cache being too small to hold the working set (see [jellyfin/jellyfin#17405](https://github.com/jellyfin/jellyfin/issues/17405)).
+
+### database.xml
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<DatabaseConfigurationOptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <DatabaseType>Jellyfin-SQLite</DatabaseType>
+  <CustomProviderOptions>
+    <Options>
+      <CustomDatabaseOption Key="cacheSize" Value="-262144" />
+    </Options>
+  </CustomProviderOptions>
+</DatabaseConfigurationOptions>
+```
+
+Each knob is a `CustomDatabaseOption` with a `Key` and a `Value`. The available keys:
+
+| Key                 | Default            | Description                                                                                                             |
+| ------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `cacheSize`         | unset (SQLite 2 MiB) | SQLite `cache_size`. A positive value is a page count. A negative value is a size in KiB, so `-262144` is 256 MiB. Applied per connection. |
+| `lockingmode`       | `NORMAL`           | SQLite `locking_mode`.                                                                                                   |
+| `journalsizelimit`  | `134217728`        | SQLite `journal_size_limit` in bytes.                                                                                    |
+| `tempstoremode`     | `2`                | SQLite `temp_store` (`2` is memory).                                                                                     |
+| `syncmode`          | `1`                | SQLite `synchronous` (`1` is NORMAL).                                                                                    |
+| `pooling`           | `True`             | Enable connection pooling.                                                                                              |
+| `command-timeout`   | `60`               | Command timeout in seconds.                                                                                              |
+
+Any additional PRAGMA can be set by prefixing the key with `#PRAGMA:`, for example `<CustomDatabaseOption Key="#PRAGMA:mmap_size" Value="268435456" />`.
+
+### Cache size and large libraries
+
+`cacheSize` is the setting that matters most for large libraries. SQLite defaults to a 2 MiB page cache. On a large database the metadata queries touch more pages than that in a single request, so the cache thrashes and pages are re-read from disk on every call.
+
+Raising `cache_size` so the hot working set stays in memory removes the thrashing. On a 189k item library, setting `cacheSize` to `-262144` (256 MiB) dropped `/Studios` from tens of seconds to roughly 2 to 3 seconds. The gain flattens out once the cache is large enough to hold the working set, so there is little point going much beyond a couple hundred MiB.
+
+Guidance:
+
+- Small libraries or low memory devices (Raspberry Pi, small NAS): leave it unset, or set a modest `-16384` (16 MiB).
+- Large libraries with memory to spare: `-131072` (128 MiB) or `-262144` (256 MiB).
+
+The value is per connection and allocated lazily, so it is an upper bound rather than a fixed reservation. Pick a value that fits comfortably within the memory available to the server. `cache_size` only affects performance, never query results, so it is safe to change.
+
 ## Fonts
 
 Jellyfin uses fonts to render text in many places.

--- a/docs/general/administration/configuration.md
+++ b/docs/general/administration/configuration.md
@@ -124,11 +124,13 @@ Most installs never need to touch this. The main reason to tune it is a large li
 <?xml version="1.0" encoding="utf-8"?>
 <DatabaseConfigurationOptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <DatabaseType>Jellyfin-SQLite</DatabaseType>
+  <LockingBehavior>NoLock</LockingBehavior>
   <CustomProviderOptions>
     <Options>
+      <!-- 1024 * 1024 * 1024 / 4096 = 1G -->
       <CustomDatabaseOption>
         <Key>cacheSize</Key>
-        <Value>-262144</Value>
+        <Value>262144</Value>
       </CustomDatabaseOption>
     </Options>
   </CustomProviderOptions>
@@ -147,7 +149,14 @@ Each knob is a `CustomDatabaseOption` with a `Key` and a `Value` child element. 
 | `pooling`           | `True`             | Enable connection pooling.                                                                                              |
 | `command-timeout`   | `60`               | Command timeout in seconds.                                                                                              |
 
-Any additional PRAGMA can be set by prefixing the key with `#PRAGMA:`, for example `<CustomDatabaseOption Key="#PRAGMA:mmap_size" Value="268435456" />`.
+Any additional PRAGMA can be set by prefixing the key with `#PRAGMA:`, for example:
+
+```xml
+<CustomDatabaseOption>
+  <Key>#PRAGMA:mmap_size</Key>
+  <Value>268435456</Value>
+</CustomDatabaseOption>
+```
 
 ### Cache size and large libraries
 

--- a/docs/general/administration/storage.md
+++ b/docs/general/administration/storage.md
@@ -58,4 +58,4 @@ Note that changing the record size on an existing ZFS dataset will not change th
 
 As ZFS snapshots can use a lot of storage over time without a sensible `destroy` schedule, there may be a temptation to keep your data on a mechanical drive instead of an SSD. Do not use ZFS-formatted mechanical drives to store your Jellyfin Server data (everything except your media files), as this will result in poor performance. An SSD is strongly recommended.
 
-For SQLite tuning options such as the `cacheSize` setting that helps large libraries, see the [Database section](/docs/general/administration/configuration#database) of the Configuration page.
+For SQLite tuning options such as the `cacheSize` setting that may help large libraries, see the [Database section](/docs/general/administration/configuration#database) of the Configuration page.

--- a/docs/general/administration/storage.md
+++ b/docs/general/administration/storage.md
@@ -57,3 +57,5 @@ For ZFS datasets containing large media files (i.e., not the dataset containing 
 Note that changing the record size on an existing ZFS dataset will not change the existing data within it, meaning performance will not be any different for anything but newly-written changes into the dataset. As such, it is recommended to rewrite your data into the dataset to take advantage of the change in record size; otherwise, the configuration change will not yield the expected change in performance.
 
 As ZFS snapshots can use a lot of storage over time without a sensible `destroy` schedule, there may be a temptation to keep your data on a mechanical drive instead of an SSD. Do not use ZFS-formatted mechanical drives to store your Jellyfin Server data (everything except your media files), as this will result in poor performance. An SSD is strongly recommended.
+
+For SQLite tuning options such as the `cacheSize` setting that helps large libraries, see the [Database section](/docs/general/administration/configuration#database) of the Configuration page.

--- a/docs/general/administration/troubleshooting.md
+++ b/docs/general/administration/troubleshooting.md
@@ -238,6 +238,8 @@ Stop your Jellyfin server and navigate to its config directory. There are a lot 
 
 then start your Jellyfin instance again. If this still does not help with the issues, you can try setting the `LockingBehavior` to `Pessimistic` instead but this comes with a significant performance impact so it is only recommended when `Optimistic` does not help with the issues.
 
+For the other `database.xml` options, including `cacheSize` tuning for large libraries, see the [Database section](/docs/general/administration/configuration#database) of the Configuration page.
+
 ### LXC specific issues
 
 It has been brought to the team's attention that there are issues with LXC specifically. If you are getting such errors on LXC after setting lock mode to `Optimistic`, it is recommended that you migrate to full virtualization (virtual machines) or Docker. There is unlikely to be a solution for LXC any time soon, and we will be unable to provide any support for database locked problems on LXC.

--- a/project-words.txt
+++ b/project-words.txt
@@ -258,6 +258,7 @@ mirrorlist
 mirrorstats
 mirrorsync
 mkinitcpio
+mmap
 mmdb
 mobi
 modeset


### PR DESCRIPTION
**Changes**

Adds a Database section to the admin Configuration page. It documents the `database.xml` `CustomProviderOptions` that have existed since 10.11 (`cacheSize`, `lockingmode`, `journalsizelimit`, `tempstoremode`, `syncmode`, `pooling`, `command-timeout`, and `#PRAGMA:` passthrough), and gives cache_size guidance for large libraries.

Motivation: on large libraries the default 2 MiB SQLite page cache is too small to hold the working set for the broad metadata queries (`/Artists`, `/Studios`, `/Genres`), so it thrashes and re-reads pages from disk on every request. Raising `cacheSize` fixes it without any code change. On a 189k item library, `cacheSize=-262144` (256 MiB) took `/Studios` from tens of seconds to ~2-3s. This documents the existing knobs rather than changing defaults, matching the discussion in jellyfin/jellyfin#17405.

**Code assistance**

Benchmarking, the cache_size sweep, and drafting were done with LLM assistance. Numbers were measured against a real 189k item library; the wording and guidance were reviewed and verified by me.

**Issues**

Refs jellyfin/jellyfin#17405
