### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/docs/general/installation/index.mdx
+++ b/docs/general/installation/index.mdx
@@ -25,3 +25,7 @@ For info on selecting hardware for a Jellyfin server, please refer to the [Hardw
 - [TrueNAS SCALE](/docs/general/installation/advanced/truenas)
 - [Generic Linux](/docs/general/installation/advanced/manual#portable-linux-install)
 - [Building from source](/docs/general/installation/advanced/source).
+
+Prefer not to run a server yourself? A third-party provider can run a managed Jellyfin instance for you.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/jellyfin)


### PR DESCRIPTION
**Changes**

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Jellyfin to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the install options list on the Installation page (links to https://zenith.hosting/host/jellyfin).

it is a docs-only change, four added lines in `docs/general/installation/index.mdx`, framed as a third-party option so it does not read as an official Jellyfin package. happy to reword or move it if you would rather it sat somewhere else, or drop it entirely if third-party hosts are not something the docs want to list.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

n/a
