### PR TITLE
initial stub guide

### DIFF
--- a/docs/general/server/media/placeholders.md
+++ b/docs/general/server/media/placeholders.md
@@ -71,3 +71,8 @@ Shows
 ## Client Behavior
 
 Jellyfin adds placeholders to the library like other media items, allowing them to have metadata and artwork. The item is marked as a placeholder instead of playable media.
+
+## Metadata
+
+`.disc`-Files will be treated as a real media file. You can attach additional files like images or `.nfo` files just as usual.
+Check the documentation regarding [TV shows](./shows.md) or [Movies](./movies.md) depending on the desired Placeholder-Type.

--- a/docs/general/server/media/placeholders.md
+++ b/docs/general/server/media/placeholders.md
@@ -1,0 +1,69 @@
+---
+uid: server-media-placeholders
+title: Media Placeholders
+---
+
+Media placeholders let you add video items to a Jellyfin library without providing a playable video file.
+These can be used to represent media that is unavailable, not currently present, or otherwise should exist in the library without an actual video file.
+
+Create an empty file using the normal naming convention for the media, with `.disc` as the file extension.
+
+For example:
+
+```txt
+Movies
+└── Blade Runner (1982)
+    └── Blade Runner (1982).disc
+```
+
+Jellyfin will add the movie to the library as a placeholder. The contents of the `.disc` file are not used.
+
+## Placeholder Types
+
+An optional type can be added immediately before `.disc`:
+
+```txt
+Blade Runner (1982).dvd.disc
+Blade Runner (1982).bluray.disc
+Blade Runner (1982).vhs.disc
+```
+
+The following types are recognized:
+
+| Keyword  | Type    |
+| -------- | ------- |
+| `dvd`    | DVD     |
+| `hddvd`  | HD DVD  |
+| `bluray` | Blu-ray |
+| `brrip`  | Blu-ray |
+| `bd25`   | Blu-ray |
+| `bd50`   | Blu-ray |
+| `vhs`    | VHS     |
+| `hdtv`   | TV      |
+| `pdtv`   | TV      |
+| `dsr`    | TV      |
+
+The type is optional. Any file ending in `.disc` is recognized as a placeholder.
+
+The type must be directly before `.disc`. For example, `MyMovie.bluray.disc` is recognized as a Blu-ray placeholder, while `MyMovie.bluray.custom.disc` is still a placeholder but does not have a recognized type.
+
+Other supported naming information can be combined with a placeholder as long as the placeholder type remains directly before `.disc`:
+
+```txt
+Movie (2020).3D.MVC.bluray.disc
+```
+
+## Episodes
+
+Placeholders can also be used for episodes by following the normal [TV show naming conventions](./shows.md):
+
+```txt
+Shows
+└── Example Show (2020)
+    └── Season 01
+        └── Example Show S01E01.dvd.disc
+```
+
+## Client Behavior
+
+Jellyfin adds placeholders to the library like other media items, allowing them to have metadata and artwork. The item is marked as a placeholder instead of playable media.

--- a/docs/general/server/media/placeholders.md
+++ b/docs/general/server/media/placeholders.md
@@ -1,6 +1,6 @@
 ---
 uid: server-media-placeholders
-title: Media Placeholders
+title: Placeholders
 ---
 
 Media placeholders let you add video items to a Jellyfin library without providing a playable video file.

--- a/docs/general/server/media/placeholders.md
+++ b/docs/general/server/media/placeholders.md
@@ -28,6 +28,8 @@ Blade Runner (1982).bluray.disc
 Blade Runner (1982).vhs.disc
 ```
 
+<!-- cSpell:disable -->
+
 The following types are recognized:
 
 | Keyword  | Type    |
@@ -42,6 +44,8 @@ The following types are recognized:
 | `hdtv`   | TV      |
 | `pdtv`   | TV      |
 | `dsr`    | TV      |
+
+<!-- cSpell:enable -->
 
 The type is optional. Any file ending in `.disc` is recognized as a placeholder.
 


### PR DESCRIPTION
Documents Jellyfin's media placeholder behavior using .disc files.

Added a dedicated Media Placeholders page covering naming and optional placeholder types.
Client behavior cannot really be documented, as it strongly depends on the client.

(Note that I have no Idea how Jellyfin-Web shows stubs)
