### PR TITLE
Add Neptune to client list

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -680,6 +680,29 @@ const thirdPartyClients: Array<Client> = [
     recommended: true
   },
   {
+    id: 'neptune',
+    name: 'Neptune',
+    description: 'A native Jellyfin client for Apple TV.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.TV],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.TVOS],
+    primaryLinks: [
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/neptune-media-player/id6756797773'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://neptuneplayer.com/'
+      }
+    ]
+  },
+  {
     id: 'volumio',
     name: 'Jellyfin Plugin for Volumio',
     description: 'A Volumio plugin for playing audio from one or more Jellyfin servers.',


### PR DESCRIPTION
```markdown
**Changes**

Adds Neptune as a third-party proprietary tvOS client, with links to the App Store and Neptune website.

**Copyediting**

This is a small data-only change.

- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.

**Issues**

None.
```