### PR TITLE
Add JellyBox player client app

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -778,7 +778,8 @@ const thirdPartyClients: Array<Client> = [
   {
     id: 'jellybox',
     name: 'JellyBox',
-    description: 'A native music player for Jellyfin with offline downloads, lyrics and artwork-based theming.',
+    description:
+      'A native music player for Jellyfin with CarPlay, AirPlay and DLNA streaming, offline downloads, lyrics and artwork-based theming.',
     clientType: ClientType.ThirdParty,
     deviceTypes: [DeviceType.Desktop, DeviceType.Mobile],
     platforms: [Platform.Desktop, Platform.IOS, Platform.Android],
@@ -787,6 +788,11 @@ const thirdPartyClients: Array<Client> = [
         id: 'app-store',
         name: 'App Store',
         url: 'https://apps.apple.com/us/app/jellybox-player/id6469732117'
+      },
+      {
+        id: 'play-store',
+        name: 'Play Store',
+        url: 'https://play.google.com/store/apps/details?id=com.prodigytech.jellybox'
       },
       {
         id: 'gh-downloads',

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -774,6 +774,38 @@ const thirdPartyClients: Array<Client> = [
         url: 'https://jellify.app'
       }
     ]
+  },
+  {
+    id: 'jellybox',
+    name: 'JellyBox',
+    description: 'A native music player for Jellyfin with offline downloads, lyrics and artwork-based theming.',
+    clientType: ClientType.ThirdParty,
+    deviceTypes: [DeviceType.Desktop, DeviceType.Mobile],
+    platforms: [Platform.Desktop, Platform.IOS, Platform.Android],
+    primaryLinks: [
+      {
+        id: 'app-store',
+        name: 'App Store',
+        url: 'https://apps.apple.com/us/app/jellybox-player/id6469732117'
+      },
+      {
+        id: 'gh-downloads',
+        name: 'GitHub Downloads',
+        url: 'https://github.com/avdept/JellyBoxPlayer/releases'
+      }
+    ],
+    secondaryLinks: [
+      {
+        id: 'github',
+        name: 'GitHub',
+        url: 'https://github.com/avdept/JellyBoxPlayer'
+      },
+      {
+        id: 'website',
+        name: 'Website',
+        url: 'https://jellybox.app'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
<!--
Thank you for contributing to our documentation. We receive a lot of pull requests here, so we want to streamline this process.
-->

**Changes**

This PR adds new music client for Jellyfin - Jellybox. This is OSS music player that runs on both - mobile and desktop platforms. The app was in development since 2023, but I didnt know you could add it to Jellyfin website.

**Copyediting**

To avoid "nitpicky" reviews, please ensure all of the following have been done for any non-trivial changes.

- [x] I have run this PR [through a spellchecker](https://jellyfin.org/docs/general/contributing/documentation#please-self-review) (e.g. `aspell`).
- [x] I have re-read my PR at least twice and fixed any obvious mistakes I see.
- [ ] I have received [out-of-band peer copyediting](https://jellyfin.org/docs/general/contributing/documentation#peer-copyediting) from someone in [#jellyfin-documentation](https://matrix.to/#/#jellyfin-documentation:matrix.org).

While you're waiting for someone to look at your pull request, How about looking at another one? You do not have to do this, but it will help ensure your PR is reviewed quickly in turn.

- [ ] I have provided [a *substantive* review of another documentation PR](https://jellyfin.org/docs/general/contributing/documentation#peer-reviews).
