### PR TITLE
Update k8s hardware acceleration docs to reflect current helm chart

### DIFF
--- a/docs/general/installation/advanced/kubernetes.md
+++ b/docs/general/installation/advanced/kubernetes.md
@@ -264,12 +264,12 @@ resources:
     gpu.intel.com/i915: 1
     # or nvidia.com/gpu: 1
 
-extraVolumes:
+volumes:
   - name: dri
     hostPath:
       path: /dev/dri
 
-extraVolumeMounts:
+volumeMounts:
   - name: dri
     mountPath: /dev/dri
 ```


### PR DESCRIPTION
**Changes**
* Update incorrect helm values in k8s hardware acceleration docs 
The chart uses `volumes` & `volumeMounts`, not `extraVolumes` & `extraVolumeMounts` https://github.com/jellyfin/jellyfin-helm/blob/b8e2455d5dcaf1285e999b2058fb8c21218e2c4e/charts/jellyfin/values.yaml#L207