### PR TITLE
remove 10.11 reference in backup page

### DIFF
--- a/docs/general/administration/backup-and-restore.md
+++ b/docs/general/administration/backup-and-restore.md
@@ -22,7 +22,7 @@ There are two ways of backing up your Jellyfin data. One is with its built-in Ba
 ## Built-in Backup
 
 Jellyfin's built-in backup system is able to create a backup while your system is online and running, as opposed to the manual process that **requires** you to stop Jellyfin beforehand.
-However in 10.11 we still recommend performing the backup process during a time of low activity and while no scan is currently active.
+However we still recommend performing the backup process during a time of low activity and while no scan is currently active.
 
 ### Create a Built-in Backup
 

--- a/docs/general/administration/backup-and-restore.md
+++ b/docs/general/administration/backup-and-restore.md
@@ -24,6 +24,12 @@ There are two ways of backing up your Jellyfin data. One is with its built-in Ba
 Jellyfin's built-in backup system is able to create a backup while your system is online and running, as opposed to the manual process that **requires** you to stop Jellyfin beforehand.
 However we still recommend performing the backup process during a time of low activity and while no scan is currently active.
 
+:::note Feature History:
+
+- 10.11: Builtin Backup feature was added
+
+:::
+
 ### Create a Built-in Backup
 
 To take a new Backup, enter the Jellyfin Dashboard, open the `Backups` tab and click on the `Create Backup` button. The popup will now ask you to select what data you want to backup.


### PR DESCRIPTION
I do not see how future versions of Jellyfin (specifically looking at 12.0) would have any affect on this.
We will always recommend that you take a backup when Jellyfin is not in the middle of changing a bunch of stuff in the Database.

The reference to 10.11 is pointless.
And it might even confuse some users... https://github.com/jellyfin/jellyfin.org/issues/1972#issuecomment-5204184177