### PR TITLE
Add Navarre (third-party Android TV / Android / Windows client)

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -1024,6 +1024,34 @@ const thirdPartyClients: Array<Client> = [
         url: 'https://jellify.app'
       }
     ]
+  },
+  {
+    id: 'navarre',
+    name: 'Navarre',
+    description: 'A third-party client for Android TV, Android, and Windows, built around a turnkey living-room experience.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.TV, DeviceType.Mobile, DeviceType.Desktop],
+    licenseType: LicenseType.Proprietary,
+    platforms: [Platform.AndroidTV, Platform.Android, Platform.Windows],
+    primaryLinks: [
+      {
+        id: 'google-play-tv',
+        name: 'Google Play (TV)',
+        url: 'https://play.google.com/store/apps/details?id=com.navarre.tv'
+      },
+      {
+        id: 'google-play',
+        name: 'Google Play',
+        url: 'https://play.google.com/store/apps/details?id=com.navarre.mobile'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://navarre.tv/?utm_source=jellyfin-forum&utm_medium=clients-list&utm_campaign=launch-2026-08'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Adds Navarre, a third-party client, to the clients list.

- Third-party, proprietary (clientType: ThirdParty, licenseType: Proprietary), consistent with the existing precedent for proprietary third-party clients such as Infuse.
- Living-room-first Android TV app with a setup wizard that discovers the server, plus Android phone and Windows desktop apps.
- Free for in-home use; remote access is a one-time paid unlock. No subscription.
- Store links: Google Play (TV and phone); the Windows installer is on the website.

Happy to adjust the entry, description, or placement to whatever the maintainers prefer.