### PR TITLE
Add AutoPlaylist to third-party plugins

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -353,6 +353,14 @@ Local AI-powered subtitle generation using whisper.cpp. Generates SRT subtitles 
 
 - [GitHub](https://github.com/GeiserX/whisper-subs)
 
+#### AutoPlaylist
+
+Curates thematic music playlists from your existing library using a local LLM served by Ollama. Tracks are chosen by musical judgment rather than genre filters, playlists the plugin owns are marked with a tag so your own playlists are never touched, and curation runs as a nightly scheduled task.
+
+**Links:**
+
+- [GitHub](https://github.com/yonie/jellyfin-plugin-autoplaylist)
+
 ## Repositories
 
 import { OfficialPluginRepositories, ThirdPartyRepositories } from '../../../../src/data/pluginRepositories';

--- a/project-words.txt
+++ b/project-words.txt
@@ -306,6 +306,7 @@ ocsp
 offtopic
 OLDFILES
 Olivo
+Ollama
 OMDB
 onevpl
 OPTOUT

--- a/src/data/pluginRepositories.ts
+++ b/src/data/pluginRepositories.ts
@@ -137,5 +137,13 @@ export const ThirdPartyRepositories: Array<PluginRepository> = [
     includes: {
       WhisperSubs: 'https://github.com/GeiserX/whisper-subs'
     }
+  },
+  {
+    id: 'gh:yonie/jellyfin-plugin-autoplaylist',
+    name: "yonie's AutoPlaylist Repo",
+    url: 'https://raw.githubusercontent.com/yonie/jellyfin-plugin-autoplaylist/main/manifest.json',
+    includes: {
+      AutoPlaylist: 'https://github.com/yonie/jellyfin-plugin-autoplaylist'
+    }
   }
 ];


### PR DESCRIPTION
**Changes**

Adds **AutoPlaylist** to the 3rd-party plugin list and to the third-party repository index.

- **Repo:** https://github.com/yonie/jellyfin-plugin-autoplaylist
- **Manifest:** https://raw.githubusercontent.com/yonie/jellyfin-plugin-autoplaylist/main/manifest.json
- **Target ABI:** 10.11.0.0

AutoPlaylist curates thematic music playlists from an existing music library using a local LLM served by Ollama, so nothing leaves the server and there are no cloud APIs or subscriptions. Playlists it creates are marked with a tag, so playlists the user made by hand are never modified, and curation runs as a nightly scheduled task.

`Ollama` is added to `project-words.txt` (case-insensitive alphabetical position, between `Olivo` and `OMDB`) because cspell does not know the word; that was the only spelling issue reported for the page.

**Copyediting**

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
