### PR TITLE
Jellyfin 12 changes

### DIFF
--- a/docs/general/contributing/release-procedure.md
+++ b/docs/general/contributing/release-procedure.md
@@ -9,7 +9,9 @@ This document is a guide for the core team, provided publicly to ensure transpar
 
 ## Versioning
 
-Jellyfin uses [semantic versioning](https://semver.org). All releases will have versions in the `X.Y.Z` format, starting from `10.0.0`. Note however that the `10.Y.Z` release chain represents the "cleanup" of the codebase, so it should be accepted that `10.Y.Z` breaks all compatibility, at some point, with previous Emby-compatible interfaces, and may also break compatibility with previous `10.Y` releases if required for later cleanup work. Our versioning will typically follow the patterns below:
+Jellyfin uses [semantic versioning](https://semver.org). Starting with Jellyfin 12, release numbers follow the `X.Y.Z` format, where the first number is the major release (for example `12.0.0` or `13.1.0`). The older `10.Y.Z` scheme was used during the previous compatibility cycle and is no longer the active release convention.
+
+Our versioning will typically follow the patterns below:
 
 ### X: Major Versions
 

--- a/docs/general/contributing/release-procedure.md
+++ b/docs/general/contributing/release-procedure.md
@@ -9,22 +9,18 @@ This document is a guide for the core team, provided publicly to ensure transpar
 
 ## Versioning
 
-Jellyfin uses [semantic versioning](https://semver.org). Starting with Jellyfin 12, release numbers follow the `X.Y.Z` format, where the first number is the major release (for example `12.0.0` or `13.1.0`). The older `10.Y.Z` scheme was used during the previous compatibility cycle and is no longer the active release convention.
+Jellyfin uses [semantic versioning](https://semver.org). Starting with Jellyfin 12, release numbers follow the `X.Y` format, where the first number is the major release (for example `12.0` or `13.1`). The older `10.X.Y` scheme was used during the previous compatibility cycle and is no longer the active release convention.
 
 Our versioning will typically follow the patterns below:
 
 ### X: Major Versions
 
-* Breaks compatibility with the HTTP or plugin APIs
+- Breaks compatibility with the HTTP or plugin APIs
+- Introduces new features
 
-### Y: Minor Versions
+### Y: Hotfix Versions
 
-* Introduces new features
-* Makes minor backwards-compatible API changes
-
-### Z: Hotfix Versions
-
-* Critical bug fixes or minor changes
+- Critical bug fixes or minor changes
 
 ## General Release Philosophy
 
@@ -34,7 +30,7 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
 #### Preparation
 
-1. Testing is ongoing via `master` nightly builds, so `master` should be generally unbroken before proceeding. The version of `master` should already reflect the upcoming major release version (i.e. `X.Y.0`).
+1. Testing is ongoing via `master` nightly builds, so `master` should be generally unbroken before proceeding. The version of `master` should already reflect the upcoming major release version (i.e. `X.Y`).
 
 1. Once `master` is in a generally stable state after extensive work, announce a "golden nightly" is incoming via the [jellyfin-dev](https://matrix.to/#/#jellyfin-dev:matrix.org) Matrix/Riot channel and Forum.
 
@@ -50,11 +46,11 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
 1. Create a release branch on the [jellyfin-web](https://github.com/jellyfin/jellyfin-web) repository via CLI from `master`, named `release-X.Y.z`, where `X` and `Y` are the new version number, and `z` is a literal `z`. Push the new branch to GitHub.
 
-2. Create a GitHub release for the new version, based on the newly-created `release-X.Y.z` branch. The tag should be named `vX.Y.Z` (i.e. `vX.Y.0`) and the release named "Release X.Y.Z". The release body should contain the following link only, replacing the version as required:
+2. Create a GitHub release for the new version, based on the newly-created `release-X.Y.z` branch. The tag should be named `vX.Y` (i.e. `vX.Y`) and the release named "Release X.Y". The release body should contain the following link only, replacing the version as required:
 
-    ```md
-    [Please see the release announcement on the main repository.](https://github.com/jellyfin/jellyfin/releases/tag/vX.Y.Z)
-    ```
+   ```md
+   [Please see the release announcement on the main repository.](https://github.com/jellyfin/jellyfin/releases/tag/vX.Y.Z)
+   ```
 
 3. Publish the release.
 
@@ -62,9 +58,9 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
 1. Create a release branch on the [jellyfin](https://github.com/jellyfin/jellyfin) repository via CLI from `master`, named `release-X.Y.z`, where `X` and `Y` are the new version number, and `z` is a literal `z`. Push the new branch to GitHub.
 
-2. Create a GitHub release for the new version, based on the newly-created `release-X.Y.z` branch. The tag should be named `vX.Y.Z` (i.e. `vX.Y.0`) and the release named "Release X.Y.Z". The release body should contain the following components:
+2. Create a GitHub release for the new version, based on the newly-created `release-X.Y.z` branch. The tag should be named `vX.Y` (i.e. `vX.Y`) and the release named "Release X.Y". The release body should contain the following components:
 
-   a. A quick top blurb under a `# Jellyfin X.Y.Z` header.
+   a. A quick top blurb under a `# Jellyfin X.Y` header.
 
    a. A list of features, including in-line links to Fider if available, under a `## New Features and Major Improvements` header.
 
@@ -87,10 +83,8 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 1. Collect the list of merged `stable-backport` PRs from all relevant repositories.
 
 1. For each repository, perform stable branch reconciliation for the relevant PRs:
-
    1. For each PR slated for backport:
-
-      1. Grab the *merge commit* hash for the PR from `master` branch.
+      1. Grab the _merge commit_ hash for the PR from `master` branch.
 
       1. Cherry-pick the merge commit into the `release-x.y.z` branch via: `git cherry-pick -sx -m1 <merge-commit-hash>`.
 
@@ -98,25 +92,25 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
       1. Finalize the cherry-pick via: `git add` and `git commit -v`.
 
-   1. For the main [jellyfin](https://github.com/jellyfin/jellyfin) repository, bump the version of the repository to the new hotfix version with the `bump_version` script and commit the result with the message "Bump version for X.Y.Z".
+   1. For the main [jellyfin](https://github.com/jellyfin/jellyfin) repository, bump the version of the repository to the new hotfix version with the `bump_version` script and commit the result with the message "Bump version for X.Y".
 
    1. Push the updated release branch to GitHub.
 
 #### Web Client
 
-1. Create a GitHub release for the new version, based on the relevant `release-X.Y.z` branch. The tag should be named `vX.Y.Z` and the release named "Release X.Y.Z". The release body should contain the following link only, replacing the version as required:
+1. Create a GitHub release for the new version, based on the relevant `release-X.Y.z` branch. The tag should be named `vX.Y` and the release named "Release X.Y". The release body should contain the following link only, replacing the version as required:
 
-    ```md
-    [Please see the release announcement on the main repository.](https://github.com/jellyfin/jellyfin/releases/tag/vX.Y.Z)
-    ```
+   ```md
+   [Please see the release announcement on the main repository.](https://github.com/jellyfin/jellyfin/releases/tag/vX.Y.Z)
+   ```
 
 2. Publish the release on GitHub and the archive repository.
 
 #### Server
 
-1. Create a GitHub release for the new version, based on the relevant `release-X.Y.z` branch. The tag should be named `vX.Y.Z` and the release named "Release X.Y.Z". The release body should contain the following components:
+1. Create a GitHub release for the new version, based on the relevant `release-X.Y.z` branch. The tag should be named `vX.Y` and the release named "Release X.Y". The release body should contain the following components:
 
-   a. A quick top blurb under a `# Jellyfin X.Y.Z` header.
+   a. A quick top blurb under a `# Jellyfin X.Y` header.
 
    a. A list of known release notes, categorized by the relevant platform (e.g. `[All]` or `[Windows]`), under a `## Important Release Notes` header.
 

--- a/docs/general/contributing/release-procedure.md
+++ b/docs/general/contributing/release-procedure.md
@@ -44,21 +44,21 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
 #### Release Web Client
 
-1. Create a release branch on the [jellyfin-web](https://github.com/jellyfin/jellyfin-web) repository via CLI from `master`, named `release-X.Y.z`, where `X` and `Y` are the new version number, and `z` is a literal `z`. Push the new branch to GitHub.
+1. Create a release branch on the [jellyfin-web](https://github.com/jellyfin/jellyfin-web) repository via CLI from `master`, named `release-X.Y`, where `X` and `Y` are the new version number. Push the new branch to GitHub.
 
-2. Create a GitHub release for the new version, based on the newly-created `release-X.Y.z` branch. The tag should be named `vX.Y` (i.e. `vX.Y`) and the release named "Release X.Y". The release body should contain the following link only, replacing the version as required:
+2. Create a GitHub release for the new version, based on the newly-created `release-X.Y` branch. The tag should be named `vX.Y` (i.e. `vX.Y`) and the release named "Release X.Y". The release body should contain the following link only, replacing the version as required:
 
    ```md
-   [Please see the release announcement on the main repository.](https://github.com/jellyfin/jellyfin/releases/tag/vX.Y.Z)
+   [Please see the release announcement on the main repository.](https://github.com/jellyfin/jellyfin/releases/tag/vX.Y)
    ```
 
 3. Publish the release.
 
 #### Release Server
 
-1. Create a release branch on the [jellyfin](https://github.com/jellyfin/jellyfin) repository via CLI from `master`, named `release-X.Y.z`, where `X` and `Y` are the new version number, and `z` is a literal `z`. Push the new branch to GitHub.
+1. Create a release branch on the [jellyfin](https://github.com/jellyfin/jellyfin) repository via CLI from `master`, named `release-X.Y`, where `X` and `Y` are the new version number. Push the new branch to GitHub.
 
-2. Create a GitHub release for the new version, based on the newly-created `release-X.Y.z` branch. The tag should be named `vX.Y` (i.e. `vX.Y`) and the release named "Release X.Y". The release body should contain the following components:
+2. Create a GitHub release for the new version, based on the newly-created `release-X.Y` branch. The tag should be named `vX.Y` (i.e. `vX.Y`) and the release named "Release X.Y". The release body should contain the following components:
 
    a. A quick top blurb under a `# Jellyfin X.Y` header.
 
@@ -86,7 +86,7 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
    1. For each PR slated for backport:
       1. Grab the _merge commit_ hash for the PR from `master` branch.
 
-      1. Cherry-pick the merge commit into the `release-x.y.z` branch via: `git cherry-pick -sx -m1 <merge-commit-hash>`.
+      1. Cherry-pick the merge commit into the `release-x.y` branch via: `git cherry-pick -sx -m1 <merge-commit-hash>`.
 
       1. Fix any merge conflicts, generally keeping what's in the merge. If there are significant merge conflicts, this likely indicates that the fix is too large for backporting.
 
@@ -98,7 +98,7 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
 #### Web Client
 
-1. Create a GitHub release for the new version, based on the relevant `release-X.Y.z` branch. The tag should be named `vX.Y` and the release named "Release X.Y". The release body should contain the following link only, replacing the version as required:
+1. Create a GitHub release for the new version, based on the relevant `release-X.Y` branch. The tag should be named `vX.Y` and the release named "Release X.Y". The release body should contain the following link only, replacing the version as required:
 
    ```md
    [Please see the release announcement on the main repository.](https://github.com/jellyfin/jellyfin/releases/tag/vX.Y.Z)
@@ -108,7 +108,7 @@ Releases will generally be performed on Sundays "when ready". For Major/Minor re
 
 #### Server
 
-1. Create a GitHub release for the new version, based on the relevant `release-X.Y.z` branch. The tag should be named `vX.Y` and the release named "Release X.Y". The release body should contain the following components:
+1. Create a GitHub release for the new version, based on the relevant `release-X.Y` branch. The tag should be named `vX.Y` and the release named "Release X.Y". The release body should contain the following components:
 
    a. A quick top blurb under a `# Jellyfin X.Y` header.
 

--- a/docs/general/post-install/transcoding/hardware-acceleration/amd.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/amd.md
@@ -189,10 +189,10 @@ Root permission is required.
 
 1. Assuming you have added the jellyfin repository to your apt source list and installed the `jellyfin-server` and `jellyfin-web`.
 
-2. Install the `jellyfin-ffmpeg7` package. Remove the deprecated `jellyfin` meta package if it breaks the dependencies:
+2. Install the `jellyfin-ffmpeg8` package. Remove the deprecated `jellyfin` meta package if it breaks the dependencies:
 
    ```shell
-   sudo apt update && sudo apt install -y jellyfin-ffmpeg7
+   sudo apt update && sudo apt install -y jellyfin-ffmpeg8
    ```
 
 3. Make sure at least one `renderD*` device exists in `/dev/dri`. Otherwise upgrade your kernel or enable the iGPU in the BIOS.
@@ -290,7 +290,7 @@ Root permission is required.
 
 Linux Mint uses Ubuntu as its package base.
 
-You can follow the configuration steps of [Debian And Ubuntu Linux](./amd.md#debian-and-ubuntu-linux) but install all Jellyfin packages `jellyfin-server`, `jellyfin-web` and `jellyfin-ffmpeg7` manually from the [Jellyfin Server Releases Page](https://repo.jellyfin.org/releases/server/). Also make sure you choose the correct codename by following the [official version maps](https://linuxmint.com/download_all.php).
+You can follow the configuration steps of [Debian And Ubuntu Linux](./amd.md#debian-and-ubuntu-linux) but install all Jellyfin packages `jellyfin-server`, `jellyfin-web` and `jellyfin-ffmpeg8` manually from the [Jellyfin Server Releases Page](https://repo.jellyfin.org/releases/server/). Also make sure you choose the correct codename by following the [official version maps](https://linuxmint.com/download_all.php).
 
 #### Arch Linux
 

--- a/docs/general/post-install/transcoding/hardware-acceleration/intel.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/intel.md
@@ -281,10 +281,10 @@ Root permission is required.
    If you are running Debian, you will need to add "non-free" to your apt config.
    :::
 
-2. Install the `jellyfin-ffmpeg7` package. Remove the deprecated `jellyfin` meta package if it breaks the dependencies:
+2. Install the `jellyfin-ffmpeg8` package. Remove the deprecated `jellyfin` meta package if it breaks the dependencies:
 
    ```shell
-   sudo apt update && sudo apt install -y jellyfin-ffmpeg7
+   sudo apt update && sudo apt install -y jellyfin-ffmpeg8
    ```
 
 3. Make sure at least one `renderD*` device exists in `/dev/dri`. Otherwise upgrade your kernel or enable the iGPU in the BIOS.
@@ -385,7 +385,7 @@ Root permission is required.
 
 Linux Mint uses Ubuntu as its package base.
 
-You can follow the configuration steps of [Debian And Ubuntu Linux](./intel.md#debian-and-ubuntu-linux) but install all Jellyfin packages `jellyfin-server`, `jellyfin-web` and `jellyfin-ffmpeg7` manually from the [Jellyfin Server Releases Page](https://repo.jellyfin.org/releases/server/). Also make sure you choose the correct codename by following the [official version maps](https://linuxmint.com/download_all.php).
+You can follow the configuration steps of [Debian And Ubuntu Linux](./intel.md#debian-and-ubuntu-linux) but install all Jellyfin packages `jellyfin-server`, `jellyfin-web` and `jellyfin-ffmpeg8` manually from the [Jellyfin Server Releases Page](https://repo.jellyfin.org/releases/server/). Also make sure you choose the correct codename by following the [official version maps](https://linuxmint.com/download_all.php).
 
 #### Arch Linux
 

--- a/docs/general/post-install/transcoding/hardware-acceleration/nvidia.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/nvidia.md
@@ -170,10 +170,10 @@ Root permission is required.
 
 1. Assuming you have added the jellyfin repository to your apt source list and installed the `jellyfin-server` and `jellyfin-web`.
 
-2. Install the `jellyfin-ffmpeg7` package. Remove the deprecated `jellyfin` meta package if it breaks the dependencies:
+2. Install the `jellyfin-ffmpeg8` package. Remove the deprecated `jellyfin` meta package if it breaks the dependencies:
 
    ```shell
-   sudo apt update && sudo apt install -y jellyfin-ffmpeg7
+   sudo apt update && sudo apt install -y jellyfin-ffmpeg8
    ```
 
 3. Install the NVIDIA proprietary driver by following these links. Then install two extra packages for NVENC and NVDEC support:
@@ -220,7 +220,7 @@ Root permission is required.
 
 Linux Mint uses Ubuntu as its package base.
 
-You can follow the configuration steps of [Debian and Ubuntu Linux](./nvidia.md#debian-and-ubuntu-linux) but install all Jellyfin packages `jellyfin-server`, `jellyfin-web` and `jellyfin-ffmpeg7` manually from the [Jellyfin Server Releases Page](https://repo.jellyfin.org/releases/server/). Also make sure you choose the correct codename by following the [official version maps](https://linuxmint.com/download_all.php).
+You can follow the configuration steps of [Debian and Ubuntu Linux](./nvidia.md#debian-and-ubuntu-linux) but install all Jellyfin packages `jellyfin-server`, `jellyfin-web` and `jellyfin-ffmpeg8` manually from the [Jellyfin Server Releases Page](https://repo.jellyfin.org/releases/server/). Also make sure you choose the correct codename by following the [official version maps](https://linuxmint.com/download_all.php).
 
 #### Arch Linux
 

--- a/docs/general/post-install/transcoding/hardware-acceleration/rockchip.md
+++ b/docs/general/post-install/transcoding/hardware-acceleration/rockchip.md
@@ -111,7 +111,7 @@ Root permission is required.
 
 :::
 
-1. Assuming you have added the jellyfin repository to your apt source list and installed the `jellyfin-server`, `jellyfin-web` and `jellyfin-ffmpeg7`.
+1. Assuming you have added the jellyfin repository to your apt source list and installed the `jellyfin-server`, `jellyfin-web` and `jellyfin-ffmpeg8`.
 
 2. Make sure `dma_heap`, `dri`, `mpp_service` and `rga` exist in `/dev`. Otherwise upgrade your BSP kernel to 5.10 LTS and newer.
 
@@ -281,7 +281,7 @@ LXC setup idea is a bit similar to docker - you need to pass the **device files*
    ```shell
    ii  clinfo                          3.0.21.02.21-1                          arm64        Query OpenCL system information
    ii  jellyfin                        10.10.1+ubu2204                         all          Jellyfin is the Free Software Media System.
-   ii  jellyfin-ffmpeg7                7.0.2-5-jammy                           arm64        Tools for transcoding, streaming and playing of multimedia files
+   ii  jellyfin-ffmpeg8                8.1.0-5-jammy                           arm64        Tools for transcoding, streaming and playing of multimedia files
    ii  jellyfin-server                 10.10.1+ubu2204                         arm64        Jellyfin is the Free Software Media System.
    ii  jellyfin-web                    10.10.1+ubu2204                         all          Jellyfin is the Free Software Media System.
    ii  libmali-valhall-g610-g13p0-gbm  1.9-1                                   arm64        Mali GPU User-Space Binary Drivers

--- a/docs/general/server/media/_video-metadata-providers.md
+++ b/docs/general/server/media/_video-metadata-providers.md
@@ -10,4 +10,12 @@ Movie Name (year) [metadata provider id]
 Series Name (year) [metadata provider id]
 ```
 
+Seasons and episodes can also include metadata provider IDs.
+
+```txt
+Series Name (year) [metadata provider id]
+└── Season 01 [metadata provider id]
+   └── S01E01 [metadata provider id].mkv
+```
+
 Read more about it in the [metadata provider identifiers section](/docs/general/server/metadata/identifiers.md).

--- a/docs/general/server/media/books.md
+++ b/docs/general/server/media/books.md
@@ -5,8 +5,6 @@ title: Books
 
 # Books
 
-The bookshelf plugin is required for books libraries.
-
 Books should be organized by type (Audiobooks, Books, Comics), then optionally by Author. Each book should be in their own folder.
 
 ```txt
@@ -47,11 +45,11 @@ For audiobooks, most common audio extensions are supported. For other books, the
 
 ## Metadata
 
-Online metadata is not supported for the books library type.
+Books can use built-in online metadata providers such as GoogleBooks, ComicVine, and OpenLibrary, as well as embedded metadata from supported files.
 
 For media in audio formats, the metadata is read from the embedded tags of the audio files. FLAC files with WebP embedded images or ID3 tags might fail to play on some browsers. Enable the `Always remux flac option` in the settings if you are experiencing this problem.
 
-For books in epub format, embedded metadata can be provided, For other formats, the metadata has to be provided in an external `content.opf`, `metadata.opf` or `ComicInfo.xml` file. The ComicInfo (from ComicRack) and ComicBookInfo (from ComicBookLover) formats are supported for `ComicInfo.xml` files.
+For books in epub format, embedded metadata can be provided. For other formats, metadata can still be provided in an external `content.opf`, `metadata.opf` or `ComicInfo.xml` file when needed. The ComicInfo (from ComicRack) and ComicBookInfo (from ComicBookLover) formats are supported for `ComicInfo.xml` files.
 
 Additionally, information about year and issue number can be provided in the file names, as seen in the example above. For comics or magazines with issues across multiple years, the year of the first issue should be used.
 

--- a/docs/general/server/media/shows.md
+++ b/docs/general/server/media/shows.md
@@ -50,11 +50,12 @@ The series folder should be named in the following format:
 Series Name (year) [metadata provider id]
 ```
 
-The `year` and `metadata provider id` fields are optional, but they will help identify media more reliably.
+The `year` and `metadata provider id` fields are optional, but they will help identify media more reliably. Plex-style provider IDs such as `{tmdb-123}` are also accepted.
 
 - Example with name only: `Jellyfin Documentary.mkv`
 - Example with year: `Jellyfin Documentary (2030)`
 - Example with metadata provider id: `Jellyfin Documentary [imdbid-tt00000000]`
+- Example with Plex-style provider id: `Jellyfin Documentary {tmdb-123}`
 - Example with both year and metadata provider id: `Jellyfin Documentary (2030) [imdbid-tt00000000]`
 
 The Season folders should be named `Season *`, with `*` being any number. Do not abbreviate the `Season` name to `S01` or `SE01`. For the best results, please pad the season number with `0`s at the front to make sure each entry has the same number of digits. For example: `Season 5` -> `Season 05`. Also do not mix Season folders with episodes in the Shows folder.

--- a/docs/general/server/media/shows.md
+++ b/docs/general/server/media/shows.md
@@ -50,12 +50,11 @@ The series folder should be named in the following format:
 Series Name (year) [metadata provider id]
 ```
 
-The `year` and `metadata provider id` fields are optional, but they will help identify media more reliably. Plex-style provider IDs such as `{tmdb-123}` are also accepted.
+The `year` and `metadata provider id` fields are optional, but they will help identify media more reliably.
 
 - Example with name only: `Jellyfin Documentary.mkv`
 - Example with year: `Jellyfin Documentary (2030)`
 - Example with metadata provider id: `Jellyfin Documentary [imdbid-tt00000000]`
-- Example with Plex-style provider id: `Jellyfin Documentary {tmdb-123}`
 - Example with both year and metadata provider id: `Jellyfin Documentary (2030) [imdbid-tt00000000]`
 
 The Season folders should be named `Season *`, with `*` being any number. Do not abbreviate the `Season` name to `S01` or `SE01`. For the best results, please pad the season number with `0`s at the front to make sure each entry has the same number of digits. For example: `Season 5` -> `Season 05`. Also do not mix Season folders with episodes in the Shows folder.

--- a/docs/general/server/metadata/identifiers.md
+++ b/docs/general/server/metadata/identifiers.md
@@ -5,12 +5,14 @@ title: Metadata Provider Identifiers
 
 # Metadata Provider Identifiers
 
-To improve the accuracy of media identification, you can manually specify a metadata provider identifier for each movie or show. Each metadata provider uses a unique identifier for its content, and adding these identifiers greatly improves media identification. Identifiers can be specified in your movie/show file or folder name. Multiple identifiers can be specified. For example:
+To improve the accuracy of media identification, you can manually specify a metadata provider identifier for each movie or show. Each metadata provider uses a unique identifier for its content, and adding these identifiers greatly improves media identification. Identifiers can be specified in your movie/show file or folder name. Multiple identifiers can be specified. Jellyfin also accepts Plex-style provider IDs, so both the Jellyfin form (`[tmdbid-680]`) and the Plex form (`{tmdb-680}` or `[tmdb-680]`) are supported. For example:
 
 ```txt
 Movies
 ├── Best_Movie_Ever (1994) [tmdbid-680] [imdbid-1234]
 │   ├── Best_Movie_Ever (1994) [tmdbid-680].mp4
+├── Best_Movie_Ever_2 (1994) {tmdb-680}
+│   └── Best_Movie_Ever_2 (1994) {tmdb-680}.mp4
 └── Movie (2021) [imdbid-tt12801262]
     └── Movie (2021) [imdbid-tt12801262].mp4
 Shows

--- a/docs/general/server/metadata/identifiers.md
+++ b/docs/general/server/metadata/identifiers.md
@@ -28,7 +28,7 @@ Shows
 The following metadata providers are supported:
 
 - [The Movie DB (TMDB)](https://www.themoviedb.org/)
-- [The TV Database (TVDB)](https://www.thetvdb.com/) (Shows Only)
+- [The TV Database (TVDB)](https://www.thetvdb.com/)
 - [OMDb API (OMDB)](https://www.omdbapi.com/) (English Only)
 
 ## Finding Metadata Provider Identifiers

--- a/docs/general/server/metadata/identifiers.md
+++ b/docs/general/server/metadata/identifiers.md
@@ -5,7 +5,7 @@ title: Metadata Provider Identifiers
 
 # Metadata Provider Identifiers
 
-To improve the accuracy of media identification, you can manually specify a metadata provider identifier for each movie or show. Each metadata provider uses a unique identifier for its content, and adding these identifiers greatly improves media identification. Identifiers can be specified in your movie/show file or folder name. Multiple identifiers can be specified. Jellyfin also accepts Plex-style provider IDs, so both the Jellyfin form (`[tmdbid-680]`) and the Plex form (`{tmdb-680}` or `[tmdb-680]`) are supported. For example:
+To improve the accuracy of media identification, you can manually specify a metadata provider identifier for each movie or show. Each metadata provider uses a unique identifier for its content, and adding these identifiers greatly improves media identification. Identifiers can be specified in your movie/show file or folder name. Multiple identifiers can be specified. For example:
 
 ```txt
 Movies
@@ -24,6 +24,8 @@ Shows
         ├── Series Name S02E01-E02.mkv
         └── Series Name S02E03.mkv
 ```
+
+Metadata identifiers support square brackets `[]`, parentheses `()`, and curly braces `{}`.
 
 ## Supported Metadata Providers
 
@@ -44,6 +46,7 @@ The identifier is found in the URL of the title. For example:
 URL: `https://www.themoviedb.org/movie/569094-spider-man-across-the-spider-verse`
 
 Identifier: `[tmdbid-569094]`
+Alias: `[tmdb-569094]`
 
 ### The TV Database (TVDB)
 
@@ -52,6 +55,7 @@ The identifier is found on the main page of the title. For example:
 ![How to find The TVDB media identifier](/images/docs/tvdb-media-identifier-example.png)
 
 Identifier: `[tvdbid-266189]`
+Alias: `[tvdb-266189]`
 
 ### OMDb API (OMDB)
 
@@ -60,3 +64,4 @@ OMDB provider uses Internet Movie Database (IMDB) IDs as identifiers. The identi
 URL: `https://www.imdb.com/title/tt9362722/`
 
 Identifier: `[imdbid-tt9362722]`
+Alias: `[imdb-tt9362722]`

--- a/docs/general/testing/upgrades.md
+++ b/docs/general/testing/upgrades.md
@@ -11,7 +11,7 @@ This document provides details on upgrading and downgrading between Stable and U
 
 Which install type to pick depends on your needs; ultimately, Unstable is for testing new things, while Stable is for running a server for others to use reliably.
 
-- Stable provides the most consistent and predictable user experience. A particular major release (e.g. 10.8.z, 10.9.z) will not introduce, remove, or change major features or functionality (with minor caveats for security). Bugfixes are provided in point releases, which are released as needed during the lifecycle of the major release in response to bugfixes and security advisories. Most users should generally use Stable releases, as this will ensure maximum uptime and consistency for your end users.
+- Stable provides the most consistent and predictable user experience. A particular major release (e.g. 12.x, 13.x) will not introduce, remove, or change major features or functionality (with minor caveats for security). Bugfixes are provided in point releases, which are released as needed during the lifecycle of the major release in response to bugfixes and security advisories. Most users should generally use Stable releases, as this will ensure maximum uptime and consistency for your end users.
 
 - Unstable provides the most up-to-date, cutting edge features, but may have rapid and unpredictable breaking changes or serious bugs, and has more limited client support as API changes are made over time. Unstable releases are provided via weekly binary builds on Monday mornings around 5:00 AM UTC, or by [building your own packages from the `master` code branches](https://github.com/jellyfin/jellyfin-packaging).
 


### PR DESCRIPTION
For details see https://github.com/jellyfin/jellyfin.org/pull/1997#issuecomment-5485410223

This PR adresses a bunch of inconsistencies between the existing docs and the new features and changes in Jellyfin 12.0
Specifically it changes:
- Release numbering examples to have 12.0 and 13.0 as "major releases" instead of "10.11" or the like
- bump hwa docs to ffmpeg8 (I dont know if we package that yet, but the blog post specifically mentions that we now use that.)
- remove the "TVDB only for movies" note
- book metadata format and providers have changed (bookshelf not required, metadata can be loaded from the Internet)
- Allow Plex-Style formatting for ID Providers. (See the [feature-request](https://features.jellyfin.org/posts/3727/support-for-plex-style-of-provider-id-in-names))