### PR TITLE
Add MuseVu to third-party clients

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -1028,6 +1028,36 @@ const thirdPartyClients: Array<Client> = [
         url: 'https://jellify.app'
       }
     ]
+  },
+  {
+    id: 'musevu',
+    name: 'MuseVu',
+    description:
+      'A cinematic Jellyfin client for Android TV, phones and tablets — moving billboard previews, trailers, continue watching with auto next episode, adaptive quality for older TVs and 8 languages.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Mobile, DeviceType.TV],
+    licenseType: LicenseType.Proprietary,
+    platforms: [
+      Platform.Android,
+      Platform.AndroidTV,
+      Platform.FireOS,
+      Platform.WebOS,
+      Platform.Tizen
+    ],
+    primaryLinks: [
+      {
+        id: 'google-play',
+        name: 'Google Play',
+        url: 'https://play.google.com/store/apps/details?id=com.thefuturecoderx.musevu'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://musevu.com'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
**Changes**

Adds **MuseVu** to the third-party clients list. MuseVu is a cinematic, closed-source Jellyfin client for Android phones, tablets and Android TV, available on [Google Play](https://play.google.com/store/apps/details?id=com.thefuturecoderx.musevu), with Fire TV, LG webOS and Samsung Tizen versions currently in testing. Features include moving billboard previews, trailer playback, continue watching with auto next episode, adaptive quality for older/low-power TVs and 8 UI languages.

The entry is marked as `ThirdParty` + `Proprietary`, following the existing entries for Infuse, Yatse, Symfonium, Manet and Finer.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**