### PR TITLE
Add IMDb Ratings plugin to 3rd-party list

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -353,6 +353,14 @@ Local AI-powered subtitle generation using whisper.cpp. Generates SRT subtitles 
 
 - [GitHub](https://github.com/GeiserX/whisper-subs)
 
+#### IMDb Ratings
+
+Fetches IMDb community ratings from OMDb and maintains an IMDb Top 250 Movies playlist. Ratings are written back to Jellyfin and the playlist is kept in ranked order, auto-creating it on first run.
+
+**Links:**
+
+- [GitHub](https://github.com/jpedrofontes/jellyfin-imdb-plugin)
+
 ## Repositories
 
 import { OfficialPluginRepositories, ThirdPartyRepositories } from '../../../../src/data/pluginRepositories';

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -137,5 +137,13 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     includes: {
       WhisperSubs: 'https://github.com/GeiserX/whisper-subs'
     }
+  },
+  {
+    id: 'gh:jpedrofontes/jellyfin-imdb-plugin',
+    name: "jpedrofontes's IMDb Ratings Repo",
+    url: 'https://raw.githubusercontent.com/jpedrofontes/jellyfin-imdb-plugin/main/manifest.json',
+    includes: {
+      'IMDb Ratings': 'https://github.com/jpedrofontes/jellyfin-imdb-plugin'
+    }
   }
 ];


### PR DESCRIPTION
## Description

Adds the [IMDb Ratings plugin](https://github.com/jpedrofontes/jellyfin-imdb-plugin) to the 3rd-party plugins list and repository catalog.

### Plugin details

- **Name:** IMDb Ratings
- **Category:** Metadata
- **Jellyfin version:** 10.11.x (net9.0)
- **Repository manifest:** `https://raw.githubusercontent.com/jpedrofontes/jellyfin-imdb-plugin/main/manifest.json`
- **GitHub:** https://github.com/jpedrofontes/jellyfin-imdb-plugin

### What it does

- Fetches IMDb community ratings from the OMDb API and writes them back to Jellyfin as community ratings
- Maintains an IMDb Top 250 Movies playlist (auto-creates it, keeps movies in ranked order)
- Both features run as scheduled tasks (daily ratings refresh, configurable playlist refresh interval)
- Admin user is auto-detected — no manual configuration of a User ID is required

### Changes

- `docs/general/server/plugins/index.mdx`: added entry under **3rd-Party Plugins**
- `src/data/pluginRepositories.ts`: added entry to `ThirdPartyRepositories`