### PR TITLE
Add TheIntroDB plugin details to Plugins Server Guide

### DIFF
--- a/docs/general/server/plugins/index.mdx
+++ b/docs/general/server/plugins/index.mdx
@@ -305,6 +305,14 @@ Plugin for Jellyfin that adds theme songs to movies and tv shows using ThemerrDB
 
 - [GitHub](https://github.com/LizardByte/themerr-jellyfin)
 
+#### TheIntroDB
+
+A plugin to skip intros, recaps, credits and previews with TheIntroDB.
+
+**Links:**
+
+- [GitHub](https://github.com/TheIntroDB/jellyfin-plugin)
+
 #### YouTube Metadata
 
 Downloads metadata of YouTube videos with a YouTube API key.


### PR DESCRIPTION

<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**
Added information about TheIntroDB plugin for skipping intros, credits, etc. TheIntroDB is a crowed sourced database of media segments.
https://theintrodb.org

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).

**Issues**

<!-- If applicable, please list any open issues that this PR addresses -->
<!-- e.g. -->
<!-- - closes #1234 -->
